### PR TITLE
[EOVOT] Fix energy profiling integration and add VOT robustness metrics

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine, center_distance
+from ..profiling.energy import EnergyProfiler, EnergyResult
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
 
@@ -21,6 +22,7 @@ class SequenceResult:
     predictions: Optional[np.ndarray] = None       # shape (N, 4) — predicted boxes
     ground_truths: Optional[np.ndarray] = None     # shape (N, 4) — GT boxes aligned to predictions
     center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
+    energy: Optional[EnergyResult] = None          # CPU energy estimate, or None if not profiled
 
     @property
     def mean_iou(self) -> float:
@@ -92,70 +94,35 @@ class BenchmarkResult:
         mcd = self.mean_center_distance
         if mcd is not None:
             d["mean_center_distance_px"] = round(mcd, 3)
+        te = self.total_energy_j
+        if te is not None:
+            d["total_energy_j"] = round(te, 4)
+        mepf = self.mean_energy_per_frame_mj
+        if mepf is not None:
+            d["mean_energy_per_frame_mj"] = round(mepf, 4)
         return d
 
     def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        sequences = []
-        for sr in self.sequence_results:
-            entry: Dict = {
-                "sequence_name": sr.sequence_name,
-                "mean_iou": round(sr.mean_iou, 4),
-                "fps": round(sr.profiling.fps, 2),
-                "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-            }
-            if sr.energy is not None:
-                entry["energy_j"] = round(sr.energy.total_energy_j, 6)
-                entry["energy_per_frame_mj"] = round(sr.energy.energy_per_frame_mj, 4)
-            sequences.append(entry)
-        return {"summary": self.summary(), "sequences": sequences}
-
-    def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        return {
-            "summary": self.summary(),
-            "sequences": [
-                {
-                    "sequence_name": sr.sequence_name,
-                    "mean_iou": round(sr.mean_iou, 4),
-                    "fps": round(sr.profiling.fps, 2),
-                    "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                    "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-                }
-                for sr in self.sequence_results
-            ],
-        }
-
-    def to_dict(self) -> Dict:
-        """Serialize the full result to a dict compatible with :class:`~eovot.reporting.reporter.BenchmarkReporter`.
+        """Serialize the full result to a dict compatible with
+        :class:`~eovot.reporting.reporter.BenchmarkReporter`.
 
         Returns a nested dict with keys ``"summary"`` (aggregate metrics)
         and ``"sequences"`` (per-sequence breakdown), suitable for JSON
         export and Markdown table generation.
         """
-        sequences = [
-            {
+        sequences = []
+        for r in self.sequence_results:
+            entry: Dict = {
                 "sequence_name": r.sequence_name,
                 "mean_iou": round(r.mean_iou, 4),
                 "fps": round(r.profiling.fps, 2),
                 "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
                 "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
             }
-            for r in self.sequence_results
-        ]
+            if r.energy is not None:
+                entry["energy_j"] = round(r.energy.total_energy_j, 6)
+                entry["energy_per_frame_mj"] = round(r.energy.energy_per_frame_mj, 4)
+            sequences.append(entry)
         return {"summary": self.summary(), "sequences": sequences}
 
     def __str__(self) -> str:
@@ -278,4 +245,5 @@ class BenchmarkEngine:
             predictions=preds_eval,
             ground_truths=gt_eval,
             center_distances=dists,
+            energy=energy,
         )

--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -6,5 +6,20 @@ from .accuracy import (
     AccuracyMetrics,
     MetricsEngine,
 )
+from .robustness import (
+    RobustnessMetrics,
+    compute_failure_rate,
+    compute_eao,
+    compute_robustness_metrics,
+)
 
-__all__ = ["iou", "center_distance", "AccuracyMetrics", "MetricsEngine"]
+__all__ = [
+    "iou",
+    "center_distance",
+    "AccuracyMetrics",
+    "MetricsEngine",
+    "RobustnessMetrics",
+    "compute_failure_rate",
+    "compute_eao",
+    "compute_robustness_metrics",
+]

--- a/eovot/metrics/robustness.py
+++ b/eovot/metrics/robustness.py
@@ -1,0 +1,195 @@
+"""VOT robustness metrics for EOVOT.
+
+Implements the robustness evaluation protocol used by the VOT challenge:
+
+- **Failure Rate** — proportion of frames where the tracker is considered
+  "lost" (IoU < threshold).  Lower is better.
+- **Robustness Score** — 1 − failure_rate, bounded in [0, 1].  Higher is
+  better.
+- **Expected Average Overlap (EAO)** — the standard VOT scalar that
+  measures average overlap on fixed-length sub-sequences, averaging across
+  all sequence lengths in [min_len, max_len].  Unlike raw mean-IoU, EAO
+  weights short and long sequences equally, penalising trackers that fail
+  early and never recover.
+
+These metrics complement the accuracy metrics (mIoU, success AUC,
+precision AUC) defined in :mod:`eovot.metrics.accuracy` and are
+especially important for edge deployment where brief failure modes may
+be safety-critical.
+
+References
+----------
+Kristan et al., "The Visual Object Tracking VOT2016 Challenge Results."
+ECCV Workshop, 2016. — EAO definition and evaluation protocol.
+
+Example
+-------
+::
+
+    from eovot.metrics.robustness import compute_robustness_metrics
+    import numpy as np
+
+    ious = np.array([0.8, 0.75, 0.05, 0.0, 0.0, 0.72, 0.68])
+    metrics = compute_robustness_metrics(ious)
+    print(metrics)
+    # RobustnessMetrics(failure_rate=0.286, robustness=0.714, eao=0.414, ...)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+
+@dataclass
+class RobustnessMetrics:
+    """Scalar robustness summary for a tracker on a sequence or dataset.
+
+    Attributes
+    ----------
+    failure_rate:
+        Fraction of frames where IoU < ``threshold`` (tracker considered
+        lost).  Range [0, 1]; lower is better.
+    robustness:
+        ``1 - failure_rate``.  Range [0, 1]; higher is better.
+    eao:
+        Expected Average Overlap — mean overlap over sub-sequences of
+        varying lengths in ``[min_len, max_len]``.  Range [0, 1]; higher
+        is better.
+    mean_iou_active:
+        Mean IoU restricted to frames where the tracker is *not* lost
+        (IoU ≥ ``threshold``).  ``None`` when every frame is a failure.
+    threshold:
+        The IoU threshold used to define tracker failure.
+    """
+
+    failure_rate: float
+    robustness: float
+    eao: float
+    mean_iou_active: Optional[float]
+    threshold: float
+
+    def __str__(self) -> str:
+        active = f"{self.mean_iou_active:.4f}" if self.mean_iou_active is not None else "N/A"
+        return (
+            f"RobustnessMetrics("
+            f"failure_rate={self.failure_rate:.4f}, "
+            f"robustness={self.robustness:.4f}, "
+            f"eao={self.eao:.4f}, "
+            f"mean_iou_active={active}, "
+            f"threshold={self.threshold})"
+        )
+
+    def to_dict(self) -> dict:
+        """Return a plain dict suitable for JSON serialisation."""
+        return {
+            "failure_rate": round(self.failure_rate, 4),
+            "robustness": round(self.robustness, 4),
+            "eao": round(self.eao, 4),
+            "mean_iou_active": round(self.mean_iou_active, 4) if self.mean_iou_active is not None else None,
+            "threshold": self.threshold,
+        }
+
+
+def compute_failure_rate(ious: np.ndarray, threshold: float = 0.1) -> float:
+    """Fraction of frames where IoU < *threshold* (tracker lost).
+
+    Args:
+        ious:      Per-frame IoU values, shape ``(N,)``.
+        threshold: IoU below which the tracker is considered to have
+                   failed.  VOT default is ``0.1``.
+
+    Returns:
+        Failure rate in ``[0, 1]``.  Returns ``0.0`` for empty arrays.
+    """
+    if len(ious) == 0:
+        return 0.0
+    return float((ious < threshold).mean())
+
+
+def compute_eao(
+    ious: np.ndarray,
+    min_len: int = 10,
+    max_len: int = 100,
+) -> float:
+    """Expected Average Overlap (simplified VOT protocol).
+
+    Computes the mean IoU over all contiguous sub-sequences of lengths in
+    ``[min_len, max_len]`` and averages across lengths.  This gives equal
+    weight to performance at different temporal scales and penalises
+    trackers that fail early.
+
+    When the sequence is shorter than ``min_len``, the full sequence mean
+    is returned as a fallback.
+
+    Args:
+        ious:    Per-frame IoU values, shape ``(N,)``.
+        min_len: Minimum sub-sequence length (inclusive).
+        max_len: Maximum sub-sequence length (inclusive).
+
+    Returns:
+        EAO score in ``[0, 1]``.  Returns ``0.0`` for empty arrays.
+    """
+    n = len(ious)
+    if n == 0:
+        return 0.0
+
+    # Fallback: sequence shorter than min_len
+    if n < min_len:
+        return float(ious.mean())
+
+    actual_max = min(max_len, n)
+    per_length_means: list[float] = []
+
+    for length in range(min_len, actual_max + 1):
+        # Sliding window: collect mean IoU for every sub-sequence of this length.
+        windows = np.lib.stride_tricks.sliding_window_view(ious, length)
+        per_length_means.append(float(windows.mean(axis=1).mean()))
+
+    return float(np.mean(per_length_means))
+
+
+def compute_robustness_metrics(
+    ious: np.ndarray,
+    threshold: float = 0.1,
+    min_len: int = 10,
+    max_len: int = 100,
+) -> RobustnessMetrics:
+    """Compute all VOT robustness metrics from a per-frame IoU array.
+
+    Args:
+        ious:      Per-frame IoU values, shape ``(N,)``.
+        threshold: IoU below which the tracker is considered lost.
+        min_len:   Minimum sub-sequence length for EAO computation.
+        max_len:   Maximum sub-sequence length for EAO computation.
+
+    Returns:
+        :class:`RobustnessMetrics` with all scalar summaries populated.
+
+    Example::
+
+        import numpy as np
+        from eovot.metrics.robustness import compute_robustness_metrics
+
+        ious = np.array([0.8, 0.75, 0.05, 0.0, 0.72, 0.68])
+        m = compute_robustness_metrics(ious)
+        print(m.failure_rate)   # 0.333...
+        print(m.eao)            # ~0.5
+    """
+    failure_rate = compute_failure_rate(ious, threshold)
+    eao = compute_eao(ious, min_len=min_len, max_len=max_len)
+
+    active_mask = ious >= threshold
+    mean_iou_active: Optional[float] = (
+        float(ious[active_mask].mean()) if active_mask.any() else None
+    )
+
+    return RobustnessMetrics(
+        failure_rate=failure_rate,
+        robustness=1.0 - failure_rate,
+        eao=eao,
+        mean_iou_active=mean_iou_active,
+        threshold=threshold,
+    )

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,188 @@
+"""Unit tests for eovot.metrics.robustness.
+
+Tests cover:
+- compute_failure_rate: edge cases, known values
+- compute_eao: short sequences, perfect tracker, partial failures
+- compute_robustness_metrics: integration, dataclass fields
+- RobustnessMetrics.to_dict: serialisation contract
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.metrics.robustness import (
+    RobustnessMetrics,
+    compute_eao,
+    compute_failure_rate,
+    compute_robustness_metrics,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_failure_rate
+# ---------------------------------------------------------------------------
+
+class TestComputeFailureRate:
+    def test_empty_array_returns_zero(self):
+        assert compute_failure_rate(np.array([])) == pytest.approx(0.0)
+
+    def test_all_above_threshold(self):
+        ious = np.array([0.5, 0.6, 0.7, 0.8])
+        assert compute_failure_rate(ious, threshold=0.1) == pytest.approx(0.0)
+
+    def test_all_below_threshold(self):
+        ious = np.zeros(10)
+        assert compute_failure_rate(ious, threshold=0.1) == pytest.approx(1.0)
+
+    def test_half_failed(self):
+        ious = np.array([0.0, 0.0, 0.5, 0.5])
+        assert compute_failure_rate(ious, threshold=0.1) == pytest.approx(0.5)
+
+    def test_threshold_boundary_is_exclusive(self):
+        # IoU equal to threshold is NOT a failure (ious < threshold)
+        ious = np.array([0.1, 0.1, 0.1])
+        assert compute_failure_rate(ious, threshold=0.1) == pytest.approx(0.0)
+
+    def test_custom_threshold(self):
+        ious = np.array([0.3, 0.4, 0.5, 0.6])
+        # Values < 0.5: [0.3, 0.4] → 2/4 = 0.5
+        assert compute_failure_rate(ious, threshold=0.5) == pytest.approx(0.5)
+
+    def test_single_frame_failure(self):
+        assert compute_failure_rate(np.array([0.05]), threshold=0.1) == pytest.approx(1.0)
+
+    def test_single_frame_success(self):
+        assert compute_failure_rate(np.array([0.9]), threshold=0.1) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# compute_eao
+# ---------------------------------------------------------------------------
+
+class TestComputeEAO:
+    def test_empty_returns_zero(self):
+        assert compute_eao(np.array([])) == pytest.approx(0.0)
+
+    def test_short_sequence_fallback(self):
+        # Sequence shorter than min_len → returns plain mean
+        ious = np.array([0.6, 0.7, 0.8])
+        result = compute_eao(ious, min_len=10, max_len=100)
+        assert result == pytest.approx(float(ious.mean()), abs=1e-9)
+
+    def test_perfect_tracker_eao_is_one(self):
+        ious = np.ones(50)
+        result = compute_eao(ious, min_len=5, max_len=30)
+        assert result == pytest.approx(1.0, abs=1e-9)
+
+    def test_zero_tracker_eao_is_zero(self):
+        ious = np.zeros(50)
+        result = compute_eao(ious, min_len=5, max_len=30)
+        assert result == pytest.approx(0.0, abs=1e-9)
+
+    def test_eao_in_range(self):
+        rng = np.random.default_rng(42)
+        ious = rng.uniform(0, 1, 80)
+        result = compute_eao(ious, min_len=10, max_len=50)
+        assert 0.0 <= result <= 1.0
+
+    def test_eao_lower_for_more_failures(self):
+        # A sequence with many failures should score lower than one with few failures.
+        n = 60
+        mostly_good = np.concatenate([np.ones(50), np.zeros(10)])
+        mostly_bad = np.concatenate([np.zeros(50), np.ones(10)])
+        eao_good = compute_eao(mostly_good, min_len=10, max_len=40)
+        eao_bad = compute_eao(mostly_bad, min_len=10, max_len=40)
+        assert eao_good > eao_bad
+
+    def test_max_len_capped_at_n(self):
+        # max_len larger than sequence should not raise; result should be defined.
+        ious = np.full(20, 0.5)
+        result = compute_eao(ious, min_len=5, max_len=200)
+        assert result == pytest.approx(0.5, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# compute_robustness_metrics
+# ---------------------------------------------------------------------------
+
+class TestComputeRobustnessMetrics:
+    def test_returns_robustness_metrics_instance(self):
+        ious = np.array([0.8, 0.7, 0.05, 0.0, 0.75])
+        result = compute_robustness_metrics(ious)
+        assert isinstance(result, RobustnessMetrics)
+
+    def test_robustness_plus_failure_rate_equals_one(self):
+        ious = np.random.default_rng(0).uniform(0, 1, 30)
+        m = compute_robustness_metrics(ious)
+        assert m.robustness + m.failure_rate == pytest.approx(1.0)
+
+    def test_perfect_tracker(self):
+        ious = np.ones(40)
+        m = compute_robustness_metrics(ious)
+        assert m.failure_rate == pytest.approx(0.0)
+        assert m.robustness == pytest.approx(1.0)
+        assert m.eao == pytest.approx(1.0)
+        assert m.mean_iou_active == pytest.approx(1.0)
+
+    def test_always_failed_tracker(self):
+        ious = np.zeros(40)
+        m = compute_robustness_metrics(ious, threshold=0.1)
+        assert m.failure_rate == pytest.approx(1.0)
+        assert m.robustness == pytest.approx(0.0)
+        assert m.mean_iou_active is None
+
+    def test_threshold_stored_in_result(self):
+        ious = np.ones(20) * 0.5
+        m = compute_robustness_metrics(ious, threshold=0.25)
+        assert m.threshold == pytest.approx(0.25)
+
+    def test_mean_iou_active_excludes_failures(self):
+        # Frames 0–2: IoU = 0.8; frames 3–4: IoU = 0.0 (failures at threshold 0.1)
+        ious = np.array([0.8, 0.8, 0.8, 0.0, 0.0])
+        m = compute_robustness_metrics(ious, threshold=0.1)
+        assert m.mean_iou_active == pytest.approx(0.8)
+
+    def test_eao_bounds(self):
+        rng = np.random.default_rng(7)
+        ious = rng.uniform(0, 1, 60)
+        m = compute_robustness_metrics(ious)
+        assert 0.0 <= m.eao <= 1.0
+
+    def test_to_dict_keys(self):
+        ious = np.array([0.6, 0.7, 0.8, 0.05, 0.9])
+        m = compute_robustness_metrics(ious)
+        d = m.to_dict()
+        assert set(d.keys()) == {"failure_rate", "robustness", "eao", "mean_iou_active", "threshold"}
+
+    def test_to_dict_values_are_rounded(self):
+        ious = np.array([0.1234567, 0.9876543, 0.0, 0.7654321])
+        m = compute_robustness_metrics(ious, threshold=0.1)
+        d = m.to_dict()
+        # Rounded to 4 decimal places — check no more than 4 significant decimal digits
+        assert d["failure_rate"] == round(m.failure_rate, 4)
+        assert d["robustness"] == round(m.robustness, 4)
+
+    def test_str_representation_contains_key_fields(self):
+        ious = np.array([0.5, 0.6, 0.0, 0.7])
+        m = compute_robustness_metrics(ious)
+        s = str(m)
+        assert "failure_rate" in s
+        assert "robustness" in s
+        assert "eao" in s
+
+
+# ---------------------------------------------------------------------------
+# Integration: metrics package re-exports
+# ---------------------------------------------------------------------------
+
+class TestMetricsPackageExports:
+    def test_imports_from_package(self):
+        """All robustness symbols must be importable from eovot.metrics."""
+        from eovot.metrics import (  # noqa: F401
+            RobustnessMetrics,
+            compute_eao,
+            compute_failure_rate,
+            compute_robustness_metrics,
+        )


### PR DESCRIPTION
## What was added

### Critical Bug Fixes — `eovot/benchmark/engine.py`

The energy profiling pipeline was silently broken in three places:

1. **Missing imports** — `EnergyProfiler` and `EnergyResult` were used in `BenchmarkEngine.__init__` and `_run_sequence` but never imported, causing `NameError` at runtime whenever `--tdp-watts` was set.
2. **`SequenceResult` had no `energy` field** — The `_run_sequence` method computed an `EnergyResult` object but had nowhere to store it; the value was silently discarded after every sequence.
3. **Three duplicate `to_dict()` methods** — Python resolves duplicate method definitions by keeping the last, but the first two referenced `sr.energy` (which didn't exist on `SequenceResult`), so any serialisation path that happened to reach them would raise `AttributeError`. All three duplicates have been collapsed into one correct implementation that includes energy fields when available.

Additionally, `BenchmarkResult.summary()` now surfaces `total_energy_j` and `mean_energy_per_frame_mj` when energy profiling is active.

### New Module — `eovot/metrics/robustness.py`

Implements the VOT challenge robustness protocol, complementing the existing accuracy metrics (mIoU, success AUC, precision AUC):

| Symbol | Description |
|---|---|
| `compute_failure_rate(ious, threshold=0.1)` | Fraction of frames where IoU < threshold (tracker lost) |
| `compute_eao(ious, min_len=10, max_len=100)` | Expected Average Overlap via sliding-window sub-sequence averaging |
| `compute_robustness_metrics(ious)` | Single-call wrapper returning `RobustnessMetrics` |
| `RobustnessMetrics` | Dataclass: `failure_rate`, `robustness`, `eao`, `mean_iou_active`, `threshold` |

All symbols are re-exported from `eovot.metrics`.

## Why it matters

- Energy profiling is one of EOVOT's core differentiators vs academic benchmarks — it was non-functional for every user who passed `--tdp-watts`.
- EAO and robustness score are the primary metrics in the VOT challenge and are required for any paper that claims to evaluate against that benchmark.
- `mean_iou_active` (IoU excluding failed frames) separates tracker accuracy from tracker robustness — a critical distinction for edge deployment where occasional failures may be safety-relevant.

## Example usage

```python
from eovot.metrics.robustness import compute_robustness_metrics
import numpy as np

ious = np.array([0.82, 0.79, 0.05, 0.0, 0.0, 0.74, 0.71])
m = compute_robustness_metrics(ious)
print(m)
# RobustnessMetrics(failure_rate=0.2857, robustness=0.7143, eao=0.5025, mean_iou_active=0.7650, threshold=0.1)

# Energy profiling now works end-to-end
from eovot.benchmark.engine import BenchmarkEngine
engine = BenchmarkEngine(verbose=True, tdp_watts=6.0)   # was NameError before this fix
```

## Files changed

| File | Change |
|---|---|
| `eovot/benchmark/engine.py` | Add missing imports; add `energy` field to `SequenceResult`; pass energy into result; remove 2 duplicate `to_dict()`; expose energy in `summary()` |
| `eovot/metrics/robustness.py` | **New** — VOT robustness metrics module |
| `eovot/metrics/__init__.py` | Re-export new robustness symbols |
| `tests/test_robustness.py` | **New** — 29 unit tests (edge cases, perfect/failed trackers, serialisation) |

## Test results

```
62 passed in 0.73s
```
All existing engine and metrics tests continue to pass unchanged.