### PR TITLE
Fix critical runtime bugs and add LaSOT dataset loader

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -11,6 +11,21 @@ from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
+
+
+@dataclass
+class BenchmarkConfig:
+    """Runtime configuration for :class:`BenchmarkEngine`.
+
+    Args:
+        max_sequences: Cap on the number of sequences to evaluate.
+            ``None`` evaluates the entire dataset.  Useful for quick smoke
+            tests without running the full benchmark.
+        verbose: Print per-sequence progress and a final summary to stdout.
+    """
+
+    max_sequences: Optional[int] = None
+    verbose: bool = True
 
 
 @dataclass
@@ -43,30 +58,84 @@ class BenchmarkResult:
     def peak_memory_mb(self) -> float:
         return float(np.max([r.profiling.peak_memory_mb for r in self.sequence_results]))
 
-    def summary(self) -> Dict:
+    def summary(self) -> Dict[str, Any]:
         return {
-            "tracker": self.tracker_name,
-            "dataset": self.dataset_name,
+            "tracker_name": self.tracker_name,
+            "dataset_name": self.dataset_name,
             "num_sequences": len(self.sequence_results),
             "mean_iou": round(self.mean_iou, 4),
             "mean_fps": round(self.mean_fps, 2),
             "peak_memory_mb": round(self.peak_memory_mb, 2),
         }
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a reporter-compatible dict.
+
+        Returns a dict with two keys:
+
+        * ``"summary"`` — scalar metrics (tracker name, mIoU, FPS, …).
+        * ``"sequences"`` — list of per-sequence breakdowns, each containing
+          the raw per-frame IoU array so downstream tools can compute
+          success / precision curves without re-running the tracker.
+        """
+        return {
+            "summary": self.summary(),
+            "sequences": [
+                {
+                    "sequence_name": r.sequence_name,
+                    "mean_iou": round(r.mean_iou, 4),
+                    "ious": r.ious.tolist(),
+                    "fps": round(r.profiling.fps, 2),
+                    "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
+                    "latency_p95_ms": round(r.profiling.latency_p95_ms, 3),
+                    "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
+                }
+                for r in self.sequence_results
+            ],
+        }
+
     def __str__(self) -> str:
         s = self.summary()
         return (
-            f"BenchmarkResult[{s['tracker']} on {s['dataset']}] "
+            f"BenchmarkResult[{s['tracker_name']} on {s['dataset_name']}] "
             f"mIoU={s['mean_iou']}  FPS={s['mean_fps']}  "
             f"mem={s['peak_memory_mb']} MiB  ({s['num_sequences']} sequences)"
         )
 
 
 class BenchmarkEngine:
-    """Run a tracker against a dataset and collect accuracy + profiling data."""
+    """Run a tracker against a dataset and collect accuracy + profiling data.
 
-    def __init__(self, verbose: bool = True) -> None:
-        self.verbose = verbose
+    Args:
+        verbose: Print per-sequence progress.  Overridden by *config* when
+            *config* is provided.
+        config: Optional :class:`BenchmarkConfig` controlling run behaviour.
+            When supplied it takes precedence over the *verbose* argument and
+            also provides the default ``max_sequences`` cap.
+
+    Example::
+
+        from eovot.benchmark.engine import BenchmarkEngine, BenchmarkConfig
+        from eovot.trackers.mosse import MOSSETracker
+        from eovot.datasets.base import OTBDataset
+
+        cfg = BenchmarkConfig(max_sequences=10, verbose=True)
+        engine = BenchmarkEngine(config=cfg)
+        result = engine.run(MOSSETracker(), OTBDataset("/data/OTB100"), dataset_name="OTB100")
+        print(result["summary"])
+    """
+
+    def __init__(
+        self,
+        verbose: bool = True,
+        config: Optional[BenchmarkConfig] = None,
+    ) -> None:
+        if config is not None:
+            self.verbose = config.verbose
+            self._config = config
+        else:
+            self.verbose = verbose
+            self._config = BenchmarkConfig(verbose=verbose)
         self._metrics = MetricsEngine()
         self._profiler = Profiler()
 
@@ -76,8 +145,24 @@ class BenchmarkEngine:
         dataset: BaseDataset,
         dataset_name: str = "unknown",
         max_sequences: Optional[int] = None,
-    ) -> BenchmarkResult:
-        """Evaluate *tracker* on every sequence in *dataset*."""
+    ) -> Dict[str, Any]:
+        """Evaluate *tracker* on every sequence in *dataset*.
+
+        Args:
+            tracker: Any :class:`~eovot.trackers.base.BaseTracker` instance.
+            dataset: Any :class:`~eovot.datasets.base.BaseDataset` instance.
+            dataset_name: Human-readable dataset label used in reports.
+            max_sequences: Override the sequence cap for this run.  Falls back
+                to :attr:`BenchmarkConfig.max_sequences` when not given.
+
+        Returns:
+            A dict with ``"summary"`` (scalar metrics) and ``"sequences"``
+            (per-sequence breakdown including raw IoU arrays), compatible with
+            :class:`~eovot.reporting.reporter.BenchmarkReporter`.
+        """
+        if max_sequences is None:
+            max_sequences = self._config.max_sequences
+
         result = BenchmarkResult(tracker_name=tracker.name, dataset_name=dataset_name)
         n = min(len(dataset), max_sequences) if max_sequences is not None else len(dataset)
 
@@ -100,7 +185,7 @@ class BenchmarkEngine:
             print("-" * 60)
             print(result)
 
-        return result
+        return result.to_dict()
 
     def _run_sequence(self, tracker: BaseTracker, seq: Sequence) -> SequenceResult:
         self._profiler.reset()

--- a/eovot/datasets/__init__.py
+++ b/eovot/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .base import BBox, Sequence, BaseDataset, OTBDataset
 from .got10k import GOT10kDataset
+from .lasot import LaSOTDataset
 
-__all__ = ["BBox", "Sequence", "BaseDataset", "OTBDataset", "GOT10kDataset"]
+__all__ = ["BBox", "Sequence", "BaseDataset", "OTBDataset", "GOT10kDataset", "LaSOTDataset"]

--- a/eovot/datasets/got10k.py
+++ b/eovot/datasets/got10k.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-import cv2
+import numpy as np
 
 from .base import BaseDataset, BBox, Sequence
 
@@ -58,7 +58,8 @@ class GOT10kDataset(BaseDataset):
     ) -> None:
         if split not in self.SPLITS:
             raise ValueError(f"split must be one of {self.SPLITS!r}, got {split!r}")
-        super().__init__(root=root, split=split)
+        self.root = root
+        self.split = split
         self.max_sequences = max_sequences
         self._split_dir = Path(root) / split
         self._seq_names: Optional[List[str]] = None
@@ -131,12 +132,11 @@ class GOT10kDataset(BaseDataset):
         frame_paths = frame_paths[:n]
         gt_boxes = gt_boxes[:n]
 
-        frames = [cv2.imread(str(p)) for p in frame_paths]
-        bad = [str(frame_paths[i]) for i, f in enumerate(frames) if f is None]
-        if bad:
-            raise IOError(f"OpenCV failed to decode {len(bad)} frame(s): {bad[:3]} ...")
-
-        return Sequence(name=seq_name, frames=frames, gt_boxes=gt_boxes)
+        return Sequence(
+            name=seq_name,
+            frame_paths=[str(p) for p in frame_paths],
+            ground_truth=np.array(gt_boxes, dtype=np.float64),
+        )
 
     @property
     def name(self) -> str:

--- a/eovot/datasets/got10k.py
+++ b/eovot/datasets/got10k.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-import cv2
+import numpy as np
 
 from .base import BaseDataset, BBox, Sequence
 
@@ -44,8 +44,14 @@ class GOT10kDataset(BaseDataset):
         split: Dataset split — one of ``"train"``, ``"val"``, ``"test"``.
             Default: ``"val"``.
         max_sequences: Optional upper limit on the number of sequences
-            returned by :meth:`list_sequences`.  Useful for quick smoke
-            tests without downloading the full dataset.
+            returned.  Useful for quick smoke tests without downloading
+            the full dataset.
+
+    Example::
+
+        dataset = GOT10kDataset("/data/GOT-10k", split="val", max_sequences=10)
+        for seq in dataset:
+            print(seq.name, len(seq))
     """
 
     SPLITS = ("train", "val", "test")
@@ -58,7 +64,8 @@ class GOT10kDataset(BaseDataset):
     ) -> None:
         if split not in self.SPLITS:
             raise ValueError(f"split must be one of {self.SPLITS!r}, got {split!r}")
-        super().__init__(root=root, split=split)
+        self.root = root
+        self.split = split
         self.max_sequences = max_sequences
         self._split_dir = Path(root) / split
         self._seq_names: Optional[List[str]] = None
@@ -66,6 +73,15 @@ class GOT10kDataset(BaseDataset):
     # ------------------------------------------------------------------
     # BaseDataset interface
     # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self.list_sequences())
+
+    def __getitem__(self, idx: int) -> Sequence:
+        names = self.list_sequences()
+        if idx < 0 or idx >= len(names):
+            raise IndexError(f"Sequence index {idx} out of range (0–{len(names) - 1})")
+        return self.load_sequence(names[idx])
 
     def list_sequences(self) -> List[str]:
         """Return the list of sequence names for this split.
@@ -99,12 +115,11 @@ class GOT10kDataset(BaseDataset):
             seq_name: Sequence folder name (e.g. ``"GOT-10k_Val_000001"``).
 
         Returns:
-            :class:`~eovot.datasets.base.Sequence` with frames and GT boxes
-            aligned to the same length.
+            :class:`~eovot.datasets.base.Sequence` with frame paths and GT
+            boxes aligned to the same length.
 
         Raises:
             FileNotFoundError: If ``groundtruth.txt`` or ``img/`` are missing.
-            IOError: If any frame image cannot be decoded by OpenCV.
         """
         seq_dir = self._split_dir / seq_name
 
@@ -122,21 +137,16 @@ class GOT10kDataset(BaseDataset):
             raise FileNotFoundError(f"img/ directory not found at {img_dir}")
 
         frame_paths = sorted(img_dir.glob("*.jpg")) + sorted(img_dir.glob("*.png"))
-        frame_paths = sorted(frame_paths)  # ensure chronological order after merge
+        frame_paths = sorted(frame_paths)
         if not frame_paths:
             raise FileNotFoundError(f"No JPEG/PNG frames found in {img_dir}")
 
         # Align frame count and GT length (some sequences may differ by one).
         n = min(len(frame_paths), len(gt_boxes))
-        frame_paths = frame_paths[:n]
-        gt_boxes = gt_boxes[:n]
+        frame_path_strs = [str(p) for p in frame_paths[:n]]
+        gt_array = np.array(gt_boxes[:n], dtype=np.float64)
 
-        frames = [cv2.imread(str(p)) for p in frame_paths]
-        bad = [str(frame_paths[i]) for i, f in enumerate(frames) if f is None]
-        if bad:
-            raise IOError(f"OpenCV failed to decode {len(bad)} frame(s): {bad[:3]} ...")
-
-        return Sequence(name=seq_name, frames=frames, gt_boxes=gt_boxes)
+        return Sequence(name=seq_name, frame_paths=frame_path_strs, ground_truth=gt_array)
 
     @property
     def name(self) -> str:

--- a/eovot/datasets/lasot.py
+++ b/eovot/datasets/lasot.py
@@ -1,0 +1,180 @@
+"""LaSOT dataset loader for EOVOT.
+
+LaSOT (Large-scale Single Object Tracking) is a benchmark with 1,400 sequences
+across 70 object categories, featuring long-term tracking scenarios with full
+occlusion and out-of-view events.
+
+Dataset directory layout::
+
+    LaSOT/
+    ├── testing_set.txt            # optional: sequence names for the test split
+    ├── airplane/
+    │   ├── airplane-1/
+    │   │   ├── img/
+    │   │   │   ├── 00000001.jpg
+    │   │   │   └── ...
+    │   │   ├── groundtruth.txt    # x,y,w,h per frame (comma-delimited)
+    │   │   ├── full_occlusion.txt # 0/1 per frame
+    │   │   └── out_of_view.txt    # 0/1 per frame
+    │   └── airplane-2/
+    │       └── ...
+    ├── basketball/
+    └── ...
+
+The official train/test split is encoded in ``testing_set.txt`` at the dataset
+root (280 test sequences).  When that file is absent all discovered sequences
+are treated as a single pool and returned regardless of *split*.
+
+Reference:
+    Fan et al., "LaSOT: A High-quality Benchmark for Large-scale Single Object
+    Tracking." CVPR 2019.  https://arxiv.org/abs/1809.07845
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+
+from .base import BaseDataset, BBox, Sequence
+
+
+class LaSOTDataset(BaseDataset):
+    """Dataset loader for LaSOT (train / test splits).
+
+    Args:
+        root: Path to the LaSOT root directory containing per-category
+            subdirectories (e.g. ``airplane/``, ``basketball/`` …).
+        split: One of ``"train"``, ``"test"``, or ``"all"``.
+            The split is resolved via ``testing_set.txt`` in *root*.
+            If the file is absent, *split* is ignored and all discovered
+            sequences are returned.
+        max_sequences: Optional upper limit on the number of sequences
+            returned.  Useful for quick smoke tests.
+
+    Example::
+
+        dataset = LaSOTDataset("/data/LaSOT", split="test", max_sequences=20)
+        for seq in dataset:
+            print(seq.name, len(seq))
+    """
+
+    SPLITS = ("train", "test", "all")
+
+    def __init__(
+        self,
+        root: str,
+        split: str = "test",
+        max_sequences: Optional[int] = None,
+    ) -> None:
+        if split not in self.SPLITS:
+            raise ValueError(f"split must be one of {self.SPLITS!r}, got {split!r}")
+        self.root = root
+        self.split = split
+        self.max_sequences = max_sequences
+        self._root = Path(root)
+        self._sequences: Optional[List[Path]] = None
+
+    # ------------------------------------------------------------------
+    # BaseDataset interface
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._get_sequences())
+
+    def __getitem__(self, idx: int) -> Sequence:
+        seqs = self._get_sequences()
+        if idx < 0 or idx >= len(seqs):
+            raise IndexError(f"Sequence index {idx} out of range (0–{len(seqs) - 1})")
+        return self._load_sequence(seqs[idx])
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_sequences(self) -> List[Path]:
+        """Discover and filter sequence directories, caching the result."""
+        if self._sequences is not None:
+            return self._sequences
+
+        # Collect all <category>/<seq_name>/ directories that have a GT file.
+        all_seqs: List[Path] = []
+        for cat_dir in sorted(self._root.iterdir()):
+            if not cat_dir.is_dir() or cat_dir.name.startswith("."):
+                continue
+            for seq_dir in sorted(cat_dir.iterdir()):
+                if seq_dir.is_dir() and (seq_dir / "groundtruth.txt").exists():
+                    all_seqs.append(seq_dir)
+
+        # Apply the official train/test split if the split file exists.
+        if self.split != "all":
+            split_file = self._root / "testing_set.txt"
+            if split_file.exists():
+                with open(split_file) as fh:
+                    test_names = {ln.strip() for ln in fh if ln.strip()}
+                if self.split == "test":
+                    all_seqs = [s for s in all_seqs if s.name in test_names]
+                else:  # "train"
+                    all_seqs = [s for s in all_seqs if s.name not in test_names]
+            # If testing_set.txt is absent we silently return all sequences.
+
+        if self.max_sequences is not None:
+            all_seqs = all_seqs[: self.max_sequences]
+
+        self._sequences = all_seqs
+        return self._sequences
+
+    def _load_sequence(self, seq_dir: Path) -> Sequence:
+        """Load a single LaSOT sequence from *seq_dir*.
+
+        Args:
+            seq_dir: Absolute path to the sequence directory (e.g.
+                ``<root>/airplane/airplane-1/``).
+
+        Returns:
+            :class:`~eovot.datasets.base.Sequence` with frame paths and GT
+            boxes aligned to the same length.
+
+        Raises:
+            FileNotFoundError: If ``img/`` or ``groundtruth.txt`` are absent.
+        """
+        gt_file = seq_dir / "groundtruth.txt"
+        if not gt_file.exists():
+            raise FileNotFoundError(f"groundtruth.txt not found at {gt_file}")
+
+        img_dir = seq_dir / "img"
+        if not img_dir.is_dir():
+            raise FileNotFoundError(f"img/ directory not found at {img_dir}")
+
+        frame_paths = sorted(img_dir.glob("*.jpg")) + sorted(img_dir.glob("*.png"))
+        frame_paths = sorted(frame_paths)
+        if not frame_paths:
+            raise FileNotFoundError(f"No JPEG/PNG frames found in {img_dir}")
+
+        gt_boxes = self._load_groundtruth(gt_file)
+        n = min(len(frame_paths), len(gt_boxes))
+        frame_path_strs = [str(p) for p in frame_paths[:n]]
+        gt_array = np.array(gt_boxes[:n], dtype=np.float64)
+
+        return Sequence(name=seq_dir.name, frame_paths=frame_path_strs, ground_truth=gt_array)
+
+    @staticmethod
+    def _load_groundtruth(gt_file: Path) -> List[BBox]:
+        """Parse ``groundtruth.txt`` into a list of ``(x, y, w, h)`` tuples.
+
+        Handles comma-separated and whitespace-delimited files and skips
+        blank lines.
+        """
+        boxes: List[BBox] = []
+        with open(gt_file) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                parts = [p for p in line.replace("\t", ",").replace(" ", ",").split(",") if p]
+                if len(parts) < 4:
+                    continue
+                x, y, w, h = float(parts[0]), float(parts[1]), float(parts[2]), float(parts[3])
+                boxes.append((x, y, w, h))
+        return boxes

--- a/eovot/datasets/lasot.py
+++ b/eovot/datasets/lasot.py
@@ -1,0 +1,193 @@
+"""LaSOT dataset loader for EOVOT.
+
+LaSOT (Large-scale Single Object Tracking) is a high-quality, large-scale
+benchmark with 1,400 sequences across 70 object categories (20 sequences/category).
+Each sequence is annotated with per-frame bounding boxes, full-occlusion labels,
+and out-of-view labels.
+
+Dataset directory layout::
+
+    LaSOT/
+    ├── testing_set.txt             # 280 test sequence names, one per line
+    ├── training_set.txt            # 1120 training sequence names, one per line
+    ├── airplane/
+    │   ├── airplane-1/
+    │   │   ├── img/
+    │   │   │   ├── 00000001.jpg
+    │   │   │   └── ...
+    │   │   ├── groundtruth.txt     # x,y,w,h — comma-separated, one per line
+    │   │   ├── full_occlusion.txt  # 0/1 per frame
+    │   │   └── out_of_view.txt     # 0/1 per frame
+    │   └── airplane-2/
+    │       └── ...
+    └── ...
+
+Reference:
+    Fan et al., "LaSOT: A High-quality Benchmark for Large-scale Single Object
+    Tracking." CVPR 2019. https://arxiv.org/abs/1809.07845
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+
+from .base import BaseDataset, BBox, Sequence
+
+
+class LaSOTDataset(BaseDataset):
+    """Dataset loader for LaSOT (train / test splits).
+
+    Args:
+        root: Path to the LaSOT root directory containing per-class subdirectories.
+        split: One of ``"train"`` or ``"test"``. Uses ``training_set.txt`` /
+            ``testing_set.txt`` when present; falls back to loading all sequences.
+        max_sequences: Optional upper limit on the number of sequences evaluated.
+            Useful for quick smoke tests without the full 1,400-sequence dataset.
+
+    Example::
+
+        dataset = LaSOTDataset("/data/LaSOT", split="test")
+        for seq in dataset:
+            print(seq.name, len(seq))
+    """
+
+    SPLITS = ("train", "test")
+    _SPLIT_FILES = {"train": "training_set.txt", "test": "testing_set.txt"}
+
+    def __init__(
+        self,
+        root: str,
+        split: str = "test",
+        max_sequences: Optional[int] = None,
+    ) -> None:
+        if split not in self.SPLITS:
+            raise ValueError(f"split must be one of {self.SPLITS!r}, got {split!r}")
+        self.root = Path(root)
+        self.split = split
+        self.max_sequences = max_sequences
+        self._seq_names: Optional[List[str]] = None
+
+    # ------------------------------------------------------------------
+    # BaseDataset interface
+    # ------------------------------------------------------------------
+
+    def list_sequences(self) -> List[str]:
+        """Return sequence names for the selected split.
+
+        Reads ``testing_set.txt`` / ``training_set.txt`` when present;
+        otherwise enumerates all ``<class>/<class>-<id>/`` directories.
+        """
+        if self._seq_names is not None:
+            return self._seq_names
+
+        split_file = self.root / self._SPLIT_FILES[self.split]
+        if split_file.exists():
+            with open(split_file) as fh:
+                names = [ln.strip() for ln in fh if ln.strip()]
+        else:
+            names = self._discover_all_sequences()
+
+        if self.max_sequences is not None:
+            names = names[: self.max_sequences]
+        self._seq_names = names
+        return self._seq_names
+
+    def __len__(self) -> int:
+        return len(self.list_sequences())
+
+    def __getitem__(self, idx: int) -> Sequence:
+        seq_names = self.list_sequences()
+        return self.load_sequence(seq_names[idx])
+
+    def load_sequence(self, seq_name: str) -> Sequence:
+        """Load a single LaSOT sequence.
+
+        Args:
+            seq_name: Sequence identifier of the form ``"<class>-<id>"``
+                (e.g. ``"airplane-1"``).
+
+        Returns:
+            :class:`~eovot.datasets.base.Sequence` with frame paths and
+            ground-truth boxes aligned to the same length.
+
+        Raises:
+            FileNotFoundError: If ``groundtruth.txt`` or ``img/`` are missing.
+        """
+        # Sequence directories are nested: <root>/<class>/<class>-<id>/
+        class_name = seq_name.rsplit("-", 1)[0]
+        seq_dir = self.root / class_name / seq_name
+
+        gt_file = seq_dir / "groundtruth.txt"
+        if not gt_file.exists():
+            raise FileNotFoundError(
+                f"groundtruth.txt not found for sequence '{seq_name}' at {gt_file}"
+            )
+        gt_boxes = self._load_groundtruth(gt_file)
+
+        img_dir = seq_dir / "img"
+        if not img_dir.is_dir():
+            raise FileNotFoundError(f"img/ directory not found at {img_dir}")
+
+        frame_paths = sorted(img_dir.glob("*.jpg")) + sorted(img_dir.glob("*.png"))
+        frame_paths = sorted(frame_paths)
+        if not frame_paths:
+            raise FileNotFoundError(f"No JPEG/PNG frames found in {img_dir}")
+
+        # Align frame count and GT length (some sequences differ by one frame).
+        n = min(len(frame_paths), len(gt_boxes))
+        frame_paths = frame_paths[:n]
+        gt_boxes = gt_boxes[:n]
+
+        return Sequence(
+            name=seq_name,
+            frame_paths=[str(p) for p in frame_paths],
+            ground_truth=np.array(gt_boxes, dtype=np.float64),
+        )
+
+    @property
+    def name(self) -> str:
+        return f"LaSOT-{self.split}"
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _discover_all_sequences(self) -> List[str]:
+        """Walk the root directory to find all valid sequence folders."""
+        names: List[str] = []
+        for class_dir in sorted(self.root.iterdir()):
+            if not class_dir.is_dir():
+                continue
+            for seq_dir in sorted(class_dir.iterdir()):
+                if seq_dir.is_dir() and (seq_dir / "groundtruth.txt").exists():
+                    names.append(seq_dir.name)
+        return names
+
+    @staticmethod
+    def _load_groundtruth(gt_file: Path) -> List[BBox]:
+        """Parse ``groundtruth.txt`` into ``(x, y, w, h)`` tuples.
+
+        Handles comma-separated and whitespace-delimited files; skips blank lines.
+        """
+        boxes: List[BBox] = []
+        with open(gt_file) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                parts = [
+                    p for p in line.replace("\t", ",").replace(" ", ",").split(",") if p
+                ]
+                if len(parts) < 4:
+                    continue
+                x, y, w, h = (
+                    float(parts[0]),
+                    float(parts[1]),
+                    float(parts[2]),
+                    float(parts[3]),
+                )
+                boxes.append((x, y, w, h))
+        return boxes

--- a/scripts/compare_trackers.py
+++ b/scripts/compare_trackers.py
@@ -40,6 +40,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from eovot.benchmark.engine import BenchmarkConfig, BenchmarkEngine
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
+from eovot.datasets.lasot import LaSOTDataset
 from eovot.reporting.reporter import BenchmarkReporter
 from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
@@ -56,6 +57,7 @@ TRACKER_REGISTRY = {
 DATASET_REGISTRY = {
     "OTBDataset": OTBDataset,
     "GOT10kDataset": GOT10kDataset,
+    "LaSOTDataset": LaSOTDataset,
 }
 
 
@@ -92,7 +94,7 @@ def main() -> None:
     parser.add_argument(
         "--split",
         default="val",
-        help="Dataset split (for GOT-10k: train | val | test).",
+        help="Dataset split (for GOT-10k / LaSOT: train | val | test).",
     )
     parser.add_argument(
         "--max-sequences",
@@ -122,7 +124,7 @@ def main() -> None:
         tracker = TRACKER_REGISTRY[tracker_name]()
 
         dataset_cls = DATASET_REGISTRY[args.dataset_loader]
-        if args.dataset_loader == "GOT10kDataset":
+        if args.dataset_loader in ("GOT10kDataset", "LaSOTDataset"):
             dataset = dataset_cls(
                 root=args.dataset_root,
                 split=args.split,
@@ -131,7 +133,7 @@ def main() -> None:
         else:
             dataset = dataset_cls(root=args.dataset_root)
 
-        result = engine.run(tracker, dataset)
+        result = engine.run(tracker, dataset, dataset_name=dataset_name)
         result["summary"].setdefault("dataset_name", dataset_name)
 
         reporter.print_summary(result)

--- a/scripts/compare_trackers.py
+++ b/scripts/compare_trackers.py
@@ -37,12 +37,33 @@ from pathlib import Path
 # Allow running as ``python scripts/compare_trackers.py`` from the repo root.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from eovot.benchmark.engine import BenchmarkConfig, BenchmarkEngine
+from eovot.benchmark.engine import BenchmarkEngine, BenchmarkResult
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
+from eovot.datasets.lasot import LaSOTDataset
 from eovot.reporting.reporter import BenchmarkReporter
 from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
+
+
+def _to_reporter_dict(result: BenchmarkResult, dataset_name: str) -> dict:
+    """Convert BenchmarkResult to the dict format expected by BenchmarkReporter."""
+    summary = result.summary()
+    # Reporter's to_markdown_row expects "tracker_name" and "dataset_name" keys
+    summary["tracker_name"] = summary.pop("tracker")
+    summary["dataset_name"] = dataset_name
+    summary.pop("dataset", None)
+    sequences = [
+        {
+            "sequence_name": sr.sequence_name,
+            "mean_iou": round(sr.mean_iou, 4),
+            "precision_score": 0.0,
+            "fps": round(sr.profiling.fps, 2),
+            "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
+        }
+        for sr in result.sequence_results
+    ]
+    return {"summary": summary, "sequences": sequences}
 
 # ---------------------------------------------------------------------------
 # Registries — add new trackers / datasets here without touching the CLI code
@@ -56,6 +77,7 @@ TRACKER_REGISTRY = {
 DATASET_REGISTRY = {
     "OTBDataset": OTBDataset,
     "GOT10kDataset": GOT10kDataset,
+    "LaSOTDataset": LaSOTDataset,
 }
 
 
@@ -109,8 +131,7 @@ def main() -> None:
 
     dataset_name = args.dataset_name or args.dataset_loader
     reporter = BenchmarkReporter(output_dir=args.output_dir)
-    config = BenchmarkConfig(max_sequences=args.max_sequences, verbose=True)
-    engine = BenchmarkEngine(config=config)
+    engine = BenchmarkEngine(verbose=True)
 
     all_results = []
 
@@ -122,7 +143,7 @@ def main() -> None:
         tracker = TRACKER_REGISTRY[tracker_name]()
 
         dataset_cls = DATASET_REGISTRY[args.dataset_loader]
-        if args.dataset_loader == "GOT10kDataset":
+        if args.dataset_loader in ("GOT10kDataset", "LaSOTDataset"):
             dataset = dataset_cls(
                 root=args.dataset_root,
                 split=args.split,
@@ -131,17 +152,21 @@ def main() -> None:
         else:
             dataset = dataset_cls(root=args.dataset_root)
 
-        result = engine.run(tracker, dataset)
-        result["summary"].setdefault("dataset_name", dataset_name)
+        result = engine.run(
+            tracker, dataset,
+            dataset_name=dataset_name,
+            max_sequences=args.max_sequences,
+        )
+        result_dict = _to_reporter_dict(result, dataset_name)
 
-        reporter.print_summary(result)
+        reporter.print_summary(result_dict)
 
         run_name = f"{tracker_name}-{dataset_name}"
-        saved = reporter.save_all(result, name=run_name)
+        saved = reporter.save_all(result_dict, name=run_name)
         for fmt, path in saved.items():
             print(f"  [{fmt.upper()}] saved → {path}")
 
-        all_results.append(result)
+        all_results.append(result_dict)
 
     # -----------------------------------------------------------------------
     # Comparison table (only meaningful with 2+ trackers)

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -32,6 +32,7 @@ import yaml
 
 from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
+from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
 
 
@@ -41,6 +42,7 @@ from eovot.trackers.mosse import MOSSETracker
 
 TRACKER_REGISTRY: Dict[str, Any] = {
     "MOSSE": MOSSETracker,
+    "KCF": KCFTracker,
 }
 
 

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -32,7 +32,10 @@ import yaml
 
 from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
+from eovot.datasets.got10k import GOT10kDataset
+from eovot.datasets.lasot import LaSOTDataset
 from eovot.trackers.mosse import MOSSETracker
+from eovot.trackers.kcf import KCFTracker
 
 
 # ------------------------------------------------------------------ #
@@ -41,6 +44,7 @@ from eovot.trackers.mosse import MOSSETracker
 
 TRACKER_REGISTRY: Dict[str, Any] = {
     "MOSSE": MOSSETracker,
+    "KCF": KCFTracker,
 }
 
 
@@ -50,6 +54,8 @@ TRACKER_REGISTRY: Dict[str, Any] = {
 
 DATASET_REGISTRY: Dict[str, Any] = {
     "OTBDataset": OTBDataset,
+    "GOT10kDataset": GOT10kDataset,
+    "LaSOTDataset": LaSOTDataset,
 }
 
 
@@ -134,7 +140,7 @@ def run_from_config(cfg: Dict) -> None:
     exp_name = cfg["experiment"].get("name", "run")
     os.makedirs(output_dir, exist_ok=True)
 
-    summary = result.summary()
+    summary = result["summary"]
 
     if report_cfg.get("print_summary", True):
         print("\n" + "=" * 60)
@@ -148,7 +154,7 @@ def run_from_config(cfg: Dict) -> None:
     if "json" in formats:
         out_path = os.path.join(output_dir, f"{exp_name}.json")
         with open(out_path, "w", encoding="utf-8") as f:
-            json.dump(summary, f, indent=2)
+            json.dump(result, f, indent=2)
         print(f"\nResults saved to {out_path}")
 
     if "csv" in formats:


### PR DESCRIPTION
## Summary

Resolves three critical bugs that prevented the framework from running at all, and adds the LaSOT dataset loader.

### Bugs Fixed

**1. `GOT10kDataset` — `TypeError` on instantiation (`got10k.py`)**
The constructor called `super().__init__(root=root, split=split)` but `BaseDataset` has no `__init__` accepting those kwargs. Fix: store `root` and `split` directly on `self`. Also adds the missing `__len__` and `__getitem__` abstract-method implementations required by `BaseDataset`.

**2. `GOT10kDataset.load_sequence` — `TypeError` on `Sequence` construction (`got10k.py`)**
`Sequence` was called with `frames=frames, gt_boxes=gt_boxes` but its `__init__` expects `frame_paths` and `ground_truth`. Fix: pass string frame paths and a numpy array under the correct parameter names; removes the eager `cv2.imread` pre-load (Sequence is lazy by design).

**3. `BenchmarkConfig` missing — `ImportError` in `compare_trackers.py`**
`compare_trackers.py` imported `BenchmarkConfig` from `engine.py` but the class did not exist. Fix: add `BenchmarkConfig` dataclass to `engine.py` and update `BenchmarkEngine` to accept it via `config=` kwarg. `engine.run()` now returns a reporter-compatible dict (`summary` + per-sequence data with raw IoU arrays) consistent with `BenchmarkReporter`'s expected input. `run_benchmark.py` updated accordingly.

### New Feature: LaSOT Dataset Loader

- `eovot/datasets/lasot.py`: Full `LaSOTDataset` implementation supporting `train`, `test`, and `all` splits via the official `testing_set.txt` file (graceful fallback when absent)
- `eovot/datasets/__init__.py`: exports `LaSOTDataset`
- `scripts/run_benchmark.py` and `scripts/compare_trackers.py`: register `GOT10kDataset`, `LaSOTDataset`, and `KCFTracker`

### Example Usage

```python
# GOT-10k
from eovot.datasets.got10k import GOT10kDataset
dataset = GOT10kDataset("/data/GOT-10k", split="val", max_sequences=10)

# LaSOT
from eovot.datasets.lasot import LaSOTDataset
dataset = LaSOTDataset("/data/LaSOT", split="test", max_sequences=20)

# BenchmarkConfig
from eovot.benchmark.engine import BenchmarkEngine, BenchmarkConfig
cfg = BenchmarkConfig(max_sequences=10, verbose=True)
engine = BenchmarkEngine(config=cfg)
result = engine.run(tracker, dataset, dataset_name="GOT-10k-val")
print(result["summary"])
```

```bash
# CLI comparison with GOT-10k
python scripts/compare_trackers.py \
    --trackers MOSSE KCF \
    --dataset-loader GOT10kDataset \
    --dataset-root /data/GOT-10k --split val
```