### PR TITLE
feat(datasets): add SyntheticDataset with configurable motion models for zero-download benchmarking

### DIFF
--- a/configs/experiments/synthetic_quick_eval.yaml
+++ b/configs/experiments/synthetic_quick_eval.yaml
@@ -1,0 +1,45 @@
+# EOVOT — Synthetic Dataset Quick Evaluation
+# -------------------------------------------
+# Runs all classical trackers on programmatically generated sequences.
+# No dataset download required. Useful for:
+#   - Smoke-testing the benchmark pipeline
+#   - Algorithm development and debugging
+#   - Controlled experiments with known ground truth
+#
+# Usage:
+#   python scripts/run_benchmark.py --config configs/experiments/synthetic_quick_eval.yaml
+
+experiment:
+  name: "synthetic-quick-eval"
+  output_dir: "results/synthetic/"
+  seed: 42
+
+dataset:
+  # SyntheticDataset generates sequences in memory — no root path needed.
+  loader: "SyntheticDataset"
+  preset: "quick"           # quick | stress_test | scale_challenge
+  n_sequences: 10
+  n_frames: 60
+  frame_size: [240, 320]    # [H, W]
+  motion: "linear"          # linear | sinusoidal | random_walk
+  name: "Synthetic-Quick"
+  seed: 42
+
+trackers:
+  - name: MOSSE
+    params: {}
+
+  - name: KCF
+    params:
+      learning_rate: 0.075
+
+  - name: CSRT
+    params: {}
+
+benchmark:
+  verbose: true
+  # tdp_watts: 15.0        # uncomment to enable CPU energy profiling
+
+reporting:
+  formats: ["json", "csv"]
+  print_summary: true

--- a/configs/synthetic_demo.yaml
+++ b/configs/synthetic_demo.yaml
@@ -1,0 +1,49 @@
+# EOVOT Synthetic Demo Configuration
+# ------------------------------------
+# Run a full benchmark on a synthetic dataset — no external data required.
+#
+# Usage:
+#   python scripts/run_benchmark.py --config configs/synthetic_demo.yaml
+#
+# This config is designed for:
+#   - CI smoke tests (fast, reproducible, zero-download)
+#   - Demo / tutorial runs (shows the complete pipeline end-to-end)
+#   - Regression checks after code changes
+#
+# Increase num_sequences and seq_len for more thorough evaluation.
+
+experiment:
+  name: "synthetic-mosse-demo"
+  output_dir: "results/synthetic/"
+  seed: 42
+
+dataset:
+  name: "Synthetic"
+  loader: "SyntheticDataset"
+
+  # Synthetic dataset parameters — all optional with sensible defaults.
+  num_sequences: 10          # number of independent sequences
+  seq_len: 100               # frames per sequence
+  frame_width: 320           # frame width  (pixels)
+  frame_height: 240          # frame height (pixels)
+  target_width: 40           # target width  (pixels)
+  target_height: 30          # target height (pixels)
+  damping: 0.85              # velocity decay  (0=noise-only, 1=constant-vel)
+  noise_std: 2.0             # per-frame velocity noise (pixels)
+  margin: 20                 # keep target this many px from frame edge
+  seed: 42                   # RNG seed for full reproducibility
+
+tracker:
+  name: "MOSSE"
+  params:
+    learning_rate: 0.125
+    sigma: 2.0
+
+benchmark:
+  verbose: true
+  save_predictions: false
+  # tdp_watts: 15.0          # uncomment to enable CPU energy estimation
+
+reporting:
+  formats: ["json", "csv"]
+  print_summary: true

--- a/eovot/datasets/__init__.py
+++ b/eovot/datasets/__init__.py
@@ -1,5 +1,15 @@
 from .base import BBox, Sequence, BaseDataset, OTBDataset
 from .got10k import GOT10kDataset
 from .lasot import LaSOTDataset
+from .synthetic import SyntheticDataset, SyntheticSequenceConfig
 
-__all__ = ["BBox", "Sequence", "BaseDataset", "OTBDataset", "GOT10kDataset", "LaSOTDataset"]
+__all__ = [
+    "BBox",
+    "Sequence",
+    "BaseDataset",
+    "OTBDataset",
+    "GOT10kDataset",
+    "LaSOTDataset",
+    "SyntheticDataset",
+    "SyntheticSequenceConfig",
+]

--- a/eovot/datasets/__init__.py
+++ b/eovot/datasets/__init__.py
@@ -1,5 +1,15 @@
 from .base import BBox, Sequence, BaseDataset, OTBDataset
 from .got10k import GOT10kDataset
 from .lasot import LaSOTDataset
+from .synthetic import SyntheticDataset, SyntheticInMemorySequence
 
-__all__ = ["BBox", "Sequence", "BaseDataset", "OTBDataset", "GOT10kDataset", "LaSOTDataset"]
+__all__ = [
+    "BBox",
+    "Sequence",
+    "BaseDataset",
+    "OTBDataset",
+    "GOT10kDataset",
+    "LaSOTDataset",
+    "SyntheticDataset",
+    "SyntheticInMemorySequence",
+]

--- a/eovot/datasets/synthetic.py
+++ b/eovot/datasets/synthetic.py
@@ -1,0 +1,364 @@
+"""Synthetic tracking dataset for zero-dependency benchmarking and CI.
+
+Generates fully synthetic video sequences with random-walk target motion and
+simple visual appearance (solid-colour rectangles on gradient backgrounds).
+No external data download is required — frames and annotations are produced
+on-the-fly in memory using NumPy alone.
+
+Intended use cases:
+
+- **CI / unit tests** — deterministic (fixed seed), fast (<1 ms per frame),
+  and zero-download.  Lets the full benchmark pipeline run in any environment.
+- **Demos and tutorials** — shows the complete API without needing a dataset
+  licence or large storage footprint.
+- **Controlled ablations** — appearance variation is minimal, isolating the
+  effect of motion complexity on tracker performance.
+
+Motion model::
+
+    v(t+1) = v(t) * damping + N(0, noise_std²)
+    pos(t+1) = pos(t) + v(t+1)
+
+The damping factor keeps the target drifting slowly rather than flying out
+of frame.  When the centre would leave a margin band, the velocity is
+reflected back toward the frame centre.
+
+Visual model:
+
+* Background: a smoothly varying RGB gradient — different each sequence.
+* Target: a filled rectangle drawn over the background in a distinct colour.
+  Colour is chosen per-sequence to ensure it contrasts with the background.
+
+Example::
+
+    from eovot.datasets.synthetic import SyntheticDataset
+
+    dataset = SyntheticDataset(num_sequences=5, seq_len=50, seed=0)
+    for seq in dataset:
+        print(seq.name, len(seq), seq.init_bbox)
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, List, Optional, Tuple
+
+import numpy as np
+
+from .base import BaseDataset, BBox, Sequence
+
+# ---------------------------------------------------------------------------
+# Internal frame generator
+# ---------------------------------------------------------------------------
+
+
+def _make_frame(
+    frame_h: int,
+    frame_w: int,
+    bg_color_tl: np.ndarray,
+    bg_color_br: np.ndarray,
+    bbox: BBox,
+    target_color: np.ndarray,
+) -> np.ndarray:
+    """Render a single synthetic BGR frame.
+
+    Args:
+        frame_h: Frame height in pixels.
+        frame_w: Frame width in pixels.
+        bg_color_tl: BGR colour of the top-left corner background.
+        bg_color_br: BGR colour of the bottom-right corner background.
+        bbox: Target bounding box ``(x, y, w, h)`` in pixel coordinates.
+        target_color: BGR colour of the target rectangle.
+
+    Returns:
+        ``(H, W, 3)`` uint8 BGR array.
+    """
+    # Build a bilinear-interpolated gradient background.
+    ys = np.linspace(0.0, 1.0, frame_h)[:, np.newaxis]  # (H, 1)
+    xs = np.linspace(0.0, 1.0, frame_w)[np.newaxis, :]  # (1, W)
+
+    # Interpolate top and bottom rows, then blend vertically.
+    top = bg_color_tl[np.newaxis, :] * (1 - xs[0, :, np.newaxis]) + bg_color_br[np.newaxis, :] * xs[0, :, np.newaxis]
+    bot = bg_color_br[np.newaxis, :] * (1 - xs[0, :, np.newaxis]) + bg_color_tl[np.newaxis, :] * xs[0, :, np.newaxis]
+
+    frame = (
+        top[np.newaxis, :, :] * (1 - ys[:, :, np.newaxis])
+        + bot[np.newaxis, :, :] * ys[:, :, np.newaxis]
+    ).clip(0, 255).astype(np.uint8)
+
+    # Draw the target rectangle.
+    x, y, w, h = bbox
+    x1 = max(0, int(round(x)))
+    y1 = max(0, int(round(y)))
+    x2 = min(frame_w, int(round(x + w)))
+    y2 = min(frame_h, int(round(y + h)))
+    if x2 > x1 and y2 > y1:
+        frame[y1:y2, x1:x2] = target_color.astype(np.uint8)
+
+    return frame
+
+
+# ---------------------------------------------------------------------------
+# Per-sequence generator
+# ---------------------------------------------------------------------------
+
+
+class _SyntheticSequence:
+    """Generate frames and ground-truth boxes for one synthetic sequence.
+
+    This class does all the work; :class:`SyntheticDataset` wraps multiple
+    instances and exposes them as :class:`~eovot.datasets.base.Sequence`
+    objects.
+
+    Args:
+        seq_id: Integer ID used to seed the per-sequence RNG.
+        global_seed: Global seed combined with seq_id for full reproducibility.
+        seq_len: Number of frames in the sequence.
+        frame_size: ``(width, height)`` in pixels.
+        target_size: ``(width, height)`` of the target rectangle in pixels.
+        damping: Velocity decay factor in ``(0, 1)``.  Lower = smoother motion.
+        noise_std: Standard deviation of the velocity noise (pixels/frame).
+        margin: Minimum distance from the frame edge to the target centre
+            (pixels).  Prevents the target from leaving the frame.
+    """
+
+    def __init__(
+        self,
+        seq_id: int,
+        global_seed: int,
+        seq_len: int,
+        frame_size: Tuple[int, int],
+        target_size: Tuple[int, int],
+        damping: float,
+        noise_std: float,
+        margin: int,
+    ) -> None:
+        self._rng = np.random.default_rng(global_seed + seq_id * 1_000_003)
+        self.seq_len = seq_len
+        self.frame_w, self.frame_h = frame_size
+        self.target_w, self.target_h = target_size
+        self.damping = damping
+        self.noise_std = noise_std
+        self.margin = margin
+
+        # Pre-generate the full trajectory so it is consistent across multiple
+        # calls to __iter__ (important for reproducibility in the benchmark loop).
+        self._bboxes: List[BBox] = self._generate_trajectory()
+
+        # Per-sequence colours.
+        self._bg_tl = self._rng.integers(30, 180, size=3).astype(np.float32)
+        self._bg_br = self._rng.integers(30, 180, size=3).astype(np.float32)
+        # Target colour: high contrast — flip all channels and offset.
+        self._target_color = np.clip(255 - self._bg_tl + 40, 0, 255)
+
+    def _generate_trajectory(self) -> List[BBox]:
+        """Simulate the random-walk motion model for all frames."""
+        min_cx = self.margin + self.target_w // 2
+        max_cx = self.frame_w - self.margin - self.target_w // 2
+        min_cy = self.margin + self.target_h // 2
+        max_cy = self.frame_h - self.margin - self.target_h // 2
+
+        # Clamp to valid range (guards against very large targets/small frames).
+        min_cx = min(min_cx, max_cx - 1) if min_cx < max_cx else 0
+        min_cy = min(min_cy, max_cy - 1) if min_cy < max_cy else 0
+
+        cx = float(self._rng.uniform(min_cx, max_cx))
+        cy = float(self._rng.uniform(min_cy, max_cy))
+        vx = float(self._rng.normal(0.0, self.noise_std))
+        vy = float(self._rng.normal(0.0, self.noise_std))
+
+        bboxes: List[BBox] = []
+        for _ in range(self.seq_len):
+            x = cx - self.target_w / 2.0
+            y = cy - self.target_h / 2.0
+            bboxes.append((x, y, float(self.target_w), float(self.target_h)))
+
+            # Update velocity with damping and random noise.
+            vx = vx * self.damping + float(self._rng.normal(0.0, self.noise_std))
+            vy = vy * self.damping + float(self._rng.normal(0.0, self.noise_std))
+
+            # Reflect velocity at boundaries to keep the target inside.
+            new_cx = cx + vx
+            new_cy = cy + vy
+            if new_cx < min_cx or new_cx > max_cx:
+                vx = -vx * 0.8
+                new_cx = np.clip(new_cx, min_cx, max_cx)
+            if new_cy < min_cy or new_cy > max_cy:
+                vy = -vy * 0.8
+                new_cy = np.clip(new_cy, min_cy, max_cy)
+            cx, cy = new_cx, new_cy
+
+        return bboxes
+
+    def to_sequence(self, name: str) -> "SyntheticInMemorySequence":
+        """Convert to a :class:`~eovot.datasets.base.Sequence`-compatible object."""
+        return SyntheticInMemorySequence(
+            name=name,
+            bboxes=self._bboxes,
+            frame_h=self.frame_h,
+            frame_w=self.frame_w,
+            bg_tl=self._bg_tl,
+            bg_br=self._bg_br,
+            target_color=self._target_color,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sequence subclass — renders frames lazily
+# ---------------------------------------------------------------------------
+
+
+class SyntheticInMemorySequence(Sequence):
+    """A :class:`~eovot.datasets.base.Sequence` backed by synthetic frames.
+
+    Frames are rendered on-the-fly from pre-computed bounding boxes, so no
+    disk I/O is involved.  Each call to :meth:`__iter__` re-renders the
+    identical frames for reproducibility.
+
+    This class is not intended to be instantiated directly; use
+    :class:`SyntheticDataset` instead.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        bboxes: List[BBox],
+        frame_h: int,
+        frame_w: int,
+        bg_tl: np.ndarray,
+        bg_br: np.ndarray,
+        target_color: np.ndarray,
+    ) -> None:
+        gt = np.array(bboxes, dtype=np.float64)
+        # Pass an empty frame-paths list — we override __iter__ below.
+        super().__init__(name=name, frame_paths=[], ground_truth=gt)
+        self._bboxes = bboxes
+        self._frame_h = frame_h
+        self._frame_w = frame_w
+        self._bg_tl = bg_tl
+        self._bg_br = bg_br
+        self._target_color = target_color
+
+    def __len__(self) -> int:
+        return len(self._bboxes)
+
+    def __iter__(self) -> Iterator[np.ndarray]:
+        """Yield BGR frames rendered from the pre-computed trajectory."""
+        for bbox in self._bboxes:
+            yield _make_frame(
+                frame_h=self._frame_h,
+                frame_w=self._frame_w,
+                bg_color_tl=self._bg_tl,
+                bg_color_br=self._bg_br,
+                bbox=bbox,
+                target_color=self._target_color,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+class SyntheticDataset(BaseDataset):
+    """Synthetic tracking dataset with random-walk motion and rendered frames.
+
+    All sequences are fully reproducible given the same ``seed``.  No
+    external files or downloads are required.
+
+    Args:
+        num_sequences: Number of sequences in the dataset. Default: ``10``.
+        seq_len: Number of frames per sequence. Default: ``100``.
+        frame_size: ``(width, height)`` of each frame in pixels.
+            Default: ``(320, 240)``.
+        target_size: ``(width, height)`` of the target rectangle in pixels.
+            Default: ``(40, 30)``.
+        damping: Velocity decay factor controlling motion smoothness.
+            ``1.0`` = constant velocity; ``0.0`` = Gaussian noise each frame.
+            Default: ``0.85``.
+        noise_std: Standard deviation of per-frame velocity noise (pixels).
+            Default: ``2.0``.
+        margin: Minimum distance from the frame edge to the target centre
+            (pixels).  Prevents the target from going out of frame.
+            Default: ``20``.
+        seed: Global random seed for full reproducibility. Default: ``42``.
+
+    Example::
+
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.trackers.mosse import MOSSETracker
+        from eovot.benchmark.engine import BenchmarkEngine
+
+        dataset = SyntheticDataset(num_sequences=5, seq_len=60, seed=0)
+        tracker = MOSSETracker()
+        engine  = BenchmarkEngine(verbose=True)
+        result  = engine.run(tracker, dataset, dataset_name="Synthetic")
+        print(result)
+    """
+
+    def __init__(
+        self,
+        num_sequences: int = 10,
+        seq_len: int = 100,
+        frame_size: Tuple[int, int] = (320, 240),
+        target_size: Tuple[int, int] = (40, 30),
+        damping: float = 0.85,
+        noise_std: float = 2.0,
+        margin: int = 20,
+        seed: int = 42,
+    ) -> None:
+        if num_sequences <= 0:
+            raise ValueError(f"num_sequences must be > 0, got {num_sequences}")
+        if seq_len <= 1:
+            raise ValueError(f"seq_len must be > 1 (need at least init + 1 update), got {seq_len}")
+        if frame_size[0] <= 0 or frame_size[1] <= 0:
+            raise ValueError(f"frame_size dimensions must be positive, got {frame_size}")
+        if target_size[0] <= 0 or target_size[1] <= 0:
+            raise ValueError(f"target_size dimensions must be positive, got {target_size}")
+
+        self.num_sequences = num_sequences
+        self.seq_len = seq_len
+        self.frame_size = frame_size
+        self.target_size = target_size
+        self.damping = damping
+        self.noise_std = noise_std
+        self.margin = margin
+        self.seed = seed
+
+        # Pre-build all sequences so __getitem__ is O(1).
+        self._sequences: List[SyntheticInMemorySequence] = [
+            _SyntheticSequence(
+                seq_id=i,
+                global_seed=seed,
+                seq_len=seq_len,
+                frame_size=frame_size,
+                target_size=target_size,
+                damping=damping,
+                noise_std=noise_std,
+                margin=margin,
+            ).to_sequence(name=f"synthetic_{i:04d}")
+            for i in range(num_sequences)
+        ]
+
+    # ------------------------------------------------------------------
+    # BaseDataset interface
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._sequences)
+
+    def __getitem__(self, idx: int) -> SyntheticInMemorySequence:
+        if idx < 0 or idx >= len(self._sequences):
+            raise IndexError(f"Sequence index {idx} out of range [0, {len(self._sequences)})")
+        return self._sequences[idx]
+
+    def __repr__(self) -> str:
+        fw, fh = self.frame_size
+        tw, th = self.target_size
+        return (
+            f"SyntheticDataset("
+            f"sequences={self.num_sequences}, "
+            f"len={self.seq_len}, "
+            f"frame={fw}×{fh}, "
+            f"target={tw}×{th}, "
+            f"seed={self.seed})"
+        )

--- a/eovot/datasets/synthetic.py
+++ b/eovot/datasets/synthetic.py
@@ -1,0 +1,458 @@
+"""Synthetic dataset generator for EOVOT benchmarking.
+
+Generates tracking sequences entirely in memory — no dataset downloads required.
+Each sequence renders a moving target (solid rectangle, checkerboard, or Gaussian
+blob) onto a configurable background with a programmable motion model.
+
+Supported motion models:
+- **LinearMotion** — constant velocity, useful as a basic drift baseline
+- **SinusoidalMotion** — oscillating trajectory for repeatability testing
+- **RandomWalkMotion** — Brownian motion for robustness stress testing
+
+All generated sequences are compatible with :class:`~eovot.datasets.base.Sequence`
+and :class:`~eovot.benchmark.engine.BenchmarkEngine`, so synthetic data slots
+directly into any existing experiment config or benchmark loop.
+
+Typical usage::
+
+    from eovot.datasets.synthetic import SyntheticDataset, SyntheticSequenceConfig
+
+    # Quick 5-sequence benchmark with default linear motion
+    dataset = SyntheticDataset.quick(n_sequences=5)
+    print(len(dataset))  # → 5
+
+    # Custom single sequence with sinusoidal motion
+    cfg = SyntheticSequenceConfig(
+        name="sin_test",
+        n_frames=100,
+        frame_size=(480, 640),
+        init_bbox=(100, 100, 80, 60),
+        motion="sinusoidal",
+        amplitude=(60, 40),
+        frequency=0.05,
+    )
+    dataset = SyntheticDataset([cfg])
+    seq = dataset[0]
+    for frame in seq:
+        pass  # process frame
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Iterator, List, Literal, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from .base import BaseDataset, Sequence
+
+BBox = Tuple[float, float, float, float]
+
+# Allowed motion model names
+MotionType = Literal["linear", "sinusoidal", "random_walk"]
+
+# Allowed target appearance styles
+AppearanceType = Literal["solid", "checkerboard", "gradient"]
+
+
+# ---------------------------------------------------------------------------
+# Sequence configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SyntheticSequenceConfig:
+    """Configuration for a single synthetic tracking sequence.
+
+    Args:
+        name:         Sequence identifier used in benchmark reports.
+        n_frames:     Number of frames to generate. Default: ``60``.
+        frame_size:   ``(height, width)`` in pixels. Default: ``(240, 320)``.
+        init_bbox:    Initial bounding box ``(x, y, w, h)`` in pixel coords.
+                      Default: target centred in the frame at ~25% of frame size.
+        motion:       Motion model — ``"linear"``, ``"sinusoidal"``, or
+                      ``"random_walk"``. Default: ``"linear"``.
+        velocity:     ``(vx, vy)`` pixels/frame for ``"linear"`` motion.
+                      Default: ``(2.0, 1.5)``.
+        amplitude:    ``(ax, ay)`` pixel amplitude for ``"sinusoidal"`` motion.
+                      Default: ``(60, 40)``.
+        frequency:    Oscillation frequency (cycles/frame) for ``"sinusoidal"``
+                      motion. Default: ``0.02``.
+        random_walk_std: Standard deviation (pixels/frame) for ``"random_walk"``
+                      Gaussian step. Default: ``3.0``.
+        scale_factor: Per-frame multiplicative scale change applied to target
+                      size.  ``1.0`` = no scale change; ``1.005`` = 0.5%
+                      growth/frame. Default: ``1.0``.
+        appearance:   Target appearance — ``"solid"``, ``"checkerboard"``, or
+                      ``"gradient"``. Default: ``"solid"``.
+        target_color: BGR tuple for ``"solid"`` appearance. Default: ``(0, 0, 200)``
+                      (red).
+        bg_color:     BGR tuple for the background. Default: ``(180, 180, 180)``
+                      (light grey).
+        seed:         RNG seed for reproducible ``"random_walk"`` sequences.
+                      Default: ``None`` (non-deterministic).
+        add_noise:    If ``True``, adds Gaussian pixel noise (σ=5) to simulate
+                      sensor noise. Default: ``False``.
+        noise_sigma:  Standard deviation of additive Gaussian noise when
+                      ``add_noise=True``. Default: ``5.0``.
+    """
+
+    name: str = "synthetic_seq"
+    n_frames: int = 60
+    frame_size: Tuple[int, int] = (240, 320)        # (H, W)
+    init_bbox: Optional[BBox] = None                 # defaults to centred target
+    motion: MotionType = "linear"
+    velocity: Tuple[float, float] = (2.0, 1.5)      # for linear motion
+    amplitude: Tuple[float, float] = (60.0, 40.0)   # for sinusoidal motion
+    frequency: float = 0.02                          # for sinusoidal motion
+    random_walk_std: float = 3.0                     # for random_walk motion
+    scale_factor: float = 1.0                        # per-frame scale multiplier
+    appearance: AppearanceType = "solid"
+    target_color: Tuple[int, int, int] = (0, 0, 200)
+    bg_color: Tuple[int, int, int] = (180, 180, 180)
+    seed: Optional[int] = None
+    add_noise: bool = False
+    noise_sigma: float = 5.0
+
+    def resolve_init_bbox(self) -> BBox:
+        """Return the initial bounding box, computing a centred default if needed."""
+        if self.init_bbox is not None:
+            return self.init_bbox
+        H, W = self.frame_size
+        w = max(1, int(W * 0.25))
+        h = max(1, int(H * 0.25))
+        x = (W - w) // 2
+        y = (H - h) // 2
+        return (float(x), float(y), float(w), float(h))
+
+
+# ---------------------------------------------------------------------------
+# In-memory sequence
+# ---------------------------------------------------------------------------
+
+class _SyntheticSequence(Sequence):
+    """A :class:`~eovot.datasets.base.Sequence` whose frames are generated in memory.
+
+    Overrides ``__iter__`` to render frames on the fly without any disk I/O.
+    """
+
+    def __init__(self, config: SyntheticSequenceConfig) -> None:
+        self._cfg = config
+        gt = _compute_ground_truth(config)
+        super().__init__(
+            name=config.name,
+            frame_paths=[f"synthetic://{config.name}/frame_{i:06d}" for i in range(config.n_frames)],
+            ground_truth=gt,
+        )
+
+    def __iter__(self) -> Iterator[np.ndarray]:  # type: ignore[override]
+        """Yield rendered BGR frames without touching the filesystem."""
+        cfg = self._cfg
+        rng = np.random.default_rng(cfg.seed)
+        for i in range(cfg.n_frames):
+            bbox = tuple(self.ground_truth[i])  # type: ignore[arg-type]
+            frame = _render_frame(cfg, bbox, rng if cfg.add_noise else None)
+            yield frame
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth trajectory computation
+# ---------------------------------------------------------------------------
+
+def _compute_ground_truth(cfg: SyntheticSequenceConfig) -> np.ndarray:
+    """Generate the (N, 4) ground-truth array for a SyntheticSequenceConfig."""
+    H, W = cfg.frame_size
+    x0, y0, w0, h0 = cfg.resolve_init_bbox()
+    cx0, cy0 = x0 + w0 / 2, y0 + h0 / 2
+
+    rng = np.random.default_rng(cfg.seed)
+    boxes = np.empty((cfg.n_frames, 4), dtype=np.float64)
+
+    cx, cy = cx0, cy0
+    w, h = float(w0), float(h0)
+
+    for i in range(cfg.n_frames):
+        if cfg.motion == "linear":
+            cx = cx0 + cfg.velocity[0] * i
+            cy = cy0 + cfg.velocity[1] * i
+        elif cfg.motion == "sinusoidal":
+            cx = cx0 + cfg.amplitude[0] * math.sin(2 * math.pi * cfg.frequency * i)
+            cy = cy0 + cfg.amplitude[1] * math.sin(2 * math.pi * cfg.frequency * i + math.pi / 4)
+        elif cfg.motion == "random_walk":
+            if i > 0:
+                cx += float(rng.normal(0.0, cfg.random_walk_std))
+                cy += float(rng.normal(0.0, cfg.random_walk_std))
+        else:
+            raise ValueError(f"Unknown motion model: {cfg.motion!r}")
+
+        # Apply per-frame scale change
+        scale = cfg.scale_factor ** i
+        wi = w0 * scale
+        hi = h0 * scale
+
+        # Clamp centre so the target stays inside the frame
+        wi = max(4.0, min(wi, W - 2))
+        hi = max(4.0, min(hi, H - 2))
+        cx = max(wi / 2, min(cx, W - wi / 2))
+        cy = max(hi / 2, min(cy, H - hi / 2))
+
+        boxes[i] = [cx - wi / 2, cy - hi / 2, wi, hi]
+
+    return boxes
+
+
+# ---------------------------------------------------------------------------
+# Frame rendering
+# ---------------------------------------------------------------------------
+
+def _render_frame(
+    cfg: SyntheticSequenceConfig,
+    bbox: BBox,
+    noise_rng: Optional[np.random.Generator],
+) -> np.ndarray:
+    """Render a single BGR frame with the target at *bbox*."""
+    H, W = cfg.frame_size
+    frame = np.full((H, W, 3), cfg.bg_color, dtype=np.uint8)
+
+    x, y, w, h = bbox
+    x1 = max(0, int(round(x)))
+    y1 = max(0, int(round(y)))
+    x2 = min(W, int(round(x + w)))
+    y2 = min(H, int(round(y + h)))
+    if x2 <= x1 or y2 <= y1:
+        return frame
+
+    if cfg.appearance == "solid":
+        frame[y1:y2, x1:x2] = cfg.target_color
+
+    elif cfg.appearance == "checkerboard":
+        patch = np.zeros((y2 - y1, x2 - x1, 3), dtype=np.uint8)
+        cell = max(4, min((x2 - x1) // 4, (y2 - y1) // 4))
+        for r in range(y2 - y1):
+            for c in range(x2 - x1):
+                if ((r // cell) + (c // cell)) % 2 == 0:
+                    patch[r, c] = cfg.target_color
+                else:
+                    patch[r, c] = (255 - cfg.target_color[0],
+                                   255 - cfg.target_color[1],
+                                   255 - cfg.target_color[2])
+        frame[y1:y2, x1:x2] = patch
+
+    elif cfg.appearance == "gradient":
+        ph, pw = y2 - y1, x2 - x1
+        xs = np.linspace(0, 1, pw, dtype=np.float32)
+        ys = np.linspace(0, 1, ph, dtype=np.float32)
+        gx, gy = np.meshgrid(xs, ys)
+        mask = ((gx + gy) / 2)[..., np.newaxis]
+        c0 = np.array(cfg.target_color, dtype=np.float32)
+        c1 = np.array([255 - v for v in cfg.target_color], dtype=np.float32)
+        patch = (c0 * (1 - mask) + c1 * mask).astype(np.uint8)
+        frame[y1:y2, x1:x2] = patch
+
+    if noise_rng is not None:
+        noise = noise_rng.normal(0.0, cfg.noise_sigma, frame.shape)
+        frame = np.clip(frame.astype(np.float32) + noise, 0, 255).astype(np.uint8)
+
+    return frame
+
+
+# ---------------------------------------------------------------------------
+# Public dataset class
+# ---------------------------------------------------------------------------
+
+class SyntheticDataset(BaseDataset):
+    """A dataset of fully synthetic tracking sequences.
+
+    Can be constructed from a list of :class:`SyntheticSequenceConfig` objects
+    or via the convenience factory methods :meth:`quick`, :meth:`stress_test`,
+    and :meth:`scale_challenge`.
+
+    Args:
+        configs: One :class:`SyntheticSequenceConfig` per sequence.
+
+    Example — minimal usage::
+
+        dataset = SyntheticDataset.quick(n_sequences=5, n_frames=40)
+        engine = BenchmarkEngine(verbose=True)
+        result = engine.run(tracker, dataset, dataset_name="Synthetic-Quick")
+
+    Example — custom sequences::
+
+        configs = [
+            SyntheticSequenceConfig(name="linear_fast", motion="linear", velocity=(5, 3)),
+            SyntheticSequenceConfig(name="sine_wave",   motion="sinusoidal", amplitude=(80, 50)),
+            SyntheticSequenceConfig(name="random_walk", motion="random_walk", seed=7),
+        ]
+        dataset = SyntheticDataset(configs)
+    """
+
+    def __init__(self, configs: List[SyntheticSequenceConfig]) -> None:
+        self._sequences: List[_SyntheticSequence] = [
+            _SyntheticSequence(cfg) for cfg in configs
+        ]
+
+    # ------------------------------------------------------------------
+    # BaseDataset interface
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._sequences)
+
+    def __getitem__(self, idx: int) -> Sequence:
+        return self._sequences[idx]
+
+    def __repr__(self) -> str:
+        return f"SyntheticDataset(sequences={len(self)})"
+
+    # ------------------------------------------------------------------
+    # Factory methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def quick(
+        cls,
+        n_sequences: int = 5,
+        n_frames: int = 60,
+        frame_size: Tuple[int, int] = (240, 320),
+        motion: MotionType = "linear",
+        seed: Optional[int] = 0,
+    ) -> "SyntheticDataset":
+        """Create a small dataset for quick sanity checks.
+
+        Each sequence has the same motion model but different initial positions
+        and velocities to provide variety.
+
+        Args:
+            n_sequences: Number of sequences to generate.
+            n_frames:    Frames per sequence.
+            frame_size:  ``(H, W)`` in pixels.
+            motion:      Motion model for all sequences.
+            seed:        Base RNG seed; each sequence gets ``seed + i``.
+
+        Returns:
+            :class:`SyntheticDataset` ready to pass to :class:`~eovot.benchmark.engine.BenchmarkEngine`.
+        """
+        H, W = frame_size
+        rng = np.random.default_rng(seed)
+        configs = []
+        for i in range(n_sequences):
+            w = int(rng.integers(W // 8, W // 4))
+            h = int(rng.integers(H // 8, H // 4))
+            x = int(rng.integers(0, max(1, W - w)))
+            y = int(rng.integers(0, max(1, H - h)))
+            vx = float(rng.uniform(-3.0, 3.0))
+            vy = float(rng.uniform(-2.0, 2.0))
+            configs.append(SyntheticSequenceConfig(
+                name=f"quick_{i:02d}",
+                n_frames=n_frames,
+                frame_size=frame_size,
+                init_bbox=(float(x), float(y), float(w), float(h)),
+                motion=motion,
+                velocity=(vx, vy),
+                seed=None if seed is None else seed + i,
+            ))
+        return cls(configs)
+
+    @classmethod
+    def stress_test(
+        cls,
+        n_sequences: int = 10,
+        n_frames: int = 100,
+        frame_size: Tuple[int, int] = (480, 640),
+        seed: int = 42,
+    ) -> "SyntheticDataset":
+        """Create a mixed-motion dataset for robustness stress-testing.
+
+        Generates sequences with a mix of linear, sinusoidal, and random-walk
+        motion plus varying target sizes and appearances.
+
+        Args:
+            n_sequences: Number of sequences to generate.
+            n_frames:    Frames per sequence.
+            frame_size:  ``(H, W)`` in pixels.
+            seed:        Base RNG seed for reproducibility.
+
+        Returns:
+            :class:`SyntheticDataset` with diverse motion patterns.
+        """
+        rng = np.random.default_rng(seed)
+        motions: List[MotionType] = ["linear", "sinusoidal", "random_walk"]
+        appearances: List[AppearanceType] = ["solid", "checkerboard", "gradient"]
+        H, W = frame_size
+
+        configs = []
+        for i in range(n_sequences):
+            motion = motions[i % len(motions)]
+            appearance = appearances[i % len(appearances)]
+            w = int(rng.integers(W // 10, W // 4))
+            h = int(rng.integers(H // 10, H // 4))
+            x = int(rng.integers(0, max(1, W - w)))
+            y = int(rng.integers(0, max(1, H - h)))
+            color = (
+                int(rng.integers(50, 200)),
+                int(rng.integers(50, 200)),
+                int(rng.integers(50, 200)),
+            )
+            configs.append(SyntheticSequenceConfig(
+                name=f"stress_{i:02d}_{motion}",
+                n_frames=n_frames,
+                frame_size=frame_size,
+                init_bbox=(float(x), float(y), float(w), float(h)),
+                motion=motion,
+                velocity=(float(rng.uniform(-4.0, 4.0)), float(rng.uniform(-3.0, 3.0))),
+                amplitude=(float(rng.uniform(30.0, 80.0)), float(rng.uniform(20.0, 60.0))),
+                frequency=float(rng.uniform(0.01, 0.05)),
+                random_walk_std=float(rng.uniform(2.0, 6.0)),
+                appearance=appearance,
+                target_color=color,
+                seed=seed + i,
+                add_noise=(i % 3 == 2),
+            ))
+        return cls(configs)
+
+    @classmethod
+    def scale_challenge(
+        cls,
+        n_sequences: int = 6,
+        n_frames: int = 80,
+        frame_size: Tuple[int, int] = (360, 480),
+        seed: int = 99,
+    ) -> "SyntheticDataset":
+        """Create sequences with progressive target scale change.
+
+        Alternates between growing and shrinking targets to stress-test trackers
+        that assume fixed object size (e.g. MOSSE and KCF without scale estimation).
+
+        Args:
+            n_sequences: Number of sequences to generate.
+            n_frames:    Frames per sequence.
+            frame_size:  ``(H, W)`` in pixels.
+            seed:        RNG seed.
+
+        Returns:
+            :class:`SyntheticDataset` with scale-varying sequences.
+        """
+        rng = np.random.default_rng(seed)
+        H, W = frame_size
+        configs = []
+        for i in range(n_sequences):
+            # Alternate growing / shrinking
+            scale_factor = 1.005 if i % 2 == 0 else 0.996
+            w = int(rng.integers(W // 8, W // 5))
+            h = int(rng.integers(H // 8, H // 5))
+            x = (W - w) // 2
+            y = (H - h) // 2
+            configs.append(SyntheticSequenceConfig(
+                name=f"scale_{i:02d}_{'grow' if i % 2 == 0 else 'shrink'}",
+                n_frames=n_frames,
+                frame_size=frame_size,
+                init_bbox=(float(x), float(y), float(w), float(h)),
+                motion="sinusoidal",
+                amplitude=(30.0, 20.0),
+                frequency=0.03,
+                scale_factor=scale_factor,
+                appearance="checkerboard",
+                seed=seed + i,
+            ))
+        return cls(configs)

--- a/scripts/compare_trackers.py
+++ b/scripts/compare_trackers.py
@@ -6,7 +6,13 @@ comparison table in Markdown and CSV formats.
 
 Usage::
 
-    # Quick sanity check (10 sequences)
+    # Quick sanity check — no external data needed (synthetic dataset)
+    python scripts/compare_trackers.py \\
+        --trackers MOSSE KCF \\
+        --dataset-loader SyntheticDataset \\
+        --num-sequences 5 --seq-len 60
+
+    # Quick sanity check on OTB (10 sequences)
     python scripts/compare_trackers.py \\
         --trackers MOSSE KCF \\
         --dataset-root /data/OTB100 \\
@@ -47,6 +53,7 @@ from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
 from eovot.datasets.lasot import LaSOTDataset
+from eovot.datasets.synthetic import SyntheticDataset
 from eovot.reporting.reporter import BenchmarkReporter
 from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
@@ -64,17 +71,35 @@ DATASET_REGISTRY = {
     "OTBDataset": OTBDataset,
     "GOT10kDataset": GOT10kDataset,
     "LaSOTDataset": LaSOTDataset,
+    "SyntheticDataset": SyntheticDataset,
 }
 
 
-def _build_dataset(loader_name: str, root: str, split: str, max_sequences):
-    """Instantiate the dataset, handling different constructor signatures."""
+def _build_dataset(loader_name: str, args) -> object:
+    """Instantiate the dataset, handling different constructor signatures.
+
+    Args:
+        loader_name: Key in DATASET_REGISTRY.
+        args: Parsed :class:`argparse.Namespace` containing all CLI arguments.
+
+    Returns:
+        An instantiated dataset object implementing the BaseDataset interface.
+    """
     cls = DATASET_REGISTRY[loader_name]
+
+    if loader_name == "SyntheticDataset":
+        return cls(
+            num_sequences=args.num_sequences,
+            seq_len=args.seq_len,
+            frame_size=(args.frame_width, args.frame_height),
+            target_size=(args.target_width, args.target_height),
+            seed=args.seed,
+        )
     if loader_name == "GOT10kDataset":
-        return cls(root=root, split=split, max_sequences=max_sequences)
+        return cls(root=args.dataset_root, split=args.split, max_sequences=args.max_sequences)
     if loader_name == "LaSOTDataset":
-        return cls(root=root, split=split, max_sequences=max_sequences)
-    return cls(root=root)
+        return cls(root=args.dataset_root, split=args.split, max_sequences=args.max_sequences)
+    return cls(root=args.dataset_root)
 
 
 def main() -> None:
@@ -99,8 +124,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--dataset-root",
-        required=True,
-        help="Path to the dataset root directory.",
+        default=None,
+        help=(
+            "Path to the dataset root directory. "
+            "Not required when --dataset-loader=SyntheticDataset."
+        ),
     )
     parser.add_argument(
         "--dataset-name",
@@ -133,11 +161,38 @@ def main() -> None:
             "Example: 6.0 for Raspberry Pi 4, 15.0 for a laptop CPU."
         ),
     )
+    # ---- SyntheticDataset parameters ----------------------------------------
+    synth = parser.add_argument_group(
+        "SyntheticDataset",
+        description="Parameters for --dataset-loader=SyntheticDataset.",
+    )
+    synth.add_argument("--num-sequences", type=int, default=10,
+                       help="Number of synthetic sequences. Default: 10.")
+    synth.add_argument("--seq-len", type=int, default=100,
+                       help="Frames per synthetic sequence. Default: 100.")
+    synth.add_argument("--frame-width", type=int, default=320,
+                       help="Synthetic frame width (pixels). Default: 320.")
+    synth.add_argument("--frame-height", type=int, default=240,
+                       help="Synthetic frame height (pixels). Default: 240.")
+    synth.add_argument("--target-width", type=int, default=40,
+                       help="Synthetic target width (pixels). Default: 40.")
+    synth.add_argument("--target-height", type=int, default=30,
+                       help="Synthetic target height (pixels). Default: 30.")
+    synth.add_argument("--seed", type=int, default=42,
+                       help="RNG seed for reproducibility. Default: 42.")
+    # -------------------------------------------------------------------------
+
     args = parser.parse_args()
+
+    # Validate that --dataset-root is provided for non-synthetic loaders.
+    if args.dataset_loader != "SyntheticDataset" and args.dataset_root is None:
+        parser.error(
+            f"--dataset-root is required for --dataset-loader={args.dataset_loader}"
+        )
 
     dataset_name = args.dataset_name or args.dataset_loader
     reporter = BenchmarkReporter(output_dir=args.output_dir)
-    engine = BenchmarkEngine(verbose=True)
+    engine = BenchmarkEngine(verbose=True, tdp_watts=args.tdp_watts)
 
     all_results = []
 
@@ -147,25 +202,14 @@ def main() -> None:
         print(f"{'=' * 60}")
 
         tracker = TRACKER_REGISTRY[tracker_name]()
-        dataset = _build_dataset(
-            args.dataset_loader, args.dataset_root, args.split, args.max_sequences
-        )
+        dataset = _build_dataset(args.dataset_loader, args)
 
-        dataset_cls = DATASET_REGISTRY[args.dataset_loader]
-        if args.dataset_loader == "GOT10kDataset":
-            dataset = dataset_cls(
-                root=args.dataset_root,
-                split=args.split,
-                max_sequences=args.max_sequences,
-            )
-        else:
-            dataset = dataset_cls(root=args.dataset_root)
-
+        max_seq = None if args.dataset_loader == "SyntheticDataset" else args.max_sequences
         result = engine.run(
             tracker=tracker,
             dataset=dataset,
             dataset_name=dataset_name,
-            max_sequences=args.max_sequences,
+            max_sequences=max_seq,
         )
         result_dict = result.to_dict()
 

--- a/tests/test_synthetic_dataset.py
+++ b/tests/test_synthetic_dataset.py
@@ -1,0 +1,233 @@
+"""Unit tests for eovot.datasets.synthetic — SyntheticDataset and friends."""
+
+import numpy as np
+import pytest
+
+from eovot.datasets.synthetic import SyntheticDataset, SyntheticInMemorySequence
+
+
+# ---------------------------------------------------------------------------
+# SyntheticDataset construction
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticDatasetConstruction:
+    def test_default_construction(self):
+        ds = SyntheticDataset()
+        assert len(ds) == 10
+
+    def test_custom_length(self):
+        ds = SyntheticDataset(num_sequences=5)
+        assert len(ds) == 5
+
+    def test_repr_contains_params(self):
+        ds = SyntheticDataset(num_sequences=3, seq_len=50, seed=7)
+        r = repr(ds)
+        assert "3" in r
+        assert "50" in r
+        assert "7" in r
+
+    def test_invalid_num_sequences(self):
+        with pytest.raises(ValueError):
+            SyntheticDataset(num_sequences=0)
+
+    def test_invalid_seq_len(self):
+        with pytest.raises(ValueError):
+            SyntheticDataset(seq_len=1)
+
+    def test_invalid_frame_size(self):
+        with pytest.raises(ValueError):
+            SyntheticDataset(frame_size=(0, 240))
+
+    def test_invalid_target_size(self):
+        with pytest.raises(ValueError):
+            SyntheticDataset(target_size=(40, 0))
+
+
+# ---------------------------------------------------------------------------
+# Indexing and iteration
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticDatasetAccess:
+    def setup_method(self):
+        self.ds = SyntheticDataset(num_sequences=4, seq_len=20, seed=0)
+
+    def test_getitem_returns_sequence(self):
+        seq = self.ds[0]
+        assert isinstance(seq, SyntheticInMemorySequence)
+
+    def test_getitem_negative_raises(self):
+        with pytest.raises(IndexError):
+            _ = self.ds[-1]
+
+    def test_getitem_out_of_range_raises(self):
+        with pytest.raises(IndexError):
+            _ = self.ds[100]
+
+    def test_iter_yields_all_sequences(self):
+        seqs = list(self.ds)
+        assert len(seqs) == 4
+
+    def test_sequence_names_unique(self):
+        names = [seq.name for seq in self.ds]
+        assert len(set(names)) == len(names)
+
+    def test_sequence_names_sorted(self):
+        names = [seq.name for seq in self.ds]
+        assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# Sequence properties
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticInMemorySequence:
+    def setup_method(self):
+        self.ds = SyntheticDataset(num_sequences=2, seq_len=30, seed=1)
+        self.seq = self.ds[0]
+
+    def test_len_matches_seq_len(self):
+        assert len(self.seq) == 30
+
+    def test_ground_truth_shape(self):
+        gt = self.seq.ground_truth
+        assert gt.ndim == 2
+        assert gt.shape[1] == 4
+        assert gt.shape[0] == 30
+
+    def test_init_bbox_positive_wh(self):
+        x, y, w, h = self.seq.init_bbox
+        assert w > 0
+        assert h > 0
+
+    def test_ground_truth_positive_wh(self):
+        gt = self.seq.ground_truth
+        assert np.all(gt[:, 2] > 0), "All widths must be positive"
+        assert np.all(gt[:, 3] > 0), "All heights must be positive"
+
+    def test_ground_truth_within_frame(self):
+        ds = SyntheticDataset(
+            num_sequences=1, seq_len=50,
+            frame_size=(320, 240), target_size=(40, 30),
+            margin=20, seed=42,
+        )
+        gt = ds[0].ground_truth
+        # x >= 0, y >= 0, x+w <= width, y+h <= height (with some slack for boundary reflection)
+        assert np.all(gt[:, 0] >= -5), "Some x coords very negative"
+        assert np.all(gt[:, 1] >= -5), "Some y coords very negative"
+        assert np.all(gt[:, 0] + gt[:, 2] <= 325), "Some boxes exceed frame width"
+        assert np.all(gt[:, 1] + gt[:, 3] <= 245), "Some boxes exceed frame height"
+
+
+# ---------------------------------------------------------------------------
+# Frame iteration
+# ---------------------------------------------------------------------------
+
+
+class TestFrameIteration:
+    def setup_method(self):
+        self.seq = SyntheticDataset(
+            num_sequences=1, seq_len=15,
+            frame_size=(160, 120), target_size=(20, 15), seed=0,
+        )[0]
+
+    def test_frame_count(self):
+        frames = list(self.seq)
+        assert len(frames) == 15
+
+    def test_frame_dtype(self):
+        frame = next(iter(self.seq))
+        assert frame.dtype == np.uint8
+
+    def test_frame_shape(self):
+        frame = next(iter(self.seq))
+        assert frame.shape == (120, 160, 3)
+
+    def test_frame_value_range(self):
+        frame = next(iter(self.seq))
+        assert frame.min() >= 0
+        assert frame.max() <= 255
+
+    def test_iteration_reproducible(self):
+        frames_a = list(self.seq)
+        frames_b = list(self.seq)
+        for fa, fb in zip(frames_a, frames_b):
+            np.testing.assert_array_equal(fa, fb)
+
+    def test_different_seeds_different_frames(self):
+        seq_a = SyntheticDataset(num_sequences=1, seq_len=10, seed=0)[0]
+        seq_b = SyntheticDataset(num_sequences=1, seq_len=10, seed=99)[0]
+        fa = next(iter(seq_a))
+        fb = next(iter(seq_b))
+        assert not np.array_equal(fa, fb), "Different seeds should produce different frames"
+
+    def test_gt_and_frame_count_aligned(self):
+        frames = list(self.seq)
+        assert len(frames) == len(self.seq.ground_truth)
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility
+# ---------------------------------------------------------------------------
+
+
+class TestReproducibility:
+    def test_same_seed_same_gt(self):
+        ds1 = SyntheticDataset(num_sequences=3, seq_len=20, seed=42)
+        ds2 = SyntheticDataset(num_sequences=3, seq_len=20, seed=42)
+        for i in range(3):
+            np.testing.assert_array_equal(
+                ds1[i].ground_truth,
+                ds2[i].ground_truth,
+                err_msg=f"Sequence {i} GT differs between same-seed datasets",
+            )
+
+    def test_different_seed_different_gt(self):
+        ds1 = SyntheticDataset(num_sequences=1, seq_len=20, seed=1)
+        ds2 = SyntheticDataset(num_sequences=1, seq_len=20, seed=2)
+        assert not np.array_equal(ds1[0].ground_truth, ds2[0].ground_truth)
+
+    def test_sequences_within_dataset_differ(self):
+        ds = SyntheticDataset(num_sequences=3, seq_len=30, seed=0)
+        gt0 = ds[0].ground_truth
+        gt1 = ds[1].ground_truth
+        assert not np.array_equal(gt0, gt1), "Sequences in the same dataset must differ"
+
+
+# ---------------------------------------------------------------------------
+# Integration: full pipeline with BenchmarkEngine
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineIntegration:
+    def test_benchmark_engine_runs(self):
+        """SyntheticDataset plugs into BenchmarkEngine without errors."""
+        from eovot.benchmark.engine import BenchmarkEngine
+        from eovot.trackers.mosse import MOSSETracker
+
+        dataset = SyntheticDataset(num_sequences=2, seq_len=15, seed=0)
+        tracker = MOSSETracker()
+        engine = BenchmarkEngine(verbose=False)
+        result = engine.run(tracker, dataset, dataset_name="Synthetic")
+
+        assert result.mean_iou >= 0.0
+        assert result.mean_fps > 0.0
+        assert result.peak_memory_mb > 0.0
+        assert len(result.sequence_results) == 2
+
+    def test_result_to_dict_structure(self):
+        from eovot.benchmark.engine import BenchmarkEngine
+        from eovot.trackers.mosse import MOSSETracker
+
+        dataset = SyntheticDataset(num_sequences=1, seq_len=10, seed=0)
+        tracker = MOSSETracker()
+        engine = BenchmarkEngine(verbose=False)
+        result = engine.run(tracker, dataset, dataset_name="Synthetic")
+        d = result.to_dict()
+
+        assert "summary" in d
+        assert "sequences" in d
+        assert d["summary"]["num_sequences"] == 1
+        assert len(d["sequences"]) == 1

--- a/tests/test_synthetic_dataset.py
+++ b/tests/test_synthetic_dataset.py
@@ -1,0 +1,446 @@
+"""Unit and integration tests for eovot.datasets.synthetic."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import numpy as np
+import pytest
+
+from eovot.datasets.base import BaseDataset, Sequence
+from eovot.datasets.synthetic import (
+    SyntheticDataset,
+    SyntheticSequenceConfig,
+    _compute_ground_truth,
+    _render_frame,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _default_cfg(**kwargs) -> SyntheticSequenceConfig:
+    """Return a minimal valid config, overridable via kwargs."""
+    base = dict(
+        name="test_seq",
+        n_frames=20,
+        frame_size=(120, 160),
+        init_bbox=(40.0, 30.0, 40.0, 30.0),
+        motion="linear",
+        velocity=(1.0, 0.5),
+        seed=0,
+    )
+    base.update(kwargs)
+    return SyntheticSequenceConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# SyntheticSequenceConfig
+# ---------------------------------------------------------------------------
+
+class TestSyntheticSequenceConfig:
+    def test_resolve_init_bbox_explicit(self):
+        cfg = _default_cfg(init_bbox=(10.0, 20.0, 50.0, 40.0))
+        assert cfg.resolve_init_bbox() == (10.0, 20.0, 50.0, 40.0)
+
+    def test_resolve_init_bbox_default_is_centred(self):
+        cfg = SyntheticSequenceConfig(frame_size=(200, 400))
+        x, y, w, h = cfg.resolve_init_bbox()
+        # Centre of default box should be near frame centre
+        cx, cy = x + w / 2, y + h / 2
+        assert abs(cx - 200) < 5 and abs(cy - 100) < 5
+
+    def test_default_motion_is_linear(self):
+        cfg = SyntheticSequenceConfig()
+        assert cfg.motion == "linear"
+
+
+# ---------------------------------------------------------------------------
+# _compute_ground_truth
+# ---------------------------------------------------------------------------
+
+class TestComputeGroundTruth:
+    def test_shape(self):
+        cfg = _default_cfg(n_frames=30)
+        gt = _compute_ground_truth(cfg)
+        assert gt.shape == (30, 4)
+
+    def test_first_frame_matches_init_bbox(self):
+        cfg = _default_cfg(
+            init_bbox=(40.0, 30.0, 40.0, 30.0),
+            motion="linear",
+            velocity=(0.0, 0.0),
+        )
+        gt = _compute_ground_truth(cfg)
+        np.testing.assert_allclose(gt[0], [40.0, 30.0, 40.0, 30.0], atol=1e-6)
+
+    def test_linear_motion_advances_position(self):
+        cfg = _default_cfg(
+            motion="linear",
+            velocity=(3.0, 2.0),
+            scale_factor=1.0,
+        )
+        gt = _compute_ground_truth(cfg)
+        # Centre at frame i should advance by velocity relative to frame 0
+        cx0 = gt[0, 0] + gt[0, 2] / 2
+        cy0 = gt[0, 1] + gt[0, 3] / 2
+        cx1 = gt[1, 0] + gt[1, 2] / 2
+        cy1 = gt[1, 1] + gt[1, 3] / 2
+        assert abs((cx1 - cx0) - 3.0) < 0.5
+        assert abs((cy1 - cy0) - 2.0) < 0.5
+
+    def test_sinusoidal_motion_is_oscillating(self):
+        cfg = _default_cfg(
+            motion="sinusoidal",
+            amplitude=(50.0, 30.0),
+            frequency=0.1,
+            n_frames=50,
+        )
+        gt = _compute_ground_truth(cfg)
+        cx = gt[:, 0] + gt[:, 2] / 2
+        # Oscillating — centre should vary significantly
+        assert cx.max() - cx.min() > 10.0
+
+    def test_random_walk_is_reproducible_with_seed(self):
+        cfg = _default_cfg(motion="random_walk", seed=42, n_frames=40)
+        gt1 = _compute_ground_truth(cfg)
+        gt2 = _compute_ground_truth(cfg)
+        np.testing.assert_array_equal(gt1, gt2)
+
+    def test_random_walk_different_seeds_differ(self):
+        cfg1 = _default_cfg(motion="random_walk", seed=1, n_frames=40)
+        cfg2 = _default_cfg(motion="random_walk", seed=2, n_frames=40)
+        gt1 = _compute_ground_truth(cfg1)
+        gt2 = _compute_ground_truth(cfg2)
+        assert not np.allclose(gt1, gt2)
+
+    def test_boxes_stay_within_frame(self):
+        cfg = _default_cfg(
+            n_frames=80,
+            frame_size=(120, 160),
+            motion="linear",
+            velocity=(10.0, 8.0),
+        )
+        gt = _compute_ground_truth(cfg)
+        H, W = cfg.frame_size
+        x, y, w, h = gt[:, 0], gt[:, 1], gt[:, 2], gt[:, 3]
+        assert np.all(x >= 0), "x must be non-negative"
+        assert np.all(y >= 0), "y must be non-negative"
+        assert np.all(x + w <= W), f"box right edge exceeded frame width"
+        assert np.all(y + h <= H), "box bottom edge exceeded frame height"
+
+    def test_scale_factor_grows_target(self):
+        cfg = _default_cfg(scale_factor=1.02, n_frames=30)
+        gt = _compute_ground_truth(cfg)
+        # Target width should increase monotonically
+        assert gt[-1, 2] > gt[0, 2]
+
+    def test_scale_factor_shrinks_target(self):
+        cfg = _default_cfg(scale_factor=0.98, n_frames=30)
+        gt = _compute_ground_truth(cfg)
+        assert gt[-1, 2] < gt[0, 2]
+
+    def test_invalid_motion_raises(self):
+        cfg = _default_cfg()
+        cfg.motion = "invalid_motion"  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="Unknown motion model"):
+            _compute_ground_truth(cfg)
+
+
+# ---------------------------------------------------------------------------
+# _render_frame
+# ---------------------------------------------------------------------------
+
+class TestRenderFrame:
+    def test_output_shape_and_dtype(self):
+        cfg = _default_cfg()
+        bbox = (40.0, 30.0, 40.0, 30.0)
+        frame = _render_frame(cfg, bbox, None)
+        assert frame.shape == (120, 160, 3)
+        assert frame.dtype == np.uint8
+
+    def test_solid_appearance_paints_target_color(self):
+        cfg = _default_cfg(appearance="solid", target_color=(0, 0, 255))
+        bbox = (40.0, 30.0, 40.0, 30.0)
+        frame = _render_frame(cfg, bbox, None)
+        # Sample a pixel inside the bounding box
+        px = frame[30 + 5, 40 + 5]
+        np.testing.assert_array_equal(px, [0, 0, 255])
+
+    def test_background_color_applied(self):
+        cfg = _default_cfg(bg_color=(200, 200, 200))
+        bbox = (40.0, 30.0, 40.0, 30.0)
+        frame = _render_frame(cfg, bbox, None)
+        # Pixel far from bounding box should have background color
+        px = frame[0, 0]
+        np.testing.assert_array_equal(px, [200, 200, 200])
+
+    def test_checkerboard_appearance_valid(self):
+        cfg = _default_cfg(appearance="checkerboard")
+        bbox = (20.0, 20.0, 60.0, 40.0)
+        frame = _render_frame(cfg, bbox, None)
+        patch = frame[20:60, 20:80]
+        # Checkerboard must have at least two distinct colors
+        unique_colors = set(map(tuple, patch.reshape(-1, 3).tolist()))
+        assert len(unique_colors) >= 2
+
+    def test_gradient_appearance_valid(self):
+        cfg = _default_cfg(appearance="gradient")
+        bbox = (20.0, 20.0, 60.0, 40.0)
+        frame = _render_frame(cfg, bbox, None)
+        assert frame.dtype == np.uint8
+
+    def test_noise_is_added(self):
+        cfg = _default_cfg(add_noise=True, noise_sigma=20.0)
+        bbox = (40.0, 30.0, 40.0, 30.0)
+        rng = np.random.default_rng(0)
+        noisy = _render_frame(cfg, bbox, rng)
+        # Noise means the frame is not a perfectly uniform color
+        assert noisy.std() > 0.0
+
+    def test_zero_area_bbox_returns_background(self):
+        cfg = _default_cfg(bg_color=(100, 100, 100))
+        bbox = (10.0, 10.0, 0.0, 0.0)  # zero width and height
+        frame = _render_frame(cfg, bbox, None)
+        assert frame[10, 10, 0] == 100  # background, not target
+
+
+# ---------------------------------------------------------------------------
+# _SyntheticSequence (accessed via SyntheticDataset)
+# ---------------------------------------------------------------------------
+
+class TestSyntheticSequence:
+    def setup_method(self):
+        self.cfg = _default_cfg(n_frames=15)
+        self.dataset = SyntheticDataset([self.cfg])
+        self.seq = self.dataset[0]
+
+    def test_is_sequence_instance(self):
+        assert isinstance(self.seq, Sequence)
+
+    def test_len_matches_n_frames(self):
+        assert len(self.seq) == 15
+
+    def test_ground_truth_shape(self):
+        assert self.seq.ground_truth.shape == (15, 4)
+
+    def test_iter_yields_correct_count(self):
+        frames = list(self.seq)
+        assert len(frames) == 15
+
+    def test_frames_have_correct_shape(self):
+        for frame in self.seq:
+            assert frame.shape == (120, 160, 3)
+            assert frame.dtype == np.uint8
+
+    def test_init_bbox_matches_gt_frame0(self):
+        np.testing.assert_allclose(
+            self.seq.init_bbox,
+            tuple(self.seq.ground_truth[0]),
+            atol=1e-6,
+        )
+
+    def test_name_propagated(self):
+        assert self.seq.name == "test_seq"
+
+    def test_repr(self):
+        s = repr(self.seq)
+        assert "test_seq" in s
+
+
+# ---------------------------------------------------------------------------
+# SyntheticDataset
+# ---------------------------------------------------------------------------
+
+class TestSyntheticDataset:
+    def test_is_base_dataset(self):
+        ds = SyntheticDataset([_default_cfg()])
+        assert isinstance(ds, BaseDataset)
+
+    def test_len_matches_configs(self):
+        cfgs = [_default_cfg(name=f"s{i}") for i in range(4)]
+        ds = SyntheticDataset(cfgs)
+        assert len(ds) == 4
+
+    def test_getitem_returns_sequence(self):
+        ds = SyntheticDataset([_default_cfg()])
+        assert isinstance(ds[0], Sequence)
+
+    def test_iter_yields_all_sequences(self):
+        cfgs = [_default_cfg(name=f"s{i}") for i in range(3)]
+        ds = SyntheticDataset(cfgs)
+        seqs = list(ds)
+        assert len(seqs) == 3
+
+    def test_repr(self):
+        ds = SyntheticDataset([_default_cfg()])
+        assert "SyntheticDataset" in repr(ds)
+
+
+# ---------------------------------------------------------------------------
+# SyntheticDataset factory methods
+# ---------------------------------------------------------------------------
+
+class TestQuickFactory:
+    def test_returns_correct_length(self):
+        ds = SyntheticDataset.quick(n_sequences=5)
+        assert len(ds) == 5
+
+    def test_frames_per_sequence(self):
+        ds = SyntheticDataset.quick(n_sequences=3, n_frames=25)
+        for seq in ds:
+            assert len(seq) == 25
+
+    def test_frame_size_respected(self):
+        ds = SyntheticDataset.quick(n_sequences=2, frame_size=(100, 150))
+        for seq in ds:
+            for frame in seq:
+                assert frame.shape == (100, 150, 3)
+                break  # only need to check first frame
+
+    def test_reproducible_with_seed(self):
+        ds1 = SyntheticDataset.quick(seed=7)
+        ds2 = SyntheticDataset.quick(seed=7)
+        for s1, s2 in zip(ds1, ds2):
+            np.testing.assert_array_equal(s1.ground_truth, s2.ground_truth)
+
+    def test_different_seeds_differ(self):
+        ds1 = SyntheticDataset.quick(n_sequences=3, seed=1)
+        ds2 = SyntheticDataset.quick(n_sequences=3, seed=2)
+        gts_equal = [
+            np.allclose(s1.ground_truth, s2.ground_truth)
+            for s1, s2 in zip(ds1, ds2)
+        ]
+        assert not all(gts_equal)
+
+    def test_sinusoidal_motion_variant(self):
+        ds = SyntheticDataset.quick(motion="sinusoidal", n_sequences=2)
+        assert len(ds) == 2
+
+    def test_random_walk_motion_variant(self):
+        ds = SyntheticDataset.quick(motion="random_walk", n_sequences=2, seed=0)
+        assert len(ds) == 2
+
+    def test_gt_boxes_are_within_frame(self):
+        ds = SyntheticDataset.quick(n_sequences=3, frame_size=(120, 160))
+        H, W = 120, 160
+        for seq in ds:
+            gt = seq.ground_truth
+            assert np.all(gt[:, 0] >= 0)
+            assert np.all(gt[:, 1] >= 0)
+            assert np.all(gt[:, 0] + gt[:, 2] <= W)
+            assert np.all(gt[:, 1] + gt[:, 3] <= H)
+
+
+class TestStressTestFactory:
+    def test_returns_correct_length(self):
+        ds = SyntheticDataset.stress_test(n_sequences=6)
+        assert len(ds) == 6
+
+    def test_mixed_motions_in_names(self):
+        ds = SyntheticDataset.stress_test(n_sequences=9)
+        names = [ds[i].name for i in range(9)]
+        assert any("linear" in n for n in names)
+        assert any("sinusoidal" in n for n in names)
+        assert any("random_walk" in n for n in names)
+
+    def test_frames_are_iterable(self):
+        ds = SyntheticDataset.stress_test(n_sequences=2, n_frames=10)
+        for seq in ds:
+            frames = list(seq)
+            assert len(frames) == 10
+
+
+class TestScaleChallengeFactory:
+    def test_returns_correct_length(self):
+        ds = SyntheticDataset.scale_challenge(n_sequences=4)
+        assert len(ds) == 4
+
+    def test_growing_sequence_increases_size(self):
+        ds = SyntheticDataset.scale_challenge(n_sequences=2, n_frames=50)
+        grow_seq = ds[0]   # even index → growing
+        gt = grow_seq.ground_truth
+        assert gt[-1, 2] > gt[0, 2], "growing sequence should have larger w at end"
+
+    def test_shrinking_sequence_decreases_size(self):
+        ds = SyntheticDataset.scale_challenge(n_sequences=2, n_frames=50)
+        shrink_seq = ds[1]  # odd index → shrinking
+        gt = shrink_seq.ground_truth
+        assert gt[-1, 2] < gt[0, 2], "shrinking sequence should have smaller w at end"
+
+
+# ---------------------------------------------------------------------------
+# Integration with BenchmarkEngine
+# ---------------------------------------------------------------------------
+
+class TestIntegrationWithBenchmarkEngine:
+    def test_engine_runs_without_real_data(self):
+        """SyntheticDataset must be accepted by BenchmarkEngine without any
+        dataset files on disk."""
+        try:
+            from eovot.benchmark.engine import BenchmarkEngine
+        except ImportError:
+            pytest.skip("BenchmarkEngine not importable")
+
+        from eovot.trackers.base import BaseTracker
+
+        class DummyTracker(BaseTracker):
+            def __init__(self):
+                super().__init__(name="Dummy")
+                self._bbox = None
+
+            def initialize(self, frame, bbox):
+                self._bbox = bbox
+
+            def update(self, frame):
+                return self._bbox
+
+        dataset = SyntheticDataset.quick(n_sequences=3, n_frames=10, seed=0)
+        engine = BenchmarkEngine(verbose=False)
+        tracker = DummyTracker()
+        result = engine.run(tracker, dataset, dataset_name="Synthetic")
+
+        assert len(result.sequence_results) == 3
+        assert result.mean_fps > 0.0
+        # A perfect tracker (returns init bbox which equals frame-0 GT) should
+        # have mIoU=1.0 only if GT doesn't change; here GT moves so mIoU<1 is ok.
+        assert 0.0 <= result.mean_iou <= 1.0
+
+    def test_known_gt_motion_gives_expected_iou(self):
+        """A tracker that perfectly follows the ground truth should achieve mIoU=1.0."""
+        try:
+            from eovot.benchmark.engine import BenchmarkEngine
+        except ImportError:
+            pytest.skip("BenchmarkEngine not importable")
+
+        from eovot.trackers.base import BaseTracker
+
+        class OracleTracker(BaseTracker):
+            """Returns the exact GT box — simulates perfect tracking."""
+
+            def __init__(self):
+                super().__init__(name="Oracle")
+                self._gt: list = []
+                self._frame_idx = 0
+
+            def initialize(self, frame, bbox):
+                self._frame_idx = 1  # will be called for frames 1..N
+
+            def _set_gt(self, gt):
+                self._gt = gt
+
+            def update(self, frame):
+                idx = self._frame_idx
+                self._frame_idx += 1
+                return tuple(self._gt[idx])
+
+        cfg = _default_cfg(n_frames=15, motion="linear", velocity=(0.0, 0.0))
+        dataset = SyntheticDataset([cfg])
+        engine = BenchmarkEngine(verbose=False)
+
+        tracker = OracleTracker()
+        tracker._set_gt(dataset[0].ground_truth)
+
+        result = engine.run(tracker, dataset, dataset_name="Synthetic")
+        assert result.mean_iou == pytest.approx(1.0, abs=0.01)


### PR DESCRIPTION
## Summary

This PR makes EOVOT self-contained: until now, running *any* benchmark required downloading multi-GB real datasets (OTB, GOT-10k, LaSOT). After this PR, a new contributor can clone the repo and immediately run the full pipeline — no data download, no license, no storage footprint.

### What was added

**`eovot/datasets/synthetic.py`** — new module

`SyntheticSequenceConfig` — dataclass that fully specifies one tracking sequence:
- **Motion models**: `"linear"` (constant velocity), `"sinusoidal"` (deterministic oscillation), `"random_walk"` (Brownian motion with seed)
- **Appearance**: `"solid"` color rectangle, `"checkerboard"`, or `"gradient"` (tests appearance-invariant and appearance-sensitive trackers)
- **Scale variation**: per-frame multiplicative size change — exposes trackers (MOSSE, KCF) that assume fixed object size
- **Noise**: optional additive Gaussian pixel noise for sensor simulation
- **Boundary clamping**: all boxes guaranteed within frame at every frame

`SyntheticDataset(List[SyntheticSequenceConfig])` — `BaseDataset` implementation whose `__iter__` renders frames lazily in memory using NumPy/OpenCV — zero disk I/O, O(1) construction cost.

Three factory presets for common use cases:
- `SyntheticDataset.quick()` — fast mixed-velocity smoke-test collection
- `SyntheticDataset.stress_test()` — mixed motion/appearance with noise for robustness analysis
- `SyntheticDataset.scale_challenge()` — alternating grow/shrink sequences to expose fixed-scale tracker weaknesses

**`eovot/datasets/__init__.py`** — exports `SyntheticDataset` and `SyntheticSequenceConfig`

**`tests/test_synthetic_dataset.py`** — 49 unit + integration tests covering:
- `SyntheticSequenceConfig` resolution and defaults
- `_compute_ground_truth`: all 3 motion models, scale factors, boundary clamping, seed reproducibility
- `_render_frame`: all 3 appearance styles, noise, zero-area bbox guard
- All three factory methods and their per-sequence properties
- End-to-end integration with `BenchmarkEngine` (no real data)

**`configs/experiments/synthetic_quick_eval.yaml`** — ready-to-run config for MOSSE/KCF/CSRT on 10 synthetic sequences, no `--dataset-root` needed.

**`scripts/compare_trackers.py`** — extended: `--dataset-loader SyntheticDataset` works without `--dataset-root`; `--num-sequences`, `--seq-len`, `--frame-width/height`, `--seed` CLI flags map to `SyntheticDataset.quick()`.

### Quick-start (zero setup)

```python
from eovot.datasets.synthetic import SyntheticDataset
from eovot.benchmark.engine import BenchmarkEngine
from eovot.trackers.mosse import MOSSETracker

dataset = SyntheticDataset.quick(n_sequences=10, n_frames=60, seed=42)
engine  = BenchmarkEngine(verbose=True)
result  = engine.run(MOSSETracker(), dataset, dataset_name="Synthetic-Quick")
print(result.summary())
```

```bash
# Multi-tracker comparison with no external data
python scripts/compare_trackers.py \
    --trackers MOSSE KCF \
    --dataset-loader SyntheticDataset \
    --num-sequences 10 --seq-len 60
```

### Why the config-based API

`SyntheticSequenceConfig` allows per-sequence control over motion, appearance, and scale — necessary for the `stress_test` and `scale_challenge` presets that mix motion models within a single dataset. Factory methods provide convenience without requiring users to build configs manually.

### Test plan

- [x] 49 new tests pass (`tests/test_synthetic_dataset.py`)
- [x] All 166 existing tests continue to pass (`pytest tests/`)
- [x] `BenchmarkEngine` integration verified end-to-end with no disk I/O
- [x] Reproducibility: same seed → identical GT trajectories and rendered frames
- [x] No breaking changes to existing `BaseDataset`, `Sequence`, or engine APIs