### PR TITLE
[feat] Add GOT-10k/VOT extended metrics and fix benchmark engine bugs

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine, center_distance
+from ..profiling.energy import EnergyProfiler, EnergyResult
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
 
@@ -21,6 +22,7 @@ class SequenceResult:
     predictions: Optional[np.ndarray] = None       # shape (N, 4) — predicted boxes
     ground_truths: Optional[np.ndarray] = None     # shape (N, 4) — GT boxes aligned to predictions
     center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
+    energy: Optional[EnergyResult] = None          # per-sequence energy estimate (when TDP set)
 
     @property
     def mean_iou(self) -> float:
@@ -95,67 +97,29 @@ class BenchmarkResult:
         return d
 
     def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
+        """Serialize the full result to a dict compatible with
+        :class:`~eovot.reporting.reporter.BenchmarkReporter`.
 
-        Returns a dict with two keys:
+        Returns a nested dict with keys:
 
         * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
+        * ``"sequences"`` — list of per-sequence metric dicts, each
+          optionally including ``"energy_j"`` and ``"energy_per_frame_mj"``
+          when energy profiling was enabled.
         """
-        sequences = []
-        for sr in self.sequence_results:
+        sequences: list = []
+        for r in self.sequence_results:
             entry: Dict = {
-                "sequence_name": sr.sequence_name,
-                "mean_iou": round(sr.mean_iou, 4),
-                "fps": round(sr.profiling.fps, 2),
-                "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-            }
-            if sr.energy is not None:
-                entry["energy_j"] = round(sr.energy.total_energy_j, 6)
-                entry["energy_per_frame_mj"] = round(sr.energy.energy_per_frame_mj, 4)
-            sequences.append(entry)
-        return {"summary": self.summary(), "sequences": sequences}
-
-    def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        return {
-            "summary": self.summary(),
-            "sequences": [
-                {
-                    "sequence_name": sr.sequence_name,
-                    "mean_iou": round(sr.mean_iou, 4),
-                    "fps": round(sr.profiling.fps, 2),
-                    "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                    "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-                }
-                for sr in self.sequence_results
-            ],
-        }
-
-    def to_dict(self) -> Dict:
-        """Serialize the full result to a dict compatible with :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a nested dict with keys ``"summary"`` (aggregate metrics)
-        and ``"sequences"`` (per-sequence breakdown), suitable for JSON
-        export and Markdown table generation.
-        """
-        sequences = [
-            {
                 "sequence_name": r.sequence_name,
                 "mean_iou": round(r.mean_iou, 4),
                 "fps": round(r.profiling.fps, 2),
                 "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
                 "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
             }
-            for r in self.sequence_results
-        ]
+            if r.energy is not None:
+                entry["energy_j"] = round(r.energy.total_energy_j, 6)
+                entry["energy_per_frame_mj"] = round(r.energy.energy_per_frame_mj, 4)
+            sequences.append(entry)
         return {"summary": self.summary(), "sequences": sequences}
 
     def __str__(self) -> str:
@@ -232,6 +196,10 @@ class BenchmarkEngine:
         if self._energy_profiler is not None:
             self._energy_profiler.reset()
 
+        # Reset tracker state between sequences so each sequence starts fresh.
+        if hasattr(tracker, "reset") and callable(tracker.reset):
+            tracker.reset()
+
         frames = list(seq)
         gt = seq.ground_truth
         preds: List = []
@@ -278,4 +246,5 @@ class BenchmarkEngine:
             predictions=preds_eval,
             ground_truths=gt_eval,
             center_distances=dists,
+            energy=energy,
         )

--- a/eovot/datasets/got10k.py
+++ b/eovot/datasets/got10k.py
@@ -82,7 +82,7 @@ class GOT10kDataset(BaseDataset):
         names = self.list_sequences()
         if idx < 0 or idx >= len(names):
             raise IndexError(f"Sequence index {idx} out of range [0, {len(names)})")
-        return self.load_sequence(names[idx])
+        return self._load_sequence(names[idx])
 
     def list_sequences(self) -> List[str]:
         """Return the list of sequence names for this split.
@@ -161,8 +161,6 @@ class GOT10kDataset(BaseDataset):
     @property
     def name(self) -> str:
         return f"GOT-10k-{self.split}"
-
-        return Sequence(name=seq_name, frame_paths=frame_paths_str, ground_truth=gt_array)
 
     @staticmethod
     def _load_groundtruth(gt_file: Path) -> List[BBox]:

--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -6,5 +6,22 @@ from .accuracy import (
     AccuracyMetrics,
     MetricsEngine,
 )
+from .extended import (
+    success_at_threshold,
+    robustness_rate,
+    eao_score,
+    ExtendedMetrics,
+    ExtendedMetricsEngine,
+)
 
-__all__ = ["iou", "center_distance", "AccuracyMetrics", "MetricsEngine"]
+__all__ = [
+    "iou",
+    "center_distance",
+    "AccuracyMetrics",
+    "MetricsEngine",
+    "success_at_threshold",
+    "robustness_rate",
+    "eao_score",
+    "ExtendedMetrics",
+    "ExtendedMetricsEngine",
+]

--- a/eovot/metrics/extended.py
+++ b/eovot/metrics/extended.py
@@ -1,0 +1,237 @@
+"""Extended tracking metrics aligned with the GOT-10k and VOT evaluation protocols.
+
+Adds metrics beyond the standard OTB success/precision curves:
+
+- :func:`success_at_threshold` — success rate (SR) at a single IoU threshold.
+  GOT-10k reports SR_0.5 and SR_0.75 alongside the mean Average Overlap (AO).
+- :func:`robustness_rate` — fraction of frames where the tracker has not lost
+  the target (IoU ≥ failure_threshold), as used by the VOT challenge.
+- :func:`eao_score` — simplified Expected Average Overlap (EAO), a single
+  scalar that combines accuracy and robustness in one measure.
+- :class:`ExtendedMetrics` — dataclass bundling all scalar summaries.
+- :class:`ExtendedMetricsEngine` — drop-in replacement for
+  :class:`~eovot.metrics.accuracy.MetricsEngine` that computes all metrics
+  in one pass.
+
+References:
+    Kristan et al., "The Seventh Visual Object Tracking VOT2019 Challenge Results."
+    ICCV Workshops, 2019.
+
+    Huang et al., "GOT-10k: A Large High-Diversity Benchmark for Generic
+    Object Tracking in the Wild." IEEE TPAMI, 2021.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+
+from .accuracy import MetricsEngine, AccuracyMetrics
+
+# Re-export the BBox type alias for convenience.
+from .accuracy import BBox  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Standalone metric functions
+# ---------------------------------------------------------------------------
+
+
+def success_at_threshold(ious: np.ndarray, threshold: float) -> float:
+    """Compute the success rate at a single IoU threshold.
+
+    Args:
+        ious: Per-frame IoU values, shape ``(N,)``.
+        threshold: IoU threshold in ``[0, 1]``.  Frames with IoU
+            **strictly greater** than this value count as successes,
+            matching the OTB/GOT-10k convention.
+
+    Returns:
+        Fraction of frames with ``IoU > threshold``, in ``[0, 1]``.
+        Returns ``0.0`` for an empty array.
+    """
+    if len(ious) == 0:
+        return 0.0
+    return float((ious > threshold).mean())
+
+
+def robustness_rate(ious: np.ndarray, failure_threshold: float = 0.1) -> float:
+    """Compute the robustness rate — fraction of non-failure frames.
+
+    A frame is considered a *failure* when the IoU falls below
+    *failure_threshold*.  This metric captures the tracker's long-sequence
+    stability independently of its localisation accuracy.
+
+    Args:
+        ious: Per-frame IoU values, shape ``(N,)``.
+        failure_threshold: IoU value at or above which a frame is considered
+            a *success*.  Default: ``0.1`` (standard VOT failure definition).
+
+    Returns:
+        Fraction of frames with ``IoU ≥ failure_threshold``, in ``[0, 1]``.
+        Returns ``0.0`` for an empty array.
+    """
+    if len(ious) == 0:
+        return 0.0
+    return float((ious >= failure_threshold).mean())
+
+
+def eao_score(
+    ious: np.ndarray,
+    min_len: int = 10,
+    max_len: int = 100,
+) -> float:
+    """Compute a simplified Expected Average Overlap (EAO).
+
+    EAO estimates the average performance of a tracker on sequences of
+    lengths in ``[min_len, max_len]`` by computing the cumulative temporal
+    mean overlap at each frame position and averaging over the evaluation
+    window.
+
+    This approximation replaces the full VOT bootstrapped Monte Carlo
+    estimate with a deterministic temporal profile, making it cheap to
+    compute online and suitable for per-sequence summaries.
+
+    Algorithm:
+
+    1. Build the temporal success profile:
+       ``profile[t] = mean(ious[0 : t+1])`` for ``t = 0 … N-1``.
+    2. Average ``profile[min_len-1 : max_len]`` to get the EAO scalar.
+
+    Args:
+        ious: Per-frame IoU values for the sequence(s), shape ``(N,)``.
+        min_len: Start of the evaluation window (inclusive). Default: ``10``.
+        max_len: End of the evaluation window (inclusive). Default: ``100``.
+
+    Returns:
+        EAO scalar in ``[0, 1]``.  Higher is better.
+        Returns ``0.0`` for an empty array or when the window is invalid.
+
+    References:
+        Kristan et al., "The VOT2015 Challenge Results." ICCV Workshops, 2015.
+    """
+    n = len(ious)
+    if n == 0:
+        return 0.0
+
+    # Clamp window to available frames.
+    actual_max = min(max_len, n)
+    actual_min = min(min_len, actual_max)
+    if actual_min >= actual_max:
+        # Degenerate window — fall back to mean over available frames.
+        return float(ious[:actual_max].mean()) if actual_max > 0 else 0.0
+
+    # Cumulative mean: profile[t] = mean IoU over frames 0 … t.
+    temporal_profile = np.cumsum(ious) / np.arange(1, n + 1)
+    window = temporal_profile[actual_min - 1 : actual_max]
+    return float(window.mean()) if len(window) > 0 else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtendedMetrics:
+    """Scalar accuracy summary including GOT-10k and VOT-style metrics.
+
+    Attributes:
+        mean_iou: Mean IoU (Average Overlap, AO) across all evaluated frames.
+        success_auc: Area under the standard success curve (IoU thresholds 0→1).
+        precision_auc: Normalised AUC of the precision curve (0→50 px).
+        sr_0_5: Success rate at IoU threshold 0.5 (GOT-10k SR₀.₅).
+        sr_0_75: Success rate at IoU threshold 0.75 (GOT-10k SR₀.₇₅).
+        robustness: Fraction of frames with IoU ≥ 0.1 (VOT robustness rate).
+        eao: Simplified Expected Average Overlap over the default window.
+    """
+
+    mean_iou: float
+    success_auc: float
+    precision_auc: float
+    sr_0_5: float
+    sr_0_75: float
+    robustness: float
+    eao: float
+
+    def __str__(self) -> str:
+        return (
+            f"ExtendedMetrics("
+            f"AO={self.mean_iou:.4f}, "
+            f"AUC={self.success_auc:.4f}, "
+            f"SR_0.5={self.sr_0_5:.4f}, "
+            f"SR_0.75={self.sr_0_75:.4f}, "
+            f"robustness={self.robustness:.4f}, "
+            f"EAO={self.eao:.4f})"
+        )
+
+    def to_dict(self) -> Dict[str, float]:
+        """Return a plain dict suitable for JSON serialisation."""
+        return {
+            "mean_iou": round(self.mean_iou, 4),
+            "success_auc": round(self.success_auc, 4),
+            "precision_auc": round(self.precision_auc, 4),
+            "sr_0_5": round(self.sr_0_5, 4),
+            "sr_0_75": round(self.sr_0_75, 4),
+            "robustness": round(self.robustness, 4),
+            "eao": round(self.eao, 4),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class ExtendedMetricsEngine(MetricsEngine):
+    """Metrics engine with GOT-10k and VOT-style extended evaluation.
+
+    Inherits all standard methods from
+    :class:`~eovot.metrics.accuracy.MetricsEngine` (IoU, success curve,
+    precision curve, :meth:`compute_all`) and adds one new method:
+    :meth:`compute_extended`.
+
+    Example::
+
+        engine = ExtendedMetricsEngine()
+        result = engine.compute_extended(preds, gts)
+        print(f"AO={result.mean_iou:.3f}  SR_0.5={result.sr_0_5:.3f}  EAO={result.eao:.3f}")
+    """
+
+    def compute_extended(
+        self,
+        preds: np.ndarray,
+        gts: np.ndarray,
+        failure_threshold: float = 0.1,
+        eao_min_len: int = 10,
+        eao_max_len: int = 100,
+    ) -> ExtendedMetrics:
+        """Compute all extended metrics in a single pass.
+
+        Args:
+            preds: ``(N, 4)`` predicted boxes in ``(x, y, w, h)`` format.
+            gts:   ``(N, 4)`` ground-truth boxes in ``(x, y, w, h)`` format.
+            failure_threshold: IoU below which a frame counts as a failure.
+                Default: ``0.1``.
+            eao_min_len: Minimum sequence length for the EAO evaluation
+                window. Default: ``10``.
+            eao_max_len: Maximum sequence length for the EAO evaluation
+                window. Default: ``100``.
+
+        Returns:
+            :class:`ExtendedMetrics` with all scalar summaries populated.
+        """
+        base: AccuracyMetrics = self.compute_all(preds, gts)
+        ious = self.batch_iou(preds, gts)
+
+        return ExtendedMetrics(
+            mean_iou=base.mean_iou,
+            success_auc=base.success_auc,
+            precision_auc=base.precision_auc,
+            sr_0_5=success_at_threshold(ious, 0.5),
+            sr_0_75=success_at_threshold(ious, 0.75),
+            robustness=robustness_rate(ious, failure_threshold),
+            eao=eao_score(ious, eao_min_len, eao_max_len),
+        )

--- a/tests/test_extended_metrics.py
+++ b/tests/test_extended_metrics.py
@@ -1,0 +1,218 @@
+"""Unit tests for eovot.metrics.extended — GOT-10k and VOT metrics."""
+
+import numpy as np
+import pytest
+
+from eovot.metrics.extended import (
+    ExtendedMetrics,
+    ExtendedMetricsEngine,
+    eao_score,
+    robustness_rate,
+    success_at_threshold,
+)
+
+
+# ---------------------------------------------------------------------------
+# success_at_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessAtThreshold:
+    def test_all_above(self):
+        ious = np.ones(10) * 0.9
+        assert success_at_threshold(ious, 0.5) == pytest.approx(1.0)
+
+    def test_all_below(self):
+        ious = np.ones(10) * 0.3
+        assert success_at_threshold(ious, 0.5) == pytest.approx(0.0)
+
+    def test_half_above(self):
+        ious = np.array([0.6, 0.4, 0.6, 0.4, 0.6, 0.4])
+        assert success_at_threshold(ious, 0.5) == pytest.approx(0.5)
+
+    def test_empty_array(self):
+        assert success_at_threshold(np.array([]), 0.5) == pytest.approx(0.0)
+
+    def test_sr_0_5_vs_sr_0_75(self):
+        ious = np.linspace(0.0, 1.0, 100)
+        sr_05 = success_at_threshold(ious, 0.5)
+        sr_075 = success_at_threshold(ious, 0.75)
+        # SR_0.5 must be >= SR_0.75 since fewer frames exceed the higher threshold.
+        assert sr_05 >= sr_075
+
+    def test_threshold_boundary_strict(self):
+        # IoU exactly equal to threshold should NOT count (strict ">").
+        ious = np.array([0.5, 0.5, 0.5])
+        assert success_at_threshold(ious, 0.5) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# robustness_rate
+# ---------------------------------------------------------------------------
+
+
+class TestRobustnessRate:
+    def test_all_above_threshold(self):
+        ious = np.ones(20) * 0.5
+        assert robustness_rate(ious, failure_threshold=0.1) == pytest.approx(1.0)
+
+    def test_all_below_threshold(self):
+        ious = np.zeros(20)
+        assert robustness_rate(ious, failure_threshold=0.1) == pytest.approx(0.0)
+
+    def test_half_failures(self):
+        # 5 frames above, 5 frames below threshold=0.1
+        ious = np.array([0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0])
+        assert robustness_rate(ious, failure_threshold=0.1) == pytest.approx(0.5)
+
+    def test_boundary_inclusive(self):
+        # IoU exactly equal to failure_threshold should count as success (>=).
+        ious = np.array([0.1, 0.1, 0.1])
+        assert robustness_rate(ious, failure_threshold=0.1) == pytest.approx(1.0)
+
+    def test_empty_array(self):
+        assert robustness_rate(np.array([])) == pytest.approx(0.0)
+
+    def test_custom_threshold(self):
+        ious = np.array([0.4, 0.4, 0.4, 0.2, 0.2])
+        # With threshold=0.3: first 3 succeed (0.4 >= 0.3), last 2 fail
+        assert robustness_rate(ious, failure_threshold=0.3) == pytest.approx(3 / 5)
+
+
+# ---------------------------------------------------------------------------
+# eao_score
+# ---------------------------------------------------------------------------
+
+
+class TestEAOScore:
+    def test_empty_array(self):
+        assert eao_score(np.array([])) == pytest.approx(0.0)
+
+    def test_perfect_tracking(self):
+        ious = np.ones(200)
+        score = eao_score(ious, min_len=10, max_len=100)
+        assert score == pytest.approx(1.0)
+
+    def test_zero_tracking(self):
+        ious = np.zeros(200)
+        score = eao_score(ious, min_len=10, max_len=100)
+        assert score == pytest.approx(0.0)
+
+    def test_range_in_0_1(self):
+        rng = np.random.default_rng(0)
+        ious = rng.uniform(0.0, 1.0, 150)
+        score = eao_score(ious, min_len=10, max_len=100)
+        assert 0.0 <= score <= 1.0
+
+    def test_short_sequence_clamping(self):
+        # Sequence shorter than max_len — should not raise.
+        ious = np.ones(30) * 0.7
+        score = eao_score(ious, min_len=5, max_len=100)
+        assert score == pytest.approx(0.7, abs=1e-4)
+
+    def test_degenerate_window(self):
+        # min_len >= max_len — should return a valid scalar.
+        ious = np.ones(20) * 0.5
+        score = eao_score(ious, min_len=15, max_len=10)
+        assert 0.0 <= score <= 1.0
+
+    def test_monotone_with_better_tracker(self):
+        # A tracker with higher IoU should have a higher EAO.
+        ious_good = np.ones(100) * 0.8
+        ious_bad = np.ones(100) * 0.4
+        assert eao_score(ious_good) > eao_score(ious_bad)
+
+
+# ---------------------------------------------------------------------------
+# ExtendedMetricsEngine
+# ---------------------------------------------------------------------------
+
+
+class TestExtendedMetricsEngine:
+    def setup_method(self):
+        self.engine = ExtendedMetricsEngine()
+
+    def test_perfect_preds_all_ones(self):
+        boxes = np.tile([0.0, 0.0, 10.0, 10.0], (50, 1))
+        result = self.engine.compute_extended(boxes, boxes)
+        assert result.mean_iou == pytest.approx(1.0)
+        assert result.sr_0_5 == pytest.approx(1.0)
+        assert result.sr_0_75 == pytest.approx(1.0)
+        assert result.robustness == pytest.approx(1.0)
+        assert 0.0 <= result.eao <= 1.0
+
+    def test_no_overlap_zero_scores(self):
+        preds = np.tile([0.0, 0.0, 10.0, 10.0], (30, 1))
+        gts = np.tile([50.0, 50.0, 10.0, 10.0], (30, 1))
+        result = self.engine.compute_extended(preds, gts)
+        assert result.mean_iou == pytest.approx(0.0)
+        assert result.sr_0_5 == pytest.approx(0.0)
+        assert result.sr_0_75 == pytest.approx(0.0)
+        assert result.robustness == pytest.approx(0.0)
+        assert result.eao == pytest.approx(0.0)
+
+    def test_sr_ordering(self):
+        # SR_0.5 must be >= SR_0.75 for any input.
+        rng = np.random.default_rng(7)
+        preds = rng.uniform(0, 80, (40, 4))
+        gts = rng.uniform(0, 80, (40, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 2
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 2
+        result = self.engine.compute_extended(preds, gts)
+        assert result.sr_0_5 >= result.sr_0_75
+
+    def test_to_dict_keys(self):
+        boxes = np.tile([5.0, 5.0, 10.0, 10.0], (20, 1))
+        result = self.engine.compute_extended(boxes, boxes)
+        d = result.to_dict()
+        for key in ("mean_iou", "success_auc", "precision_auc",
+                    "sr_0_5", "sr_0_75", "robustness", "eao"):
+            assert key in d, f"Missing key in to_dict(): {key}"
+
+    def test_str_representation(self):
+        boxes = np.tile([0.0, 0.0, 5.0, 5.0], (10, 1))
+        result = self.engine.compute_extended(boxes, boxes)
+        s = str(result)
+        assert "AO=" in s
+        assert "SR_0.5=" in s
+        assert "EAO=" in s
+
+    def test_values_in_range(self):
+        rng = np.random.default_rng(42)
+        preds = rng.uniform(0, 100, (60, 4))
+        gts = rng.uniform(0, 100, (60, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 1
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 1
+        result = self.engine.compute_extended(preds, gts)
+        for field_name, value in result.to_dict().items():
+            assert 0.0 <= value <= 1.0, f"{field_name}={value} out of [0, 1]"
+
+
+# ---------------------------------------------------------------------------
+# ExtendedMetrics dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestExtendedMetricsDataclass:
+    def _make(self, **overrides):
+        defaults = dict(
+            mean_iou=0.5,
+            success_auc=0.45,
+            precision_auc=0.7,
+            sr_0_5=0.6,
+            sr_0_75=0.3,
+            robustness=0.8,
+            eao=0.4,
+        )
+        defaults.update(overrides)
+        return ExtendedMetrics(**defaults)
+
+    def test_to_dict_rounds_to_4dp(self):
+        m = self._make(mean_iou=0.123456789)
+        assert m.to_dict()["mean_iou"] == 0.1235  # rounded to 4 dp
+
+    def test_str_contains_all_fields(self):
+        m = self._make()
+        s = str(m)
+        for tag in ("AO=", "AUC=", "SR_0.5=", "SR_0.75=", "robustness=", "EAO="):
+            assert tag in s


### PR DESCRIPTION
## Summary

This PR adds a new `ExtendedMetricsEngine` with GOT-10k and VOT protocol metrics, and fixes four critical bugs in the benchmark engine and dataset loader.

### What was added

**`eovot/metrics/extended.py`** — new module with:
- `success_at_threshold(ious, threshold)` — SR_0.5 and SR_0.75 (GOT-10k standard)
- `robustness_rate(ious, failure_threshold=0.1)` — fraction of non-failure frames (VOT protocol)
- `eao_score(ious, min_len, max_len)` — simplified Expected Average Overlap (VOT EAO)
- `ExtendedMetrics` dataclass — bundles all scalar summaries, with `to_dict()` for JSON export
- `ExtendedMetricsEngine` — subclasses `MetricsEngine`, adds `compute_extended()` for a single-pass computation of all metrics

**`tests/test_extended_metrics.py`** — 27 unit tests covering edge cases (empty arrays, boundary conditions, ordering invariants, range checks).

### Bug fixes

| File | Bug | Fix |
|------|-----|-----|
| `eovot/benchmark/engine.py` | `EnergyProfiler` and `EnergyResult` used but never imported → `NameError` at runtime | Added missing imports |
| `eovot/benchmark/engine.py` | `SequenceResult` had no `energy` field; `BenchmarkResult.total_energy_j` accessed `.energy` → `AttributeError` | Added `energy: Optional[EnergyResult] = None` to dataclass |
| `eovot/benchmark/engine.py` | `to_dict()` defined three times; only the last (weakest) version was used | Consolidated into one complete implementation with energy support |
| `eovot/benchmark/engine.py` | Tracker state not reset between sequences → first sequence's learned model leaks into later sequences | Added `tracker.reset()` call before each sequence when the method exists |
| `eovot/datasets/got10k.py` | `__getitem__` called `self.load_sequence()` (no such method) → `AttributeError` on any GOT-10k evaluation | Corrected to `self._load_sequence()` |
| `eovot/datasets/got10k.py` | Unreachable dead code after `return` in `name` property | Removed |

### Example usage

```python
from eovot.metrics.extended import ExtendedMetricsEngine
import numpy as np

engine = ExtendedMetricsEngine()
result = engine.compute_extended(preds, gts)
print(f"AO={result.mean_iou:.3f}  SR_0.5={result.sr_0_5:.3f}  SR_0.75={result.sr_0_75:.3f}")
print(f"Robustness={result.robustness:.3f}  EAO={result.eao:.3f}")
print(result.to_dict())  # JSON-ready dict
```

### Why it matters

- **SR_0.5 / SR_0.75** are the primary GOT-10k reporting metrics alongside AO. Without them, results cannot be compared to published GOT-10k baselines.
- **Robustness rate** and **EAO** are the core VOT challenge metrics. Adding them moves EOVOT toward being a multi-protocol benchmark, not just an OTB-style one.
- The engine bugs caused silent incorrect behaviour (wrong energy values, stale tracker state, AttributeError crashes) that would corrupt any real evaluation run.

## Test plan

- [x] All 27 new tests pass: `pytest tests/test_extended_metrics.py -v`
- [x] Full suite passes (158 tests): `pytest tests/ -v --ignore=tests/test_lasot_dataset.py`
- [x] No breaking changes to existing `MetricsEngine`, `BenchmarkEngine`, or `SequenceResult` APIs

https://claude.ai/code/session_017PwnxMmtCGz5Gs4La9kR7F