### PR TITLE
fix: GOT-10k dataset API, energy profiling integration, script repairs

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine
+from ..profiling.energy import EnergyProfiler, EnergyResult
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
 
@@ -18,6 +19,7 @@ class SequenceResult:
     sequence_name: str
     ious: np.ndarray
     profiling: ProfilingResult
+    energy: Optional[EnergyResult] = None
 
     @property
     def mean_iou(self) -> float:
@@ -43,8 +45,24 @@ class BenchmarkResult:
     def peak_memory_mb(self) -> float:
         return float(np.max([r.profiling.peak_memory_mb for r in self.sequence_results]))
 
+    @property
+    def total_energy_j(self) -> Optional[float]:
+        """Sum of per-sequence energy estimates (Joules), or ``None`` if not profiled."""
+        with_energy = [r for r in self.sequence_results if r.energy is not None]
+        if not with_energy:
+            return None
+        return sum(r.energy.total_energy_j for r in with_energy)
+
+    @property
+    def mean_energy_per_frame_mj(self) -> Optional[float]:
+        """Mean per-frame energy across all sequences (milli-Joules), or ``None``."""
+        with_energy = [r for r in self.sequence_results if r.energy is not None]
+        if not with_energy:
+            return None
+        return float(np.mean([r.energy.energy_per_frame_mj for r in with_energy]))
+
     def summary(self) -> Dict:
-        return {
+        d = {
             "tracker": self.tracker_name,
             "dataset": self.dataset_name,
             "num_sequences": len(self.sequence_results),
@@ -52,6 +70,10 @@ class BenchmarkResult:
             "mean_fps": round(self.mean_fps, 2),
             "peak_memory_mb": round(self.peak_memory_mb, 2),
         }
+        if self.total_energy_j is not None:
+            d["total_energy_j"] = round(self.total_energy_j, 4)
+            d["mean_energy_per_frame_mj"] = round(self.mean_energy_per_frame_mj, 4)
+        return d
 
     def to_dict(self) -> Dict:
         """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
@@ -61,36 +83,52 @@ class BenchmarkResult:
         * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
         * ``"sequences"`` — list of per-sequence metric dicts.
         """
-        return {
-            "summary": self.summary(),
-            "sequences": [
-                {
-                    "sequence_name": sr.sequence_name,
-                    "mean_iou": round(sr.mean_iou, 4),
-                    "fps": round(sr.profiling.fps, 2),
-                    "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                    "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-                }
-                for sr in self.sequence_results
-            ],
-        }
+        sequences = []
+        for sr in self.sequence_results:
+            entry: Dict = {
+                "sequence_name": sr.sequence_name,
+                "mean_iou": round(sr.mean_iou, 4),
+                "fps": round(sr.profiling.fps, 2),
+                "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
+                "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
+            }
+            if sr.energy is not None:
+                entry["energy_j"] = round(sr.energy.total_energy_j, 6)
+                entry["energy_per_frame_mj"] = round(sr.energy.energy_per_frame_mj, 4)
+            sequences.append(entry)
+        return {"summary": self.summary(), "sequences": sequences}
 
     def __str__(self) -> str:
         s = self.summary()
-        return (
+        base = (
             f"BenchmarkResult[{s['tracker']} on {s['dataset']}] "
             f"mIoU={s['mean_iou']}  FPS={s['mean_fps']}  "
             f"mem={s['peak_memory_mb']} MiB  ({s['num_sequences']} sequences)"
         )
+        if "total_energy_j" in s:
+            base += f"  energy={s['total_energy_j']} J"
+        return base
 
 
 class BenchmarkEngine:
-    """Run a tracker against a dataset and collect accuracy + profiling data."""
+    """Run a tracker against a dataset and collect accuracy + profiling data.
 
-    def __init__(self, verbose: bool = True) -> None:
+    Args:
+        verbose: Print per-sequence progress to stdout. Default: ``True``.
+        tdp_watts: If provided, enables CPU energy estimation using
+            :class:`~eovot.profiling.energy.EnergyProfiler` with this TDP
+            value (Watts).  Set to the device's CPU TDP for meaningful
+            estimates (e.g. ``6.0`` for Raspberry Pi 4, ``15.0`` for a
+            laptop).  Default: ``None`` (energy profiling disabled).
+    """
+
+    def __init__(self, verbose: bool = True, tdp_watts: Optional[float] = None) -> None:
         self.verbose = verbose
         self._metrics = MetricsEngine()
         self._profiler = Profiler()
+        self._energy_profiler: Optional[EnergyProfiler] = (
+            EnergyProfiler(tdp_watts=tdp_watts) if tdp_watts is not None else None
+        )
 
     def run(
         self,
@@ -104,7 +142,8 @@ class BenchmarkEngine:
         n = min(len(dataset), max_sequences) if max_sequences is not None else len(dataset)
 
         if self.verbose:
-            print(f"\nEvaluating {tracker.name} on {dataset_name} ({n} sequences)")
+            energy_tag = f"  [energy TDP={self._energy_profiler.tdp_watts}W]" if self._energy_profiler else ""
+            print(f"\nEvaluating {tracker.name} on {dataset_name} ({n} sequences){energy_tag}")
             print("-" * 60)
 
         for idx in range(n):
@@ -112,10 +151,14 @@ class BenchmarkEngine:
             seq_result = self._run_sequence(tracker, seq)
             result.sequence_results.append(seq_result)
             if self.verbose:
+                energy_str = ""
+                if seq_result.energy is not None:
+                    energy_str = f"  E={seq_result.energy.energy_per_frame_mj:.2f}mJ/fr"
                 print(
                     f"  [{idx + 1:>3}/{n}] {seq_result.sequence_name:<30s} "
                     f"mIoU={seq_result.mean_iou:.3f}  "
                     f"FPS={seq_result.profiling.fps:.1f}"
+                    f"{energy_str}"
                 )
 
         if self.verbose:
@@ -126,6 +169,9 @@ class BenchmarkEngine:
 
     def _run_sequence(self, tracker: BaseTracker, seq: Sequence) -> SequenceResult:
         self._profiler.reset()
+        if self._energy_profiler is not None:
+            self._energy_profiler.reset()
+
         frames = list(seq)
         gt = seq.ground_truth
         preds: List = []
@@ -136,16 +182,28 @@ class BenchmarkEngine:
                 preds.append(seq.init_bbox)
             else:
                 self._profiler.start_frame()
+                if self._energy_profiler is not None:
+                    self._energy_profiler.start_frame()
                 bbox = tracker.update(frame)
                 self._profiler.end_frame()
+                if self._energy_profiler is not None:
+                    self._energy_profiler.end_frame()
                 preds.append(bbox)
 
         preds_arr = np.array(preds, dtype=np.float64)
         n_eval = min(len(preds_arr), len(gt))
         ious = self._metrics.batch_iou(preds_arr[:n_eval], gt[:n_eval])
 
+        energy: Optional[EnergyResult] = None
+        if self._energy_profiler is not None:
+            try:
+                energy = self._energy_profiler.summary(tracker.name)
+            except ValueError:
+                pass  # sequence too short (0 update frames)
+
         return SequenceResult(
             sequence_name=seq.name,
             ious=ious,
             profiling=self._profiler.summary(tracker.name),
+            energy=energy,
         )

--- a/eovot/datasets/got10k.py
+++ b/eovot/datasets/got10k.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-import cv2
+import numpy as np
 
 from .base import BaseDataset, BBox, Sequence
 
@@ -38,14 +38,27 @@ from .base import BaseDataset, BBox, Sequence
 class GOT10kDataset(BaseDataset):
     """Dataset loader for GOT-10k (train / val / test splits).
 
+    Implements the :class:`~eovot.datasets.base.BaseDataset` interface via
+    ``__len__`` and ``__getitem__``, so it works directly with
+    :class:`~eovot.benchmark.engine.BenchmarkEngine`.
+
+    Frames are loaded lazily on iteration (not pre-loaded into RAM), keeping
+    memory usage constant regardless of dataset size.
+
     Args:
         root: Path to the GOT-10k root directory.  Must contain
             ``train/``, ``val/``, or ``test/`` subdirectories.
         split: Dataset split — one of ``"train"``, ``"val"``, ``"test"``.
             Default: ``"val"``.
         max_sequences: Optional upper limit on the number of sequences
-            returned by :meth:`list_sequences`.  Useful for quick smoke
-            tests without downloading the full dataset.
+            returned.  Useful for quick smoke tests without downloading the
+            full dataset.
+
+    Example::
+
+        dataset = GOT10kDataset("/data/GOT-10k", split="val", max_sequences=10)
+        for seq in dataset:
+            print(seq.name, len(seq))
     """
 
     SPLITS = ("train", "val", "test")
@@ -58,7 +71,9 @@ class GOT10kDataset(BaseDataset):
     ) -> None:
         if split not in self.SPLITS:
             raise ValueError(f"split must be one of {self.SPLITS!r}, got {split!r}")
-        super().__init__(root=root, split=split)
+        # BaseDataset has no constructor parameters — do NOT forward kwargs.
+        self.root = root
+        self.split = split
         self.max_sequences = max_sequences
         self._split_dir = Path(root) / split
         self._seq_names: Optional[List[str]] = None
@@ -67,8 +82,23 @@ class GOT10kDataset(BaseDataset):
     # BaseDataset interface
     # ------------------------------------------------------------------
 
-    def list_sequences(self) -> List[str]:
-        """Return the list of sequence names for this split.
+    def __len__(self) -> int:
+        return len(self._get_seq_names())
+
+    def __getitem__(self, idx: int) -> Sequence:
+        seq_name = self._get_seq_names()[idx]
+        return self._load_sequence(seq_name)
+
+    @property
+    def name(self) -> str:
+        return f"GOT-10k-{self.split}"
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_seq_names(self) -> List[str]:
+        """Return (and cache) the ordered list of sequence names for this split.
 
         Reads ``list.txt`` when present; falls back to enumerating
         subdirectories that contain an ``img/`` folder.
@@ -92,19 +122,21 @@ class GOT10kDataset(BaseDataset):
         self._seq_names = names
         return self._seq_names
 
-    def load_sequence(self, seq_name: str) -> Sequence:
+    def _load_sequence(self, seq_name: str) -> Sequence:
         """Load a single GOT-10k sequence by name.
+
+        Frames are referenced by path (lazy I/O) rather than pre-loaded,
+        matching the :class:`~eovot.datasets.base.Sequence` contract.
 
         Args:
             seq_name: Sequence folder name (e.g. ``"GOT-10k_Val_000001"``).
 
         Returns:
-            :class:`~eovot.datasets.base.Sequence` with frames and GT boxes
-            aligned to the same length.
+            :class:`~eovot.datasets.base.Sequence` with frame paths and GT
+            boxes aligned to the same length.
 
         Raises:
             FileNotFoundError: If ``groundtruth.txt`` or ``img/`` are missing.
-            IOError: If any frame image cannot be decoded by OpenCV.
         """
         seq_dir = self._split_dir / seq_name
 
@@ -121,30 +153,18 @@ class GOT10kDataset(BaseDataset):
         if not img_dir.is_dir():
             raise FileNotFoundError(f"img/ directory not found at {img_dir}")
 
+        # Collect paths in chronological order; merge JPG and PNG.
         frame_paths = sorted(img_dir.glob("*.jpg")) + sorted(img_dir.glob("*.png"))
-        frame_paths = sorted(frame_paths)  # ensure chronological order after merge
+        frame_paths = sorted(frame_paths)
         if not frame_paths:
             raise FileNotFoundError(f"No JPEG/PNG frames found in {img_dir}")
 
         # Align frame count and GT length (some sequences may differ by one).
         n = min(len(frame_paths), len(gt_boxes))
-        frame_paths = frame_paths[:n]
-        gt_boxes = gt_boxes[:n]
+        frame_paths_str = [str(p) for p in frame_paths[:n]]
+        gt_array = np.array(gt_boxes[:n], dtype=np.float64)
 
-        frames = [cv2.imread(str(p)) for p in frame_paths]
-        bad = [str(frame_paths[i]) for i, f in enumerate(frames) if f is None]
-        if bad:
-            raise IOError(f"OpenCV failed to decode {len(bad)} frame(s): {bad[:3]} ...")
-
-        return Sequence(name=seq_name, frames=frames, gt_boxes=gt_boxes)
-
-    @property
-    def name(self) -> str:
-        return f"GOT-10k-{self.split}"
-
-    # ------------------------------------------------------------------
-    # Private helpers
-    # ------------------------------------------------------------------
+        return Sequence(name=seq_name, frame_paths=frame_paths_str, ground_truth=gt_array)
 
     @staticmethod
     def _load_groundtruth(gt_file: Path) -> List[BBox]:

--- a/scripts/compare_trackers.py
+++ b/scripts/compare_trackers.py
@@ -26,6 +26,12 @@ Usage::
         --dataset-loader GOT10kDataset \\
         --dataset-root /data/GOT-10k \\
         --split val
+
+    # With CPU energy estimation (laptop TDP)
+    python scripts/compare_trackers.py \\
+        --trackers MOSSE KCF \\
+        --dataset-root /data/OTB100 \\
+        --tdp-watts 15.0
 """
 
 from __future__ import annotations
@@ -37,9 +43,10 @@ from pathlib import Path
 # Allow running as ``python scripts/compare_trackers.py`` from the repo root.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from eovot.benchmark.engine import BenchmarkConfig, BenchmarkEngine
+from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
+from eovot.datasets.lasot import LaSOTDataset
 from eovot.reporting.reporter import BenchmarkReporter
 from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
@@ -56,7 +63,18 @@ TRACKER_REGISTRY = {
 DATASET_REGISTRY = {
     "OTBDataset": OTBDataset,
     "GOT10kDataset": GOT10kDataset,
+    "LaSOTDataset": LaSOTDataset,
 }
+
+
+def _build_dataset(loader_name: str, root: str, split: str, max_sequences):
+    """Instantiate the dataset, handling different constructor signatures."""
+    cls = DATASET_REGISTRY[loader_name]
+    if loader_name == "GOT10kDataset":
+        return cls(root=root, split=split, max_sequences=max_sequences)
+    if loader_name == "LaSOTDataset":
+        return cls(root=root, split=split, max_sequences=max_sequences)
+    return cls(root=root)
 
 
 def main() -> None:
@@ -92,7 +110,7 @@ def main() -> None:
     parser.add_argument(
         "--split",
         default="val",
-        help="Dataset split (for GOT-10k: train | val | test).",
+        help="Dataset split (for GOT-10k: train | val | test; for LaSOT: train | test | all).",
     )
     parser.add_argument(
         "--max-sequences",
@@ -105,12 +123,21 @@ def main() -> None:
         default="results/",
         help="Directory where JSON, CSV, and Markdown reports are saved.",
     )
+    parser.add_argument(
+        "--tdp-watts",
+        type=float,
+        default=None,
+        metavar="W",
+        help=(
+            "Enable CPU energy estimation using this TDP value in Watts. "
+            "Example: 6.0 for Raspberry Pi 4, 15.0 for a laptop CPU."
+        ),
+    )
     args = parser.parse_args()
 
     dataset_name = args.dataset_name or args.dataset_loader
     reporter = BenchmarkReporter(output_dir=args.output_dir)
-    config = BenchmarkConfig(max_sequences=args.max_sequences, verbose=True)
-    engine = BenchmarkEngine(config=config)
+    engine = BenchmarkEngine(verbose=True, tdp_watts=args.tdp_watts)
 
     all_results = []
 
@@ -120,28 +147,27 @@ def main() -> None:
         print(f"{'=' * 60}")
 
         tracker = TRACKER_REGISTRY[tracker_name]()
+        dataset = _build_dataset(
+            args.dataset_loader, args.dataset_root, args.split, args.max_sequences
+        )
 
-        dataset_cls = DATASET_REGISTRY[args.dataset_loader]
-        if args.dataset_loader == "GOT10kDataset":
-            dataset = dataset_cls(
-                root=args.dataset_root,
-                split=args.split,
-                max_sequences=args.max_sequences,
-            )
-        else:
-            dataset = dataset_cls(root=args.dataset_root)
+        result = engine.run(
+            tracker,
+            dataset,
+            dataset_name=dataset_name,
+            max_sequences=args.max_sequences,
+        )
+        result_dict = result.to_dict()
+        result_dict["summary"].setdefault("dataset_name", dataset_name)
 
-        result = engine.run(tracker, dataset)
-        result["summary"].setdefault("dataset_name", dataset_name)
-
-        reporter.print_summary(result)
+        reporter.print_summary(result_dict)
 
         run_name = f"{tracker_name}-{dataset_name}"
-        saved = reporter.save_all(result, name=run_name)
+        saved = reporter.save_all(result_dict, name=run_name)
         for fmt, path in saved.items():
             print(f"  [{fmt.upper()}] saved → {path}")
 
-        all_results.append(result)
+        all_results.append(result_dict)
 
     # -----------------------------------------------------------------------
     # Comparison table (only meaningful with 2+ trackers)

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -32,6 +32,9 @@ import yaml
 
 from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
+from eovot.datasets.got10k import GOT10kDataset
+from eovot.datasets.lasot import LaSOTDataset
+from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
 
 
@@ -41,6 +44,7 @@ from eovot.trackers.mosse import MOSSETracker
 
 TRACKER_REGISTRY: Dict[str, Any] = {
     "MOSSE": MOSSETracker,
+    "KCF": KCFTracker,
 }
 
 
@@ -50,6 +54,8 @@ TRACKER_REGISTRY: Dict[str, Any] = {
 
 DATASET_REGISTRY: Dict[str, Any] = {
     "OTBDataset": OTBDataset,
+    "GOT10kDataset": GOT10kDataset,
+    "LaSOTDataset": LaSOTDataset,
 }
 
 
@@ -82,6 +88,7 @@ def _config_from_args(args: argparse.Namespace) -> Dict:
         },
         "benchmark": {
             "verbose": not args.quiet,
+            "tdp_watts": args.tdp_watts,
         },
         "reporting": {
             "formats": ["json"],
@@ -102,7 +109,15 @@ def run_from_config(cfg: Dict) -> None:
     if loader_cls is None:
         print(f"[ERROR] Unknown dataset loader: {ds_cfg['loader']}", file=sys.stderr)
         sys.exit(1)
-    dataset = loader_cls(ds_cfg["root"])
+    loader_name = ds_cfg.get("loader", "OTBDataset")
+    if loader_name in ("GOT10kDataset", "LaSOTDataset"):
+        dataset = loader_cls(
+            ds_cfg["root"],
+            split=ds_cfg.get("split", "val"),
+            max_sequences=ds_cfg.get("max_sequences"),
+        )
+    else:
+        dataset = loader_cls(ds_cfg["root"])
 
     # --- Tracker ---
     tr_cfg = cfg["tracker"]
@@ -119,7 +134,10 @@ def run_from_config(cfg: Dict) -> None:
 
     # --- Engine ---
     bm_cfg = cfg.get("benchmark", {})
-    engine = BenchmarkEngine(verbose=bm_cfg.get("verbose", True))
+    engine = BenchmarkEngine(
+        verbose=bm_cfg.get("verbose", True),
+        tdp_watts=bm_cfg.get("tdp_watts"),
+    )
 
     result = engine.run(
         tracker=tracker,
@@ -190,6 +208,11 @@ def _build_parser() -> argparse.ArgumentParser:
                         help="Directory for output reports (default: results/).")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress per-sequence progress output.")
+    parser.add_argument("--tdp-watts", type=float, default=None, metavar="W",
+                        help=(
+                            "Enable CPU energy estimation with this TDP (Watts). "
+                            "E.g. 6.0 for Raspberry Pi 4, 15.0 for a laptop."
+                        ))
     return parser
 
 


### PR DESCRIPTION
- GOT-10k dataset (got10k.py): replace broken super().__init__(root, split) with plain attribute assignment; implement __len__ / __getitem__ to satisfy BaseDataset contract; switch to lazy frame loading via frame_paths strings instead of eager cv2.imread + wrong Sequence(frames=...) constructor.

- BenchmarkEngine (engine.py): add optional tdp_watts parameter that enables EnergyProfiler for per-sequence CPU energy estimation; SequenceResult gains an optional energy field; BenchmarkResult exposes total_energy_j and mean_energy_per_frame_mj aggregates; summary() and to_dict() include energy metrics when available.

- compare_trackers.py: remove import of non-existent BenchmarkConfig; fix engine instantiation and engine.run() call signature; add --tdp-watts flag; add LaSOTDataset to DATASET_REGISTRY; unify dataset construction logic.

- run_benchmark.py: register KCFTracker, GOT10kDataset, LaSOTDataset; handle split / max_sequences kwargs for multi-split datasets; thread tdp_watts from CLI flag and YAML config through to BenchmarkEngine.

https://claude.ai/code/session_01UuBuJUAcg51rYuNH5NXbWh