### PR TITLE
[agent] fix: resolve GOT10kDataset and compare_trackers runtime errors

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
+
+try:
+    from tqdm import tqdm as _tqdm
+    _TQDM_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TQDM_AVAILABLE = False
 
 from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine
@@ -53,6 +59,27 @@ class BenchmarkResult:
             "peak_memory_mb": round(self.peak_memory_mb, 2),
         }
 
+    def to_report_dict(self) -> Dict[str, Any]:
+        """Serialise to the dict format expected by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
+
+        Returns a nested dict with:
+        - ``"summary"``: aggregate metrics (passed to ``print_summary``, ``save_json``).
+        - ``"sequences"``: per-sequence rows (passed to ``save_csv``).
+        """
+        return {
+            "summary": self.summary(),
+            "sequences": [
+                {
+                    "sequence_name": r.sequence_name,
+                    "mean_iou": round(r.mean_iou, 4),
+                    "fps": round(r.profiling.fps, 2),
+                    "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
+                    "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
+                }
+                for r in self.sequence_results
+            ],
+        }
+
     def __str__(self) -> str:
         s = self.summary()
         return (
@@ -85,11 +112,15 @@ class BenchmarkEngine:
             print(f"\nEvaluating {tracker.name} on {dataset_name} ({n} sequences)")
             print("-" * 60)
 
-        for idx in range(n):
+        indices = range(n)
+        if self.verbose and _TQDM_AVAILABLE:
+            indices = _tqdm(indices, desc=f"{tracker.name} on {dataset_name}", unit="seq")
+
+        for idx in indices:
             seq = dataset[idx]
             seq_result = self._run_sequence(tracker, seq)
             result.sequence_results.append(seq_result)
-            if self.verbose:
+            if self.verbose and not _TQDM_AVAILABLE:
                 print(
                     f"  [{idx + 1:>3}/{n}] {seq_result.sequence_name:<30s} "
                     f"mIoU={seq_result.mean_iou:.3f}  "

--- a/eovot/datasets/got10k.py
+++ b/eovot/datasets/got10k.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-import cv2
+import numpy as np
 
 from .base import BaseDataset, BBox, Sequence
 
@@ -58,7 +58,9 @@ class GOT10kDataset(BaseDataset):
     ) -> None:
         if split not in self.SPLITS:
             raise ValueError(f"split must be one of {self.SPLITS!r}, got {split!r}")
-        super().__init__(root=root, split=split)
+        super().__init__()
+        self.root = root
+        self.split = split
         self.max_sequences = max_sequences
         self._split_dir = Path(root) / split
         self._seq_names: Optional[List[str]] = None
@@ -66,6 +68,12 @@ class GOT10kDataset(BaseDataset):
     # ------------------------------------------------------------------
     # BaseDataset interface
     # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self.list_sequences())
+
+    def __getitem__(self, idx: int) -> Sequence:
+        return self.load_sequence(self.list_sequences()[idx])
 
     def list_sequences(self) -> List[str]:
         """Return the list of sequence names for this split.
@@ -99,12 +107,11 @@ class GOT10kDataset(BaseDataset):
             seq_name: Sequence folder name (e.g. ``"GOT-10k_Val_000001"``).
 
         Returns:
-            :class:`~eovot.datasets.base.Sequence` with frames and GT boxes
-            aligned to the same length.
+            :class:`~eovot.datasets.base.Sequence` with frame paths and GT
+            boxes aligned to the same length.
 
         Raises:
             FileNotFoundError: If ``groundtruth.txt`` or ``img/`` are missing.
-            IOError: If any frame image cannot be decoded by OpenCV.
         """
         seq_dir = self._split_dir / seq_name
 
@@ -131,12 +138,12 @@ class GOT10kDataset(BaseDataset):
         frame_paths = frame_paths[:n]
         gt_boxes = gt_boxes[:n]
 
-        frames = [cv2.imread(str(p)) for p in frame_paths]
-        bad = [str(frame_paths[i]) for i, f in enumerate(frames) if f is None]
-        if bad:
-            raise IOError(f"OpenCV failed to decode {len(bad)} frame(s): {bad[:3]} ...")
-
-        return Sequence(name=seq_name, frames=frames, gt_boxes=gt_boxes)
+        gt_arr = np.array(gt_boxes, dtype=np.float64)
+        return Sequence(
+            name=seq_name,
+            frame_paths=[str(p) for p in frame_paths],
+            ground_truth=gt_arr,
+        )
 
     @property
     def name(self) -> str:

--- a/scripts/compare_trackers.py
+++ b/scripts/compare_trackers.py
@@ -37,7 +37,7 @@ from pathlib import Path
 # Allow running as ``python scripts/compare_trackers.py`` from the repo root.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from eovot.benchmark.engine import BenchmarkConfig, BenchmarkEngine
+from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
 from eovot.reporting.reporter import BenchmarkReporter
@@ -109,10 +109,9 @@ def main() -> None:
 
     dataset_name = args.dataset_name or args.dataset_loader
     reporter = BenchmarkReporter(output_dir=args.output_dir)
-    config = BenchmarkConfig(max_sequences=args.max_sequences, verbose=True)
-    engine = BenchmarkEngine(config=config)
+    engine = BenchmarkEngine(verbose=True)
 
-    all_results = []
+    all_reports = []
 
     for tracker_name in args.trackers:
         print(f"\n{'=' * 60}")
@@ -131,25 +130,30 @@ def main() -> None:
         else:
             dataset = dataset_cls(root=args.dataset_root)
 
-        result = engine.run(tracker, dataset)
-        result["summary"].setdefault("dataset_name", dataset_name)
+        result = engine.run(
+            tracker,
+            dataset,
+            dataset_name=dataset_name,
+            max_sequences=args.max_sequences,
+        )
+        report = result.to_report_dict()
 
-        reporter.print_summary(result)
+        reporter.print_summary(report)
 
         run_name = f"{tracker_name}-{dataset_name}"
-        saved = reporter.save_all(result, name=run_name)
+        saved = reporter.save_all(report, name=run_name)
         for fmt, path in saved.items():
             print(f"  [{fmt.upper()}] saved → {path}")
 
-        all_results.append(result)
+        all_reports.append(report)
 
     # -----------------------------------------------------------------------
     # Comparison table (only meaningful with 2+ trackers)
     # -----------------------------------------------------------------------
-    if len(all_results) > 1:
-        cmp_path = reporter.save_comparison(all_results, name=f"comparison-{dataset_name}")
+    if len(all_reports) > 1:
+        cmp_path = reporter.save_comparison(all_reports, name=f"comparison-{dataset_name}")
         print(f"\n[COMPARISON TABLE] saved → {cmp_path}")
-        print("\n" + reporter.comparison_table(all_results))
+        print("\n" + reporter.comparison_table(all_reports))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What was added / fixed

This PR resolves **three distinct categories of runtime errors** that prevented the framework from running end-to-end:

### 1. `GOT10kDataset` — 4 bugs fixed (`eovot/datasets/got10k.py`)

| Bug | Root cause | Fix |
|-----|-----------|-----|
| `TypeError` on instantiation | `super().__init__(root=root, split=split)` passed kwargs to `BaseDataset` which inherits from `object` | Changed to `super().__init__()`, store `self.root` and `self.split` explicitly |
| `TypeError: Can't instantiate abstract class` | `__len__` and `__getitem__` were never implemented despite being abstract in `BaseDataset` | Added both methods delegating to `list_sequences()` / `load_sequence()` |
| `AttributeError: 'GOT10kDataset' has no attribute 'split'` | `self.split` used in the `name` property but never assigned | Set `self.split = split` in `__init__` |
| `TypeError` in `Sequence(...)` | `load_sequence` called `Sequence(frames=..., gt_boxes=...)` but `Sequence.__init__` expects `frame_paths: List[str]` and `ground_truth: np.ndarray` | Removed eager `cv2.imread` loading; build `np.array(gt_boxes)` and pass correct kwargs |

### 2. `BenchmarkEngine` — 2 additions (`eovot/benchmark/engine.py`)

- **`BenchmarkResult.to_report_dict()`** — serialises a result object to the `{"summary": {...}, "sequences": [...]}` dict format consumed by `BenchmarkReporter`. This was the missing bridge between the engine and reporter APIs.
- **tqdm progress bars** — the evaluation loop now renders a live `tqdm` progress bar when the package is installed; falls back to plain `print` otherwise (zero new hard dependency).

### 3. `compare_trackers.py` — 3 bugs fixed (`scripts/compare_trackers.py`)

| Bug | Root cause | Fix |
|-----|-----------|-----|
| `ImportError` | `from eovot.benchmark.engine import BenchmarkConfig` — class never existed | Removed import |
| `TypeError` | `BenchmarkEngine(config=BenchmarkConfig(...))` — engine only accepts `verbose=` | Changed to `BenchmarkEngine(verbose=True)` |
| `TypeError` | `result["summary"]` — `engine.run()` returns `BenchmarkResult`, not a dict | Call `result.to_report_dict()` before passing to reporter methods |

## Why it matters

These bugs made it **impossible to instantiate `GOT10kDataset`** or **run `compare_trackers.py`** at all — both would raise exceptions before processing a single frame. Fixing them unblocks end-to-end evaluation on the GOT-10k benchmark and multi-tracker comparison, which are core use cases of the framework.

## Example usage

```bash
# GOT-10k evaluation now works
python scripts/compare_trackers.py \
    --trackers MOSSE KCF \
    --dataset-loader GOT10kDataset \
    --dataset-root /data/GOT-10k \
    --split val \
    --max-sequences 10 \
    --output-dir results/
```

## No breaking changes

- `BenchmarkEngine.run()` still returns `BenchmarkResult`; `to_report_dict()` is additive.
- `run_benchmark.py` is unchanged (it already used `result.summary()` directly).
- All existing tracker and dataset APIs are untouched.