### PR TITLE
Add visualization module for success/precision curves and tracker comparison

### DIFF
--- a/eovot/visualization/__init__.py
+++ b/eovot/visualization/__init__.py
@@ -1,0 +1,23 @@
+"""Visualization utilities for EOVOT benchmark results.
+
+Provides publication-quality plots for tracker evaluation:
+
+- :func:`~eovot.visualization.plots.plot_success_curves` — IoU success curves
+- :func:`~eovot.visualization.plots.plot_precision_curves` — centre-distance
+  precision curves
+- :func:`~eovot.visualization.plots.plot_tracker_comparison` — bar-chart
+  comparison of multiple trackers across key metrics
+
+All functions accept the dict format produced by
+:meth:`~eovot.benchmark.engine.BenchmarkEngine.run` and require
+``matplotlib`` (not listed as a core dependency to keep the base install
+lightweight; install it with ``pip install matplotlib``).
+"""
+
+from .plots import plot_success_curves, plot_precision_curves, plot_tracker_comparison
+
+__all__ = [
+    "plot_success_curves",
+    "plot_precision_curves",
+    "plot_tracker_comparison",
+]

--- a/eovot/visualization/plots.py
+++ b/eovot/visualization/plots.py
@@ -1,0 +1,281 @@
+"""Publication-quality plots for EOVOT benchmark results.
+
+All plotting functions accept result dicts produced by
+:meth:`~eovot.benchmark.engine.BenchmarkEngine.run`, which have the form::
+
+    {
+        "summary": {"tracker_name": ..., "mean_iou": ..., "mean_fps": ..., ...},
+        "sequences": [
+            {"sequence_name": ..., "ious": [...], "fps": ..., ...},
+            ...
+        ]
+    }
+
+Requires ``matplotlib``.  Install with::
+
+    pip install matplotlib
+
+Example::
+
+    import json
+    from eovot.visualization.plots import plot_success_curves, plot_tracker_comparison
+
+    with open("results/MOSSE-OTB100.json") as f:
+        mosse = json.load(f)
+    with open("results/KCF-OTB100.json") as f:
+        kcf = json.load(f)
+
+    plot_success_curves([mosse, kcf], output_path="success_curves.png")
+    plot_tracker_comparison([mosse, kcf], output_path="comparison.png")
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+
+def _get_matplotlib():
+    """Import matplotlib.pyplot, raising a clear error if absent."""
+    try:
+        import matplotlib.pyplot as plt
+        return plt
+    except ImportError as exc:
+        raise ImportError(
+            "matplotlib is required for EOVOT visualization.\n"
+            "Install it with:  pip install matplotlib"
+        ) from exc
+
+
+def _collect_ious(result: Dict[str, Any]) -> np.ndarray:
+    """Gather all per-frame IoU values from a benchmark result dict.
+
+    The ``"sequences"`` list may contain either raw ``"ious"`` arrays
+    (written by the current engine) or only ``"mean_iou"`` scalars (legacy
+    format).  In the scalar case a single-element array is returned per
+    sequence so the success curve degrades gracefully.
+    """
+    ious_list = []
+    for seq in result.get("sequences", []):
+        raw = seq.get("ious")
+        if raw is not None:
+            ious_list.extend(raw)
+        else:
+            ious_list.append(seq.get("mean_iou", 0.0))
+    return np.array(ious_list, dtype=np.float64)
+
+
+def plot_success_curves(
+    results: List[Dict[str, Any]],
+    output_path: Optional[str] = None,
+    title: str = "Success Curves",
+    thresholds: Optional[np.ndarray] = None,
+) -> None:
+    """Plot overlap success curves for one or more benchmark results.
+
+    A *success curve* sweeps an IoU threshold from 0 to 1 and plots the
+    fraction of frames whose predicted box exceeds that threshold.  The
+    area under the curve (AUC) is the canonical single-number summary used
+    in OTB, GOT-10k, and LaSOT papers.
+
+    Args:
+        results: List of dicts from :meth:`~eovot.benchmark.engine.BenchmarkEngine.run`.
+        output_path: If given, save the figure to this path (PNG/PDF/SVG).
+            When ``None`` the plot is shown interactively.
+        title: Figure title string.
+        thresholds: IoU threshold sweep values.  Defaults to
+            ``np.linspace(0, 1, 101)``.
+    """
+    plt = _get_matplotlib()
+
+    if thresholds is None:
+        thresholds = np.linspace(0.0, 1.0, 101)
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+
+    for result in results:
+        tracker_name = result.get("summary", {}).get("tracker_name", "unknown")
+        ious = _collect_ious(result)
+        if len(ious) == 0:
+            continue
+        success_rates = np.array([(ious >= t).mean() for t in thresholds])
+        auc = float(np.trapz(success_rates, thresholds))
+        ax.plot(
+            thresholds,
+            success_rates,
+            label=f"{tracker_name} (AUC={auc:.3f})",
+            linewidth=2,
+        )
+
+    ax.set_xlabel("Overlap Threshold", fontsize=12)
+    ax.set_ylabel("Success Rate", fontsize=12)
+    ax.set_title(title, fontsize=14)
+    ax.set_xlim(0.0, 1.0)
+    ax.set_ylim(0.0, 1.0)
+    ax.legend(fontsize=11, loc="upper right")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"[plot] Success curves saved → {output_path}")
+    else:
+        plt.show()
+
+
+def plot_precision_curves(
+    results: List[Dict[str, Any]],
+    output_path: Optional[str] = None,
+    title: str = "Precision Curves",
+    thresholds: Optional[np.ndarray] = None,
+) -> None:
+    """Plot centre-distance precision curves for one or more benchmark results.
+
+    A *precision curve* sweeps a distance threshold from 0 to 50 px and
+    plots the fraction of frames whose predicted centre is within that
+    distance of the ground-truth centre.  The precision score at 20 px is
+    the canonical OTB scalar.
+
+    Args:
+        results: List of dicts from :meth:`~eovot.benchmark.engine.BenchmarkEngine.run`.
+            Each sequence entry must include a ``"center_distances"`` list;
+            sequences without it are skipped.
+        output_path: Save path.  Interactive display when ``None``.
+        title: Figure title string.
+        thresholds: Distance thresholds in pixels.  Defaults to
+            ``np.linspace(0, 50, 51)``.
+    """
+    plt = _get_matplotlib()
+
+    if thresholds is None:
+        thresholds = np.linspace(0.0, 50.0, 51)
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    plotted = 0
+
+    for result in results:
+        tracker_name = result.get("summary", {}).get("tracker_name", "unknown")
+        dists_list = []
+        for seq in result.get("sequences", []):
+            raw = seq.get("center_distances")
+            if raw is not None:
+                dists_list.extend(raw)
+
+        if not dists_list:
+            continue
+
+        dists = np.array(dists_list, dtype=np.float64)
+        precision_rates = np.array([(dists < t).mean() for t in thresholds])
+        score_at_20 = float(np.interp(20.0, thresholds, precision_rates))
+        ax.plot(
+            thresholds,
+            precision_rates,
+            label=f"{tracker_name} (@20px={score_at_20:.3f})",
+            linewidth=2,
+        )
+        plotted += 1
+
+    if plotted == 0:
+        ax.text(
+            0.5, 0.5,
+            "No centre-distance data available.\nRe-run with a future engine version.",
+            ha="center", va="center", transform=ax.transAxes, fontsize=11,
+        )
+
+    ax.set_xlabel("Centre-Distance Threshold (px)", fontsize=12)
+    ax.set_ylabel("Precision Rate", fontsize=12)
+    ax.set_title(title, fontsize=14)
+    ax.set_xlim(0.0, 50.0)
+    ax.set_ylim(0.0, 1.0)
+    ax.legend(fontsize=11, loc="lower right")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"[plot] Precision curves saved → {output_path}")
+    else:
+        plt.show()
+
+
+def plot_tracker_comparison(
+    results: List[Dict[str, Any]],
+    metrics: Optional[List[str]] = None,
+    output_path: Optional[str] = None,
+    title: str = "Tracker Comparison",
+) -> None:
+    """Plot a grouped bar chart comparing trackers across multiple metrics.
+
+    Args:
+        results: List of dicts from :meth:`~eovot.benchmark.engine.BenchmarkEngine.run`.
+        metrics: Metric keys to plot from each ``"summary"`` dict.  Defaults
+            to ``["mean_iou", "mean_fps", "peak_memory_mb"]``.
+        output_path: Save path.  Interactive display when ``None``.
+        title: Figure title string.
+    """
+    plt = _get_matplotlib()
+    import matplotlib
+
+    if metrics is None:
+        metrics = ["mean_iou", "mean_fps", "peak_memory_mb"]
+
+    labels = [r.get("summary", {}).get("tracker_name", f"tracker_{i}")
+              for i, r in enumerate(results)]
+    values = {
+        m: [r.get("summary", {}).get(m, 0.0) for r in results]
+        for m in metrics
+    }
+
+    # Normalise each metric to [0, 1] so all bars live on the same axis.
+    # We also track the raw max to annotate bars.
+    n_metrics = len(metrics)
+    n_trackers = len(results)
+    x = np.arange(n_trackers)
+    bar_width = 0.8 / n_metrics
+
+    fig, ax = plt.subplots(figsize=(max(6, n_trackers * 2), 5))
+    color_cycle = matplotlib.rcParams["axes.prop_cycle"].by_key()["color"]
+
+    for m_idx, metric in enumerate(metrics):
+        raw = np.array(values[metric], dtype=np.float64)
+        max_val = raw.max() if raw.max() > 0 else 1.0
+        normalised = raw / max_val
+        offset = (m_idx - n_metrics / 2 + 0.5) * bar_width
+        bars = ax.bar(
+            x + offset,
+            normalised,
+            width=bar_width * 0.9,
+            label=metric,
+            color=color_cycle[m_idx % len(color_cycle)],
+            alpha=0.85,
+        )
+        # Annotate each bar with the raw value.
+        for bar, raw_val in zip(bars, raw):
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 0.01,
+                f"{raw_val:.2f}",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                rotation=45,
+            )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, fontsize=11)
+    ax.set_ylabel("Normalised Score (raw value annotated)", fontsize=11)
+    ax.set_title(title, fontsize=14)
+    ax.set_ylim(0.0, 1.3)
+    ax.legend(fontsize=10, loc="upper right")
+    ax.grid(True, axis="y", alpha=0.3)
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"[plot] Tracker comparison saved → {output_path}")
+    else:
+        plt.show()

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""CLI for generating benchmark visualizations from saved EOVOT result files.
+
+Reads one or more JSON result files produced by
+:meth:`~eovot.benchmark.engine.BenchmarkEngine.run` (or saved via
+:class:`~eovot.reporting.reporter.BenchmarkReporter`) and generates
+publication-quality plots.
+
+Requires ``matplotlib``::
+
+    pip install matplotlib
+
+Usage
+-----
+Plot success curves for two trackers::
+
+    python scripts/plot_results.py \\
+        --results results/MOSSE-OTB100.json results/KCF-OTB100.json \\
+        --plot success \\
+        --output plots/success_curves.png
+
+Plot comparison bar chart::
+
+    python scripts/plot_results.py \\
+        --results results/MOSSE-OTB100.json results/KCF-OTB100.json \\
+        --plot comparison \\
+        --output plots/comparison.png
+
+Generate all plot types at once::
+
+    python scripts/plot_results.py \\
+        --results results/MOSSE-OTB100.json results/KCF-OTB100.json \\
+        --plot all \\
+        --output-dir plots/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from eovot.visualization.plots import (
+    plot_precision_curves,
+    plot_success_curves,
+    plot_tracker_comparison,
+)
+
+PLOT_TYPES = ("success", "precision", "comparison", "all")
+
+
+def load_results(paths: List[str]) -> list:
+    """Load and return benchmark result dicts from JSON files."""
+    results = []
+    for p in paths:
+        with open(p) as fh:
+            data = json.load(fh)
+        # Support both raw engine dicts and legacy summary-only JSONs.
+        if "summary" not in data:
+            data = {"summary": data, "sequences": []}
+        results.append(data)
+        tracker = data.get("summary", {}).get("tracker_name", Path(p).stem)
+        n_seq = len(data.get("sequences", []))
+        print(f"  Loaded {tracker!r}: {n_seq} sequences from {p}")
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="plot_results",
+        description="Generate EOVOT benchmark visualizations from saved JSON result files.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--results",
+        nargs="+",
+        required=True,
+        metavar="PATH",
+        help="One or more JSON result files to visualize.",
+    )
+    parser.add_argument(
+        "--plot",
+        choices=PLOT_TYPES,
+        default="all",
+        help=(
+            "Plot type: 'success' (overlap success curves), "
+            "'precision' (centre-distance precision curves), "
+            "'comparison' (bar chart across metrics), "
+            "or 'all' to generate every type."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Output file path (PNG / PDF / SVG).  Used only when --plot is "
+            "not 'all'.  If omitted, the plot is shown interactively."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="plots/",
+        metavar="DIR",
+        help="Output directory when --plot all is used.",
+    )
+    parser.add_argument(
+        "--title",
+        default=None,
+        help="Custom figure title.  Auto-generated from tracker names when omitted.",
+    )
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=["mean_iou", "mean_fps", "peak_memory_mb"],
+        metavar="METRIC",
+        help="Metrics to include in the comparison bar chart.",
+    )
+    args = parser.parse_args()
+
+    print("\nLoading result files …")
+    results = load_results(args.results)
+    if not results:
+        print("[ERROR] No valid result files loaded.", file=sys.stderr)
+        sys.exit(1)
+
+    names = " vs ".join(
+        r.get("summary", {}).get("tracker_name", f"tracker_{i}")
+        for i, r in enumerate(results)
+    )
+    auto_title = names
+
+    def _out(stem: str, ext: str = ".png") -> str:
+        outdir = Path(args.output_dir)
+        outdir.mkdir(parents=True, exist_ok=True)
+        return str(outdir / f"{stem}{ext}")
+
+    plot_type = args.plot
+
+    if plot_type in ("success", "all"):
+        title = args.title or f"Success Curves — {auto_title}"
+        out = args.output if plot_type == "success" else _out("success_curves")
+        plot_success_curves(results, output_path=out, title=title)
+
+    if plot_type in ("precision", "all"):
+        title = args.title or f"Precision Curves — {auto_title}"
+        out = args.output if plot_type == "precision" else _out("precision_curves")
+        plot_precision_curves(results, output_path=out, title=title)
+
+    if plot_type in ("comparison", "all"):
+        title = args.title or f"Tracker Comparison — {auto_title}"
+        out = args.output if plot_type == "comparison" else _out("tracker_comparison")
+        plot_tracker_comparison(results, metrics=args.metrics, output_path=out, title=title)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `eovot/visualization/` — a matplotlib-based plotting layer that turns saved benchmark JSON files into publication-ready figures for research papers and READMEs.

### Three Plot Types

**1. Success Curves (`plot_success_curves`)**
Sweeps IoU thresholds 0→1 and plots the fraction of frames exceeding each threshold (the standard OTB/GOT-10k "success curve"). Per-tracker AUC is shown in the legend. Uses raw per-frame IoU arrays stored in the result dict.

**2. Precision Curves (`plot_precision_curves`)**
Sweeps centre-distance thresholds 0→50 px and plots the fraction of frames within each threshold. Annotates the canonical 20 px precision score. Degrades gracefully when centre-distance data is absent.

**3. Tracker Comparison Bar Chart (`plot_tracker_comparison`)**
Grouped bar chart comparing any set of summary-level metrics (default: `mean_iou`, `mean_fps`, `peak_memory_mb`) across all trackers. Values are normalised to [0,1] for visual consistency; raw values are annotated above each bar.

### CLI Script

`scripts/plot_results.py` wraps all three functions:

```bash
# Generate all plots at once
python scripts/plot_results.py \
    --results results/MOSSE-OTB100.json results/KCF-OTB100.json \
    --plot all \
    --output-dir plots/

# Single plot type
python scripts/plot_results.py \
    --results results/MOSSE-OTB100.json results/KCF-OTB100.json \
    --plot success \
    --output plots/success_curves.png
```

### Files Added
- `eovot/visualization/__init__.py`
- `eovot/visualization/plots.py`
- `scripts/plot_results.py`

Requires `matplotlib` (optional dependency): `pip install matplotlib`