### PR TITLE
feat(profiling): add DeployabilityChecker for edge hardware constraint evaluation

### DIFF
--- a/configs/devices/jetson_nano.yaml
+++ b/configs/devices/jetson_nano.yaml
@@ -1,0 +1,34 @@
+# Device profile: NVIDIA Jetson Nano Developer Kit
+#
+# The Jetson Nano runs classical trackers on its ARM CPU and can accelerate
+# deep trackers (SiamRPN, NanoTrack) via its Maxwell GPU.
+# This profile targets CPU-only trackers; GPU trackers will exceed these FPS
+# limits significantly.
+
+device:
+  name: "NVIDIA Jetson Nano"
+  description: >
+    NVIDIA Jetson Nano Developer Kit (4 GB).
+    Quad-core ARM Cortex-A57 @ 1.43 GHz, 4 GB LPDDR4, 128-core Maxwell GPU.
+    10 W power mode (default); 5 W low-power mode available.
+    Classical CPU trackers run well; GPU-accelerated deep trackers are the
+    primary target platform for SiamRPN and similar architectures.
+  min_fps: 25.0
+  max_memory_mb: 512.0
+  tdp_watts: 10.0
+  max_energy_per_frame_mj: 8.0
+
+benchmark_guidance:
+  recommended_trackers:
+    - MOSSE
+    - KCF
+    - MedianFlow
+  marginal_trackers:
+    - CSRT       # ~25–35 FPS in 10 W mode
+  gpu_accelerated:
+    - NanoTrack  # 60+ FPS via ONNX + GPU
+    - DaSiamRPN  # 30+ FPS via TensorRT
+  notes:
+    - "Set tdp_watts: 10.0 in BenchmarkEngine for energy profiling."
+    - "Use tegrastats for true board-level power measurement."
+    - "Jetson shared CPU/GPU memory: peak_memory_mb is RSS only."

--- a/configs/devices/laptop_cpu.yaml
+++ b/configs/devices/laptop_cpu.yaml
@@ -1,0 +1,27 @@
+# Device profile: Generic Laptop CPU
+#
+# Represents a 15 W TDP laptop (Intel Core i5/i7 U-series or equivalent).
+# Use as the development baseline before testing on constrained hardware.
+
+device:
+  name: "Laptop CPU"
+  description: >
+    Generic laptop with a 15 W TDP CPU (e.g. Intel Core i5/i7 U-series,
+    AMD Ryzen 5/7 mobile). 16 GB RAM, no GPU acceleration assumed.
+    Comfortable baseline for all classical trackers; suitable for
+    development and CI evaluation.
+  min_fps: 30.0
+  max_memory_mb: 2048.0
+  tdp_watts: 15.0
+  max_energy_per_frame_mj: 50.0
+
+benchmark_guidance:
+  recommended_trackers:
+    - MOSSE
+    - KCF
+    - MedianFlow
+    - CSRT
+  notes:
+    - "All classical trackers comfortably exceed 30 FPS on this hardware."
+    - "Use tdp_watts: 15.0 for energy estimates."
+    - "Deep trackers (SiamRPN) will be slow without GPU — use ONNX Runtime."

--- a/configs/devices/raspberry_pi4.yaml
+++ b/configs/devices/raspberry_pi4.yaml
@@ -1,0 +1,37 @@
+# Device profile: Raspberry Pi 4 Model B
+#
+# Use this profile with DeployabilityChecker to evaluate whether a tracker
+# can run in real time on a Raspberry Pi 4.
+#
+# Example usage:
+#   from eovot.profiling.device_profile import DeviceProfile, DeployabilityChecker
+#   import yaml
+#   with open("configs/devices/raspberry_pi4.yaml") as f:
+#       cfg = yaml.safe_load(f)
+#   profile = DeviceProfile(**cfg["device"])
+#   report = DeployabilityChecker().check(benchmark_result, profile)
+
+device:
+  name: "Raspberry Pi 4"
+  description: >
+    Raspberry Pi 4 Model B (4 GB variant).
+    ARM Cortex-A72 @ 1.5 GHz, 4 GB LPDDR4-3200, VideoCore VI GPU.
+    Typical tracking use-case: 15 FPS real-time inference at 6 W TDP.
+    Suitable for MOSSE and KCF; CSRT may run below real-time threshold.
+  min_fps: 15.0
+  max_memory_mb: 256.0
+  tdp_watts: 6.0
+  max_energy_per_frame_mj: 10.0
+
+benchmark_guidance:
+  recommended_trackers:
+    - MOSSE      # 500+ FPS — very comfortable
+    - KCF        # 150–350 FPS — comfortable
+  marginal_trackers:
+    - MedianFlow # ~60–80 FPS on RPi4
+  not_recommended:
+    - CSRT       # ~10–15 FPS on RPi4 — too slow for real-time
+  notes:
+    - "Run BenchmarkEngine with tdp_watts: 6.0 to collect energy estimates."
+    - "Disable SWAP to get accurate peak_memory_mb readings."
+    - "Consider ONNX export for 2–3x speedup on ARM without GPU."

--- a/eovot/profiling/__init__.py
+++ b/eovot/profiling/__init__.py
@@ -2,5 +2,15 @@
 
 from .profiler import Profiler, ProfilingResult
 from .energy import EnergyProfiler, EnergyResult
+from .device_profiles import DeviceProfile, get_profile, list_profiles, register_profile
 
-__all__ = ["Profiler", "ProfilingResult", "EnergyProfiler", "EnergyResult"]
+__all__ = [
+    "Profiler",
+    "ProfilingResult",
+    "EnergyProfiler",
+    "EnergyResult",
+    "DeviceProfile",
+    "get_profile",
+    "list_profiles",
+    "register_profile",
+]

--- a/eovot/profiling/device_profile.py
+++ b/eovot/profiling/device_profile.py
@@ -1,0 +1,398 @@
+"""Device profiles and deployability checking for edge-aware tracker evaluation.
+
+This module provides:
+
+- :class:`DeviceProfile` — dataclass encoding the hardware constraints of a
+  target deployment platform (FPS budget, memory ceiling, TDP).
+- :data:`DEVICE_PRESETS` — a registry of common edge and desktop devices.
+- :class:`DeployabilityChecker` — evaluates whether a benchmark result meets
+  a device's constraints and returns a structured :class:`DeployabilityReport`.
+
+Motivation
+----------
+Academic trackers are typically evaluated on desktop-class hardware where FPS
+and memory are not limiting factors.  EOVOT bridges this gap by letting
+researchers quantify *which trackers can actually run* on a target device
+before investing in deployment work.
+
+Usage::
+
+    from eovot.profiling.device_profile import DEVICE_PRESETS, DeployabilityChecker
+
+    checker = DeployabilityChecker()
+    report = checker.check(benchmark_result, DEVICE_PRESETS["raspberry_pi4"])
+    print(report)
+
+    if report.deployable:
+        print("Tracker meets all constraints — ready for edge deployment.")
+    else:
+        for violation in report.violations:
+            print(f"  FAIL: {violation}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from eovot.benchmark.engine import BenchmarkResult
+
+
+@dataclass
+class DeviceProfile:
+    """Hardware constraints for a target deployment device.
+
+    All limits are *soft* constraints used to generate the deployability
+    report; exceeding one marks the tracker as non-deployable on that device
+    but does not raise an error.
+
+    Attributes:
+        name: Human-readable device name (e.g. ``"Raspberry Pi 4"``).
+        min_fps: Minimum required throughput in frames per second.
+            Set to ``None`` to skip the FPS check.
+        max_memory_mb: Maximum peak RSS memory in megabytes.
+            Set to ``None`` to skip the memory check.
+        tdp_watts: CPU Thermal Design Power in Watts, used as the TDP value
+            for energy estimation.  Set to ``None`` if no energy budget is
+            defined.
+        max_energy_per_frame_mj: Maximum allowed per-frame energy in
+            milli-Joules.  Only evaluated when the benchmark result includes
+            energy profiling data.  Set to ``None`` to skip.
+        max_latency_ms: Maximum acceptable mean per-frame latency in
+            milliseconds (= 1000 / min_fps when not set explicitly).
+            Overrides the FPS-derived latency threshold when provided.
+        description: Free-text description of the device for report output.
+    """
+
+    name: str
+    min_fps: Optional[float] = None
+    max_memory_mb: Optional[float] = None
+    tdp_watts: Optional[float] = None
+    max_energy_per_frame_mj: Optional[float] = None
+    max_latency_ms: Optional[float] = None
+    description: str = ""
+
+    @property
+    def derived_max_latency_ms(self) -> Optional[float]:
+        """Latency ceiling derived from min_fps when max_latency_ms is not set."""
+        if self.max_latency_ms is not None:
+            return self.max_latency_ms
+        if self.min_fps is not None and self.min_fps > 0:
+            return 1_000.0 / self.min_fps
+        return None
+
+    def __str__(self) -> str:
+        parts = [f"DeviceProfile({self.name!r}"]
+        if self.min_fps is not None:
+            parts.append(f"min_fps={self.min_fps}")
+        if self.max_memory_mb is not None:
+            parts.append(f"max_mem={self.max_memory_mb} MB")
+        if self.tdp_watts is not None:
+            parts.append(f"TDP={self.tdp_watts} W")
+        return ", ".join(parts) + ")"
+
+
+# ---------------------------------------------------------------------------
+# Built-in device presets
+# ---------------------------------------------------------------------------
+
+DEVICE_PRESETS: Dict[str, DeviceProfile] = {
+    "raspberry_pi4": DeviceProfile(
+        name="Raspberry Pi 4",
+        min_fps=15.0,
+        max_memory_mb=256.0,
+        tdp_watts=6.0,
+        max_energy_per_frame_mj=10.0,
+        description=(
+            "Raspberry Pi 4 Model B (4 GB variant). "
+            "ARM Cortex-A72 @ 1.5 GHz, 4 GB LPDDR4. "
+            "Typical tracking use-case: 15 FPS real-time with 6 W TDP."
+        ),
+    ),
+    "jetson_nano": DeviceProfile(
+        name="NVIDIA Jetson Nano",
+        min_fps=25.0,
+        max_memory_mb=512.0,
+        tdp_watts=10.0,
+        max_energy_per_frame_mj=8.0,
+        description=(
+            "NVIDIA Jetson Nano Developer Kit. "
+            "Quad-core ARM Cortex-A57 @ 1.43 GHz, 4 GB LPDDR4, Maxwell GPU. "
+            "5–10 W power mode; GPU-accelerated trackers can achieve 30+ FPS."
+        ),
+    ),
+    "jetson_orin_nano": DeviceProfile(
+        name="NVIDIA Jetson Orin Nano",
+        min_fps=30.0,
+        max_memory_mb=1024.0,
+        tdp_watts=15.0,
+        max_energy_per_frame_mj=6.0,
+        description=(
+            "NVIDIA Jetson Orin Nano 8 GB. "
+            "6-core Arm Cortex-A78AE, 1024-core Ampere GPU. "
+            "10–15 W power mode; suitable for real-time deep tracking."
+        ),
+    ),
+    "laptop_cpu": DeviceProfile(
+        name="Laptop CPU",
+        min_fps=30.0,
+        max_memory_mb=2048.0,
+        tdp_watts=15.0,
+        max_energy_per_frame_mj=50.0,
+        description=(
+            "Generic laptop with a 15 W TDP CPU (e.g. Intel Core i5/i7 U-series). "
+            "Baseline for development and non-edge evaluation."
+        ),
+    ),
+    "desktop_cpu": DeviceProfile(
+        name="Desktop CPU",
+        min_fps=60.0,
+        max_memory_mb=8192.0,
+        tdp_watts=65.0,
+        max_energy_per_frame_mj=200.0,
+        description=(
+            "Desktop workstation with a 65 W TDP CPU. "
+            "Used as an unconstrained upper-bound reference."
+        ),
+    ),
+    "coral_usb": DeviceProfile(
+        name="Google Coral USB Accelerator",
+        min_fps=15.0,
+        max_memory_mb=128.0,
+        tdp_watts=2.5,
+        max_energy_per_frame_mj=5.0,
+        description=(
+            "Google Coral USB Accelerator attached to a host CPU. "
+            "Edge TPU @ 2 TOPS, ~2.5 W peak; suited for quantised models."
+        ),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Deployability report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ConstraintResult:
+    """Outcome of checking a single hardware constraint."""
+
+    name: str
+    passed: bool
+    measured: float
+    limit: float
+    unit: str
+
+    def __str__(self) -> str:
+        status = "PASS" if self.passed else "FAIL"
+        return (
+            f"[{status}] {self.name}: "
+            f"measured={self.measured:.3f} {self.unit}  "
+            f"limit={self.limit:.3f} {self.unit}"
+        )
+
+
+@dataclass
+class DeployabilityReport:
+    """Full deployability assessment of one tracker on one device.
+
+    Attributes:
+        tracker_name: Name of the evaluated tracker.
+        device: :class:`DeviceProfile` the tracker was checked against.
+        constraint_results: Ordered list of individual constraint outcomes.
+        deployable: ``True`` when all checked constraints passed.
+        notes: Optional list of informational strings (warnings, tips).
+    """
+
+    tracker_name: str
+    device: DeviceProfile
+    constraint_results: List[ConstraintResult] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+
+    @property
+    def deployable(self) -> bool:
+        return all(c.passed for c in self.constraint_results)
+
+    @property
+    def violations(self) -> List[str]:
+        """Human-readable descriptions of all failed constraints."""
+        return [str(c) for c in self.constraint_results if not c.passed]
+
+    def summary_dict(self) -> Dict:
+        """Return a JSON-serialisable summary dict."""
+        return {
+            "tracker": self.tracker_name,
+            "device": self.device.name,
+            "deployable": self.deployable,
+            "constraints": [
+                {
+                    "name": c.name,
+                    "passed": c.passed,
+                    "measured": round(c.measured, 4),
+                    "limit": round(c.limit, 4),
+                    "unit": c.unit,
+                }
+                for c in self.constraint_results
+            ],
+            "notes": self.notes,
+        }
+
+    def __str__(self) -> str:
+        status = "DEPLOYABLE" if self.deployable else "NOT DEPLOYABLE"
+        lines = [
+            f"DeployabilityReport — {self.tracker_name} on {self.device.name}",
+            f"  Verdict: {status}",
+            "  Constraints:",
+        ]
+        for c in self.constraint_results:
+            lines.append(f"    {c}")
+        if self.notes:
+            lines.append("  Notes:")
+            for n in self.notes:
+                lines.append(f"    • {n}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Checker
+# ---------------------------------------------------------------------------
+
+class DeployabilityChecker:
+    """Evaluate whether a :class:`~eovot.benchmark.engine.BenchmarkResult`
+    meets the hardware constraints of a :class:`DeviceProfile`.
+
+    Example::
+
+        from eovot.profiling.device_profile import DeployabilityChecker, DEVICE_PRESETS
+
+        checker = DeployabilityChecker()
+        report = checker.check(result, DEVICE_PRESETS["raspberry_pi4"])
+        print(report)
+    """
+
+    def check(
+        self,
+        result: "BenchmarkResult",
+        device: DeviceProfile,
+    ) -> DeployabilityReport:
+        """Evaluate *result* against *device* constraints.
+
+        Checks (in order):
+        1. Mean FPS ≥ ``device.min_fps`` (if set).
+        2. Mean latency ≤ derived latency ceiling (if FPS or latency limit set).
+        3. Peak memory ≤ ``device.max_memory_mb`` (if set).
+        4. Mean energy per frame ≤ ``device.max_energy_per_frame_mj`` (if set
+           and energy data is present in the result).
+
+        Args:
+            result: Output of :class:`~eovot.benchmark.engine.BenchmarkEngine.run`.
+            device: Target device profile to evaluate against.
+
+        Returns:
+            :class:`DeployabilityReport` with per-constraint outcomes.
+        """
+        report = DeployabilityReport(tracker_name=result.tracker_name, device=device)
+
+        # 1. FPS check
+        if device.min_fps is not None:
+            measured_fps = result.mean_fps
+            passed = measured_fps >= device.min_fps
+            report.constraint_results.append(
+                ConstraintResult(
+                    name="Mean FPS",
+                    passed=passed,
+                    measured=measured_fps,
+                    limit=device.min_fps,
+                    unit="fps",
+                )
+            )
+
+        # 2. Latency check
+        lat_limit = device.derived_max_latency_ms
+        if lat_limit is not None:
+            mean_lat = float(
+                sum(sr.profiling.latency_mean_ms for sr in result.sequence_results)
+                / len(result.sequence_results)
+            )
+            passed = mean_lat <= lat_limit
+            report.constraint_results.append(
+                ConstraintResult(
+                    name="Mean Latency",
+                    passed=passed,
+                    measured=mean_lat,
+                    limit=lat_limit,
+                    unit="ms",
+                )
+            )
+
+        # 3. Memory check
+        if device.max_memory_mb is not None:
+            measured_mem = result.peak_memory_mb
+            passed = measured_mem <= device.max_memory_mb
+            report.constraint_results.append(
+                ConstraintResult(
+                    name="Peak Memory",
+                    passed=passed,
+                    measured=measured_mem,
+                    limit=device.max_memory_mb,
+                    unit="MB",
+                )
+            )
+
+        # 4. Energy check (only when both limit and data are available)
+        energy_available = any(
+            sr.energy is not None for sr in result.sequence_results
+        )
+        if device.max_energy_per_frame_mj is not None:
+            if energy_available:
+                mef = result.mean_energy_per_frame_mj
+                if mef is not None:
+                    passed = mef <= device.max_energy_per_frame_mj
+                    report.constraint_results.append(
+                        ConstraintResult(
+                            name="Energy per Frame",
+                            passed=passed,
+                            measured=mef,
+                            limit=device.max_energy_per_frame_mj,
+                            unit="mJ",
+                        )
+                    )
+            else:
+                report.notes.append(
+                    f"Energy limit is {device.max_energy_per_frame_mj} mJ/frame but "
+                    "no energy data was collected. Re-run BenchmarkEngine with "
+                    f"tdp_watts={device.tdp_watts} to enable energy profiling."
+                )
+
+        # Informational notes
+        if not report.deployable:
+            report.notes.append(
+                f"Consider a lighter tracker or reduce resolution to meet "
+                f"{device.name} constraints."
+            )
+        else:
+            report.notes.append(
+                f"All constraints satisfied — tracker is compatible with {device.name}."
+            )
+
+        return report
+
+    def check_all(
+        self,
+        result: "BenchmarkResult",
+        devices: Optional[Dict[str, DeviceProfile]] = None,
+    ) -> Dict[str, DeployabilityReport]:
+        """Check *result* against multiple devices at once.
+
+        Args:
+            result: Benchmark result to evaluate.
+            devices: Dict mapping device key → :class:`DeviceProfile`.
+                Defaults to :data:`DEVICE_PRESETS`.
+
+        Returns:
+            Dict mapping device key → :class:`DeployabilityReport`.
+        """
+        if devices is None:
+            devices = DEVICE_PRESETS
+        return {key: self.check(result, profile) for key, profile in devices.items()}

--- a/eovot/profiling/device_profiles.py
+++ b/eovot/profiling/device_profiles.py
@@ -1,0 +1,345 @@
+"""Hardware device profile registry for EOVOT edge-aware benchmarking.
+
+Provides a structured, named catalogue of common edge and desktop hardware
+platforms with their energy and compute characteristics.  Profiles are used
+by :class:`~eovot.profiling.energy.EnergyProfiler` to set a realistic TDP
+estimate without requiring the user to look up datasheet values.
+
+Usage::
+
+    from eovot.profiling.device_profiles import get_profile, list_profiles
+
+    profile = get_profile("jetson-nano")
+    print(profile.tdp_watts)       # 10.0
+    print(profile.device_class)    # "edge-gpu"
+
+    for name, p in list_profiles():
+        print(f"{name}: {p.description}")
+
+Device classes
+--------------
+- ``"edge-cpu"``   — microcontrollers / low-power SBCs (RPi, etc.)
+- ``"edge-gpu"``   — GPU-equipped edge boards (Jetson family)
+- ``"laptop"``     — typical consumer / research laptop CPUs
+- ``"workstation"``— desktop-class CPUs and GPU workstations
+- ``"server"``     — data-centre / cloud inference nodes
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass
+class DeviceProfile:
+    """Hardware characteristics for one target platform.
+
+    Attributes:
+        name: Short identifier used as registry key (e.g. ``"jetson-nano"``).
+        display_name: Human-readable name for reports.
+        device_class: Category string — one of ``"edge-cpu"``, ``"edge-gpu"``,
+            ``"laptop"``, ``"workstation"``, or ``"server"``.
+        tdp_watts: CPU Thermal Design Power in Watts.  Used as the upper bound
+            for :class:`~eovot.profiling.energy.EnergyProfiler`.
+        peak_power_w: Whole-board peak power draw (optional).  Includes GPU,
+            memory, I/O — useful for battery-budget calculations.
+        ram_gb: Total RAM in GiB (useful for memory-constrained profiling).
+        cpu_cores: Number of physical CPU cores.
+        has_gpu: Whether the device includes an integrated or discrete GPU.
+        typical_fps_target: Rough real-time tracking FPS threshold for this
+            class of device (informational — used in reporting).
+        description: One-line human description for CLI help text.
+    """
+
+    name: str
+    display_name: str
+    device_class: str
+    tdp_watts: float
+    peak_power_w: Optional[float] = None
+    ram_gb: float = 0.0
+    cpu_cores: int = 1
+    has_gpu: bool = False
+    typical_fps_target: float = 30.0
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        valid_classes = {"edge-cpu", "edge-gpu", "laptop", "workstation", "server"}
+        if self.device_class not in valid_classes:
+            raise ValueError(
+                f"device_class must be one of {valid_classes}, got {self.device_class!r}"
+            )
+        if self.tdp_watts <= 0:
+            raise ValueError(f"tdp_watts must be positive, got {self.tdp_watts}")
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable representation."""
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "device_class": self.device_class,
+            "tdp_watts": self.tdp_watts,
+            "peak_power_w": self.peak_power_w,
+            "ram_gb": self.ram_gb,
+            "cpu_cores": self.cpu_cores,
+            "has_gpu": self.has_gpu,
+            "typical_fps_target": self.typical_fps_target,
+            "description": self.description,
+        }
+
+    def __str__(self) -> str:
+        gpu_tag = " +GPU" if self.has_gpu else ""
+        return (
+            f"DeviceProfile[{self.name}] "
+            f"class={self.device_class}{gpu_tag}  "
+            f"TDP={self.tdp_watts}W  "
+            f"RAM={self.ram_gb}GB  "
+            f"cores={self.cpu_cores}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Built-in device registry
+# ---------------------------------------------------------------------------
+
+_REGISTRY: Dict[str, DeviceProfile] = {}
+
+
+def _register(profile: DeviceProfile) -> DeviceProfile:
+    _REGISTRY[profile.name] = profile
+    return profile
+
+
+# ---- Raspberry Pi family --------------------------------------------------
+
+_register(DeviceProfile(
+    name="rpi3b",
+    display_name="Raspberry Pi 3B",
+    device_class="edge-cpu",
+    tdp_watts=4.0,
+    peak_power_w=6.5,
+    ram_gb=1.0,
+    cpu_cores=4,
+    has_gpu=False,
+    typical_fps_target=10.0,
+    description="Raspberry Pi 3B (1 GB RAM, Cortex-A53 quad-core @ 1.2 GHz)",
+))
+
+_register(DeviceProfile(
+    name="rpi4",
+    display_name="Raspberry Pi 4 (4 GB)",
+    device_class="edge-cpu",
+    tdp_watts=6.0,
+    peak_power_w=8.5,
+    ram_gb=4.0,
+    cpu_cores=4,
+    has_gpu=False,
+    typical_fps_target=20.0,
+    description="Raspberry Pi 4 (4 GB RAM, Cortex-A72 quad-core @ 1.8 GHz)",
+))
+
+_register(DeviceProfile(
+    name="rpi5",
+    display_name="Raspberry Pi 5 (8 GB)",
+    device_class="edge-cpu",
+    tdp_watts=12.0,
+    peak_power_w=15.0,
+    ram_gb=8.0,
+    cpu_cores=4,
+    has_gpu=False,
+    typical_fps_target=40.0,
+    description="Raspberry Pi 5 (8 GB RAM, Cortex-A76 quad-core @ 2.4 GHz)",
+))
+
+# ---- NVIDIA Jetson family -------------------------------------------------
+
+_register(DeviceProfile(
+    name="jetson-nano",
+    display_name="NVIDIA Jetson Nano",
+    device_class="edge-gpu",
+    tdp_watts=10.0,
+    peak_power_w=10.0,
+    ram_gb=4.0,
+    cpu_cores=4,
+    has_gpu=True,
+    typical_fps_target=30.0,
+    description="NVIDIA Jetson Nano (4 GB, 128-core Maxwell GPU, 10 W TDP)",
+))
+
+_register(DeviceProfile(
+    name="jetson-xavier-nx",
+    display_name="NVIDIA Jetson Xavier NX",
+    device_class="edge-gpu",
+    tdp_watts=15.0,
+    peak_power_w=20.0,
+    ram_gb=8.0,
+    cpu_cores=6,
+    has_gpu=True,
+    typical_fps_target=60.0,
+    description="NVIDIA Jetson Xavier NX (8 GB, 384-core Volta GPU, 15 W mode)",
+))
+
+_register(DeviceProfile(
+    name="jetson-agx-orin",
+    display_name="NVIDIA Jetson AGX Orin",
+    device_class="edge-gpu",
+    tdp_watts=60.0,
+    peak_power_w=75.0,
+    ram_gb=32.0,
+    cpu_cores=12,
+    has_gpu=True,
+    typical_fps_target=120.0,
+    description="NVIDIA Jetson AGX Orin (32 GB, 2048-core Ampere GPU, 60 W max)",
+))
+
+# ---- Coral / NPU devices -------------------------------------------------
+
+_register(DeviceProfile(
+    name="coral-dev-board",
+    display_name="Google Coral Dev Board",
+    device_class="edge-cpu",
+    tdp_watts=2.0,
+    peak_power_w=4.0,
+    ram_gb=1.0,
+    cpu_cores=4,
+    has_gpu=False,
+    typical_fps_target=15.0,
+    description="Google Coral Dev Board (1 GB RAM, i.MX 8M + Edge TPU, ~2 W CPU TDP)",
+))
+
+# ---- Laptop / Consumer ---------------------------------------------------
+
+_register(DeviceProfile(
+    name="laptop-low",
+    display_name="Laptop (low-power, U-series)",
+    device_class="laptop",
+    tdp_watts=15.0,
+    peak_power_w=25.0,
+    ram_gb=16.0,
+    cpu_cores=4,
+    has_gpu=False,
+    typical_fps_target=100.0,
+    description="Typical ultrabook CPU (Intel Core U-series / AMD Ryzen 5 U, 15 W TDP)",
+))
+
+_register(DeviceProfile(
+    name="laptop-mid",
+    display_name="Laptop (mid-range, H-series)",
+    device_class="laptop",
+    tdp_watts=28.0,
+    peak_power_w=45.0,
+    ram_gb=16.0,
+    cpu_cores=8,
+    has_gpu=True,
+    typical_fps_target=150.0,
+    description="Mid-range laptop CPU with dGPU (Intel Core H / Ryzen 7 H, 28 W TDP)",
+))
+
+# ---- Workstation / Desktop -----------------------------------------------
+
+_register(DeviceProfile(
+    name="desktop-cpu",
+    display_name="Desktop CPU (mid-range)",
+    device_class="workstation",
+    tdp_watts=65.0,
+    peak_power_w=120.0,
+    ram_gb=32.0,
+    cpu_cores=8,
+    has_gpu=False,
+    typical_fps_target=300.0,
+    description="Mid-range desktop CPU (Intel Core i7 / AMD Ryzen 7, 65 W TDP)",
+))
+
+_register(DeviceProfile(
+    name="workstation-gpu",
+    display_name="GPU Workstation (RTX-class)",
+    device_class="workstation",
+    tdp_watts=125.0,
+    peak_power_w=350.0,
+    ram_gb=64.0,
+    cpu_cores=16,
+    has_gpu=True,
+    typical_fps_target=500.0,
+    description="High-end CPU + NVIDIA RTX GPU workstation (125 W CPU TDP)",
+))
+
+# ---- Server / Cloud ------------------------------------------------------
+
+_register(DeviceProfile(
+    name="server-cpu",
+    display_name="Server CPU (Xeon / EPYC)",
+    device_class="server",
+    tdp_watts=200.0,
+    peak_power_w=400.0,
+    ram_gb=128.0,
+    cpu_cores=32,
+    has_gpu=False,
+    typical_fps_target=1000.0,
+    description="Cloud server CPU (Intel Xeon / AMD EPYC, 200 W TDP)",
+))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_profile(name: str) -> DeviceProfile:
+    """Return a :class:`DeviceProfile` by its registry key.
+
+    Args:
+        name: Case-insensitive profile identifier (e.g. ``"jetson-nano"``,
+              ``"rpi4"``, ``"laptop-mid"``).
+
+    Raises:
+        KeyError: If no profile with *name* is registered.
+
+    Example::
+
+        profile = get_profile("rpi4")
+        energy_profiler = EnergyProfiler(tdp_watts=profile.tdp_watts)
+    """
+    key = name.lower()
+    if key not in _REGISTRY:
+        available = ", ".join(sorted(_REGISTRY))
+        raise KeyError(
+            f"Unknown device profile {name!r}. Available profiles: {available}"
+        )
+    return _REGISTRY[key]
+
+
+def list_profiles() -> List[Tuple[str, DeviceProfile]]:
+    """Return all registered profiles as ``(name, DeviceProfile)`` pairs.
+
+    Profiles are returned sorted alphabetically by name.
+
+    Example::
+
+        for name, profile in list_profiles():
+            print(f"{name:20s} — {profile.description}")
+    """
+    return sorted(_REGISTRY.items())
+
+
+def register_profile(profile: DeviceProfile) -> None:
+    """Add a custom :class:`DeviceProfile` to the global registry.
+
+    Raises:
+        ValueError: If a profile with the same name is already registered.
+
+    Example::
+
+        custom = DeviceProfile(
+            name="my-board",
+            display_name="My Custom Board",
+            device_class="edge-cpu",
+            tdp_watts=5.0,
+            description="Custom SBC with 5 W TDP",
+        )
+        register_profile(custom)
+    """
+    if profile.name in _REGISTRY:
+        raise ValueError(
+            f"A profile named {profile.name!r} is already registered. "
+            "Use a unique name or modify _REGISTRY directly."
+        )
+    _REGISTRY[profile.name] = profile

--- a/scripts/compare_trackers.py
+++ b/scripts/compare_trackers.py
@@ -47,8 +47,11 @@ from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
 from eovot.datasets.lasot import LaSOTDataset
+from eovot.profiling.device_profile import DEVICE_PRESETS, DeployabilityChecker
 from eovot.reporting.reporter import BenchmarkReporter
+from eovot.trackers.csrt import CSRTTracker
 from eovot.trackers.kcf import KCFTracker
+from eovot.trackers.median_flow import MedianFlowTracker
 from eovot.trackers.mosse import MOSSETracker
 
 # ---------------------------------------------------------------------------
@@ -58,6 +61,8 @@ from eovot.trackers.mosse import MOSSETracker
 TRACKER_REGISTRY = {
     "MOSSE": MOSSETracker,
     "KCF": KCFTracker,
+    "CSRT": CSRTTracker,
+    "MedianFlow": MedianFlowTracker,
 }
 
 DATASET_REGISTRY = {
@@ -133,13 +138,25 @@ def main() -> None:
             "Example: 6.0 for Raspberry Pi 4, 15.0 for a laptop CPU."
         ),
     )
+    parser.add_argument(
+        "--device",
+        default=None,
+        choices=list(DEVICE_PRESETS),
+        metavar="DEVICE",
+        help=(
+            "Run a deployability check against this device profile after benchmarking. "
+            f"Choices: {list(DEVICE_PRESETS)}"
+        ),
+    )
     args = parser.parse_args()
 
     dataset_name = args.dataset_name or args.dataset_loader
     reporter = BenchmarkReporter(output_dir=args.output_dir)
-    engine = BenchmarkEngine(verbose=True)
+    engine = BenchmarkEngine(verbose=True, tdp_watts=args.tdp_watts)
+    checker = DeployabilityChecker() if args.device else None
 
     all_results = []
+    raw_results = []  # BenchmarkResult objects needed for deployability check
 
     for tracker_name in args.trackers:
         print(f"\n{'=' * 60}")
@@ -147,12 +164,9 @@ def main() -> None:
         print(f"{'=' * 60}")
 
         tracker = TRACKER_REGISTRY[tracker_name]()
-        dataset = _build_dataset(
-            args.dataset_loader, args.dataset_root, args.split, args.max_sequences
-        )
 
         dataset_cls = DATASET_REGISTRY[args.dataset_loader]
-        if args.dataset_loader == "GOT10kDataset":
+        if args.dataset_loader in ("GOT10kDataset", "LaSOTDataset"):
             dataset = dataset_cls(
                 root=args.dataset_root,
                 split=args.split,
@@ -177,6 +191,13 @@ def main() -> None:
             print(f"  [{fmt.upper()}] saved → {path}")
 
         all_results.append(result_dict)
+        raw_results.append(result)
+
+        # Per-tracker deployability report
+        if checker is not None and args.device:
+            profile = DEVICE_PRESETS[args.device]
+            report = checker.check(result, profile)
+            print(f"\n{report}")
 
     # -----------------------------------------------------------------------
     # Comparison table (only meaningful with 2+ trackers)
@@ -185,6 +206,19 @@ def main() -> None:
         cmp_path = reporter.save_comparison(all_results, name=f"comparison-{dataset_name}")
         print(f"\n[COMPARISON TABLE] saved → {cmp_path}")
         print("\n" + reporter.comparison_table(all_results))
+
+    # -----------------------------------------------------------------------
+    # Cross-tracker deployability summary
+    # -----------------------------------------------------------------------
+    if checker is not None and args.device and len(raw_results) > 1:
+        profile = DEVICE_PRESETS[args.device]
+        print(f"\n{'=' * 60}")
+        print(f"  Deployability Summary for {profile.name}")
+        print(f"{'=' * 60}")
+        for r in raw_results:
+            rpt = checker.check(r, profile)
+            verdict = "OK" if rpt.deployable else "FAIL"
+            print(f"  [{verdict}]  {r.tracker_name:<16s}  FPS={r.mean_fps:.1f}  mem={r.peak_memory_mb:.0f} MB")
 
 
 if __name__ == "__main__":

--- a/scripts/compare_trackers.py
+++ b/scripts/compare_trackers.py
@@ -47,8 +47,11 @@ from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
 from eovot.datasets.lasot import LaSOTDataset
+from eovot.profiling.device_profiles import get_profile, list_profiles
 from eovot.reporting.reporter import BenchmarkReporter
+from eovot.trackers.csrt import CSRTTracker
 from eovot.trackers.kcf import KCFTracker
+from eovot.trackers.median_flow import MedianFlowTracker
 from eovot.trackers.mosse import MOSSETracker
 
 # ---------------------------------------------------------------------------
@@ -58,6 +61,8 @@ from eovot.trackers.mosse import MOSSETracker
 TRACKER_REGISTRY = {
     "MOSSE": MOSSETracker,
     "KCF": KCFTracker,
+    "CSRT": CSRTTracker,
+    "MedianFlow": MedianFlowTracker,
 }
 
 DATASET_REGISTRY = {
@@ -130,14 +135,51 @@ def main() -> None:
         metavar="W",
         help=(
             "Enable CPU energy estimation using this TDP value in Watts. "
-            "Example: 6.0 for Raspberry Pi 4, 15.0 for a laptop CPU."
+            "Example: 6.0 for Raspberry Pi 4, 15.0 for a laptop CPU. "
+            "Ignored if --device-profile is set."
         ),
+    )
+    profile_choices = [name for name, _ in list_profiles()]
+    parser.add_argument(
+        "--device-profile",
+        default=None,
+        metavar="PROFILE",
+        choices=profile_choices,
+        help=(
+            "Named hardware profile — sets TDP automatically. "
+            f"Available: {', '.join(profile_choices)}. "
+            "Takes precedence over --tdp-watts."
+        ),
+    )
+    parser.add_argument(
+        "--list-devices",
+        action="store_true",
+        help="Print all available device profiles and exit.",
     )
     args = parser.parse_args()
 
+    if args.list_devices:
+        print("\nAvailable EOVOT device profiles:\n")
+        print(f"  {'Name':<22} {'Class':<14} {'TDP (W)':>7}  Description")
+        print("  " + "-" * 70)
+        for name, profile in list_profiles():
+            print(
+                f"  {name:<22} {profile.device_class:<14} {profile.tdp_watts:>7.1f}  "
+                f"{profile.description}"
+            )
+        print()
+        sys.exit(0)
+
+    # Resolve TDP: device profile takes precedence over --tdp-watts
+    tdp: float | None = args.tdp_watts
+    if args.device_profile:
+        profile = get_profile(args.device_profile)
+        tdp = profile.tdp_watts
+        print(f"\n[device] Using profile '{profile.display_name}' — TDP={tdp} W")
+
     dataset_name = args.dataset_name or args.dataset_loader
     reporter = BenchmarkReporter(output_dir=args.output_dir)
-    engine = BenchmarkEngine(verbose=True)
+    engine = BenchmarkEngine(verbose=True, tdp_watts=tdp)
 
     all_results = []
 
@@ -150,16 +192,6 @@ def main() -> None:
         dataset = _build_dataset(
             args.dataset_loader, args.dataset_root, args.split, args.max_sequences
         )
-
-        dataset_cls = DATASET_REGISTRY[args.dataset_loader]
-        if args.dataset_loader == "GOT10kDataset":
-            dataset = dataset_cls(
-                root=args.dataset_root,
-                split=args.split,
-                max_sequences=args.max_sequences,
-            )
-        else:
-            dataset = dataset_cls(root=args.dataset_root)
 
         result = engine.run(
             tracker=tracker,

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -34,9 +34,9 @@ from eovot.benchmark.engine import BenchmarkEngine
 from eovot.datasets.base import OTBDataset
 from eovot.datasets.got10k import GOT10kDataset
 from eovot.datasets.lasot import LaSOTDataset
+from eovot.profiling.device_profiles import get_profile, list_profiles
 from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
-from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.csrt import CSRTTracker
 from eovot.trackers.median_flow import MedianFlowTracker
 
@@ -74,6 +74,15 @@ def _load_config(path: str) -> Dict:
         return yaml.safe_load(f)
 
 
+def _resolve_tdp(args: argparse.Namespace) -> Optional[float]:
+    """Return the TDP to use: device profile takes precedence over --tdp-watts."""
+    if getattr(args, "device_profile", None):
+        profile = get_profile(args.device_profile)
+        print(f"[device] Using profile '{profile.display_name}' — TDP={profile.tdp_watts} W")
+        return profile.tdp_watts
+    return getattr(args, "tdp_watts", None)
+
+
 def _config_from_args(args: argparse.Namespace) -> Dict:
     """Build a minimal config dict from CLI arguments."""
     return {
@@ -93,7 +102,7 @@ def _config_from_args(args: argparse.Namespace) -> Dict:
         },
         "benchmark": {
             "verbose": not args.quiet,
-            "tdp_watts": args.tdp_watts,
+            "tdp_watts": _resolve_tdp(args),
         },
         "reporting": {
             "formats": ["json"],
@@ -216,8 +225,27 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--tdp-watts", type=float, default=None, metavar="W",
                         help=(
                             "Enable CPU energy estimation with this TDP (Watts). "
-                            "E.g. 6.0 for Raspberry Pi 4, 15.0 for a laptop."
+                            "E.g. 6.0 for Raspberry Pi 4, 15.0 for a laptop. "
+                            "Ignored if --device-profile is set."
                         ))
+    profile_choices = [name for name, _ in list_profiles()]
+    parser.add_argument(
+        "--device-profile",
+        default=None,
+        metavar="PROFILE",
+        choices=profile_choices,
+        help=(
+            "Named hardware profile for energy estimation. "
+            "Sets TDP automatically based on known device specs. "
+            f"Available: {', '.join(profile_choices)}. "
+            "Takes precedence over --tdp-watts."
+        ),
+    )
+    parser.add_argument(
+        "--list-devices",
+        action="store_true",
+        help="Print all available device profiles and exit.",
+    )
     return parser
 
 
@@ -225,8 +253,25 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
+    if getattr(args, "list_devices", False):
+        print("\nAvailable EOVOT device profiles:\n")
+        print(f"  {'Name':<22} {'Class':<14} {'TDP (W)':>7}  Description")
+        print("  " + "-" * 70)
+        for name, profile in list_profiles():
+            print(
+                f"  {name:<22} {profile.device_class:<14} {profile.tdp_watts:>7.1f}  "
+                f"{profile.description}"
+            )
+        print()
+        sys.exit(0)
+
     if args.config:
         cfg = _load_config(args.config)
+        # Allow device-profile override from CLI even when using a config file
+        if getattr(args, "device_profile", None):
+            profile = get_profile(args.device_profile)
+            cfg.setdefault("benchmark", {})["tdp_watts"] = profile.tdp_watts
+            print(f"[device] Profile override '{profile.display_name}' — TDP={profile.tdp_watts} W")
     elif args.dataset_root:
         cfg = _config_from_args(args)
     else:

--- a/tests/test_device_profile.py
+++ b/tests/test_device_profile.py
@@ -1,0 +1,341 @@
+"""Unit tests for eovot.profiling.device_profile.
+
+Tests cover:
+- DeviceProfile construction and derived properties
+- DEVICE_PRESETS registry completeness
+- DeployabilityChecker constraint logic (pass/fail)
+- DeployabilityReport structure and helpers
+- check_all() multi-device sweep
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterator, List
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from eovot.profiling.device_profile import (
+    DEVICE_PRESETS,
+    ConstraintResult,
+    DeployabilityChecker,
+    DeployabilityReport,
+    DeviceProfile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — lightweight BenchmarkResult mock
+# ---------------------------------------------------------------------------
+
+def _make_profiling(fps: float, latency_ms: float, memory_mb: float):
+    p = MagicMock()
+    p.fps = fps
+    p.latency_mean_ms = latency_ms
+    p.peak_memory_mb = memory_mb
+    return p
+
+
+def _make_result(
+    tracker_name: str = "TestTracker",
+    fps: float = 100.0,
+    latency_ms: float = 10.0,
+    memory_mb: float = 100.0,
+    energy_per_frame_mj: float = None,
+    n_sequences: int = 3,
+):
+    """Build a minimal BenchmarkResult-like mock for checker tests."""
+    result = MagicMock()
+    result.tracker_name = tracker_name
+    result.mean_fps = fps
+    result.peak_memory_mb = memory_mb
+    result.mean_energy_per_frame_mj = energy_per_frame_mj
+    result.total_energy_j = (energy_per_frame_mj * 0.001 * n_sequences * 20) if energy_per_frame_mj else None
+
+    seq = MagicMock()
+    seq.profiling.latency_mean_ms = latency_ms
+    seq.energy = None if energy_per_frame_mj is None else MagicMock()
+    result.sequence_results = [seq] * n_sequences
+    return result
+
+
+# ---------------------------------------------------------------------------
+# DeviceProfile
+# ---------------------------------------------------------------------------
+
+class TestDeviceProfile:
+    def test_basic_construction(self):
+        p = DeviceProfile(name="TestDevice", min_fps=30.0, max_memory_mb=512.0)
+        assert p.name == "TestDevice"
+        assert p.min_fps == 30.0
+        assert p.max_memory_mb == 512.0
+
+    def test_derived_max_latency_from_fps(self):
+        p = DeviceProfile(name="X", min_fps=25.0)
+        assert p.derived_max_latency_ms == pytest.approx(40.0)  # 1000/25
+
+    def test_derived_max_latency_explicit_override(self):
+        p = DeviceProfile(name="X", min_fps=25.0, max_latency_ms=50.0)
+        assert p.derived_max_latency_ms == pytest.approx(50.0)
+
+    def test_derived_max_latency_none_when_no_fps(self):
+        p = DeviceProfile(name="X")
+        assert p.derived_max_latency_ms is None
+
+    def test_str_representation(self):
+        p = DeviceProfile(name="RPi4", min_fps=15.0, tdp_watts=6.0)
+        s = str(p)
+        assert "RPi4" in s
+        assert "min_fps=15.0" in s
+
+    def test_defaults_are_none(self):
+        p = DeviceProfile(name="Empty")
+        assert p.min_fps is None
+        assert p.max_memory_mb is None
+        assert p.tdp_watts is None
+        assert p.max_energy_per_frame_mj is None
+
+
+# ---------------------------------------------------------------------------
+# DEVICE_PRESETS registry
+# ---------------------------------------------------------------------------
+
+class TestDevicePresets:
+    def test_expected_keys_present(self):
+        expected = {"raspberry_pi4", "jetson_nano", "jetson_orin_nano", "laptop_cpu", "desktop_cpu", "coral_usb"}
+        assert expected.issubset(set(DEVICE_PRESETS.keys()))
+
+    def test_all_presets_are_device_profiles(self):
+        for key, profile in DEVICE_PRESETS.items():
+            assert isinstance(profile, DeviceProfile), f"{key} is not a DeviceProfile"
+
+    def test_rpi4_has_tight_constraints(self):
+        rpi4 = DEVICE_PRESETS["raspberry_pi4"]
+        assert rpi4.min_fps <= 20.0
+        assert rpi4.max_memory_mb <= 512.0
+        assert rpi4.tdp_watts <= 10.0
+
+    def test_desktop_more_relaxed_than_rpi4(self):
+        desktop = DEVICE_PRESETS["desktop_cpu"]
+        rpi4 = DEVICE_PRESETS["raspberry_pi4"]
+        assert desktop.min_fps > rpi4.min_fps
+        assert desktop.max_memory_mb > rpi4.max_memory_mb
+
+    def test_all_presets_have_name(self):
+        for profile in DEVICE_PRESETS.values():
+            assert profile.name, "every preset must have a non-empty name"
+
+
+# ---------------------------------------------------------------------------
+# DeployabilityChecker — FPS constraint
+# ---------------------------------------------------------------------------
+
+class TestFPSConstraint:
+    def setup_method(self):
+        self.checker = DeployabilityChecker()
+        self.device = DeviceProfile(name="TestDev", min_fps=30.0)
+
+    def test_fps_pass(self):
+        result = _make_result(fps=100.0)
+        report = self.checker.check(result, self.device)
+        fps_check = next(c for c in report.constraint_results if c.name == "Mean FPS")
+        assert fps_check.passed
+
+    def test_fps_fail(self):
+        result = _make_result(fps=10.0)
+        report = self.checker.check(result, self.device)
+        fps_check = next(c for c in report.constraint_results if c.name == "Mean FPS")
+        assert not fps_check.passed
+
+    def test_fps_exactly_at_limit_passes(self):
+        result = _make_result(fps=30.0)
+        report = self.checker.check(result, self.device)
+        fps_check = next(c for c in report.constraint_results if c.name == "Mean FPS")
+        assert fps_check.passed
+
+    def test_no_fps_constraint_skips_check(self):
+        device = DeviceProfile(name="NoFPS")
+        result = _make_result(fps=5.0)
+        report = self.checker.check(result, device)
+        fps_checks = [c for c in report.constraint_results if c.name == "Mean FPS"]
+        assert len(fps_checks) == 0
+
+
+# ---------------------------------------------------------------------------
+# DeployabilityChecker — memory constraint
+# ---------------------------------------------------------------------------
+
+class TestMemoryConstraint:
+    def setup_method(self):
+        self.checker = DeployabilityChecker()
+        self.device = DeviceProfile(name="MemDev", max_memory_mb=256.0)
+
+    def test_memory_pass(self):
+        result = _make_result(memory_mb=100.0)
+        report = self.checker.check(result, self.device)
+        mem_check = next(c for c in report.constraint_results if c.name == "Peak Memory")
+        assert mem_check.passed
+
+    def test_memory_fail(self):
+        result = _make_result(memory_mb=512.0)
+        report = self.checker.check(result, self.device)
+        mem_check = next(c for c in report.constraint_results if c.name == "Peak Memory")
+        assert not mem_check.passed
+
+    def test_no_memory_constraint_skips(self):
+        device = DeviceProfile(name="NoMem")
+        result = _make_result(memory_mb=99999.0)
+        report = self.checker.check(result, device)
+        mem_checks = [c for c in report.constraint_results if c.name == "Peak Memory"]
+        assert len(mem_checks) == 0
+
+
+# ---------------------------------------------------------------------------
+# DeployabilityChecker — latency constraint
+# ---------------------------------------------------------------------------
+
+class TestLatencyConstraint:
+    def setup_method(self):
+        self.checker = DeployabilityChecker()
+
+    def test_latency_derived_from_fps(self):
+        device = DeviceProfile(name="LatDev", min_fps=25.0)
+        result = _make_result(fps=25.0, latency_ms=30.0)
+        report = self.checker.check(result, device)
+        lat_check = next(c for c in report.constraint_results if c.name == "Mean Latency")
+        assert lat_check.limit == pytest.approx(40.0)  # 1000/25
+
+    def test_latency_pass(self):
+        device = DeviceProfile(name="LatDev", min_fps=25.0)
+        result = _make_result(fps=25.0, latency_ms=10.0)
+        report = self.checker.check(result, device)
+        lat_check = next(c for c in report.constraint_results if c.name == "Mean Latency")
+        assert lat_check.passed
+
+    def test_latency_fail(self):
+        device = DeviceProfile(name="LatDev", min_fps=25.0)
+        result = _make_result(fps=10.0, latency_ms=100.0)
+        report = self.checker.check(result, device)
+        lat_check = next(c for c in report.constraint_results if c.name == "Mean Latency")
+        assert not lat_check.passed
+
+
+# ---------------------------------------------------------------------------
+# DeployabilityChecker — energy constraint
+# ---------------------------------------------------------------------------
+
+class TestEnergyConstraint:
+    def setup_method(self):
+        self.checker = DeployabilityChecker()
+        self.device = DeviceProfile(name="EnergyDev", max_energy_per_frame_mj=10.0)
+
+    def test_energy_pass(self):
+        result = _make_result(energy_per_frame_mj=5.0)
+        report = self.checker.check(result, self.device)
+        e_checks = [c for c in report.constraint_results if c.name == "Energy per Frame"]
+        assert len(e_checks) == 1
+        assert e_checks[0].passed
+
+    def test_energy_fail(self):
+        result = _make_result(energy_per_frame_mj=20.0)
+        report = self.checker.check(result, self.device)
+        e_checks = [c for c in report.constraint_results if c.name == "Energy per Frame"]
+        assert len(e_checks) == 1
+        assert not e_checks[0].passed
+
+    def test_energy_limit_set_but_no_data_adds_note(self):
+        result = _make_result(energy_per_frame_mj=None)  # no energy data
+        report = self.checker.check(result, self.device)
+        e_checks = [c for c in report.constraint_results if c.name == "Energy per Frame"]
+        assert len(e_checks) == 0
+        assert any("energy" in n.lower() for n in report.notes)
+
+
+# ---------------------------------------------------------------------------
+# DeployabilityReport structure
+# ---------------------------------------------------------------------------
+
+class TestDeployabilityReport:
+    def test_deployable_true_when_all_pass(self):
+        result = _make_result(fps=200.0, memory_mb=50.0)
+        device = DEVICE_PRESETS["raspberry_pi4"]
+        report = DeployabilityChecker().check(result, device)
+        # High FPS and low memory → deployable
+        assert report.deployable
+
+    def test_deployable_false_when_fps_fails(self):
+        result = _make_result(fps=1.0, memory_mb=50.0)
+        device = DEVICE_PRESETS["raspberry_pi4"]
+        report = DeployabilityChecker().check(result, device)
+        assert not report.deployable
+
+    def test_violations_list_on_failure(self):
+        result = _make_result(fps=1.0, memory_mb=9999.0)
+        device = DEVICE_PRESETS["raspberry_pi4"]
+        report = DeployabilityChecker().check(result, device)
+        assert len(report.violations) >= 2  # FPS + memory
+
+    def test_violations_empty_when_deployable(self):
+        result = _make_result(fps=500.0, memory_mb=10.0)
+        device = DEVICE_PRESETS["laptop_cpu"]
+        report = DeployabilityChecker().check(result, device)
+        assert report.violations == []
+
+    def test_summary_dict_keys(self):
+        result = _make_result(fps=100.0, memory_mb=100.0)
+        device = DEVICE_PRESETS["laptop_cpu"]
+        report = DeployabilityChecker().check(result, device)
+        d = report.summary_dict()
+        assert "tracker" in d
+        assert "device" in d
+        assert "deployable" in d
+        assert "constraints" in d
+        assert isinstance(d["constraints"], list)
+
+    def test_str_contains_verdict(self):
+        result = _make_result(fps=500.0, memory_mb=10.0)
+        device = DEVICE_PRESETS["laptop_cpu"]
+        report = DeployabilityChecker().check(result, device)
+        s = str(report)
+        assert "DEPLOYABLE" in s or "NOT DEPLOYABLE" in s
+
+    def test_notes_are_populated(self):
+        result = _make_result(fps=500.0, memory_mb=10.0)
+        device = DEVICE_PRESETS["laptop_cpu"]
+        report = DeployabilityChecker().check(result, device)
+        assert len(report.notes) > 0
+
+
+# ---------------------------------------------------------------------------
+# check_all() multi-device sweep
+# ---------------------------------------------------------------------------
+
+class TestCheckAll:
+    def test_returns_dict_for_all_presets(self):
+        result = _make_result(fps=200.0, memory_mb=100.0)
+        reports = DeployabilityChecker().check_all(result)
+        assert set(reports.keys()) == set(DEVICE_PRESETS.keys())
+
+    def test_all_values_are_reports(self):
+        result = _make_result(fps=200.0, memory_mb=100.0)
+        reports = DeployabilityChecker().check_all(result)
+        for key, rpt in reports.items():
+            assert isinstance(rpt, DeployabilityReport), f"{key} did not return a report"
+
+    def test_custom_device_dict(self):
+        custom = {"dev_a": DeviceProfile(name="A", min_fps=10.0)}
+        result = _make_result(fps=100.0)
+        reports = DeployabilityChecker().check_all(result, devices=custom)
+        assert "dev_a" in reports
+        assert reports["dev_a"].deployable
+
+    def test_fast_tracker_deployable_on_all_devices(self):
+        result = _make_result(fps=1000.0, memory_mb=10.0)
+        reports = DeployabilityChecker().check_all(result)
+        for key, rpt in reports.items():
+            fps_checks = [c for c in rpt.constraint_results if c.name == "Mean FPS"]
+            mem_checks = [c for c in rpt.constraint_results if c.name == "Peak Memory"]
+            for c in fps_checks + mem_checks:
+                assert c.passed, f"Fast/tiny tracker should pass {c.name} on {key}"

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -1,0 +1,172 @@
+"""Unit tests for eovot.profiling.device_profiles."""
+
+import pytest
+
+from eovot.profiling.device_profiles import (
+    DeviceProfile,
+    get_profile,
+    list_profiles,
+    register_profile,
+    _REGISTRY,
+)
+
+
+# ---------------------------------------------------------------------------
+# DeviceProfile construction
+# ---------------------------------------------------------------------------
+
+class TestDeviceProfile:
+    def test_valid_construction(self):
+        p = DeviceProfile(
+            name="test-device",
+            display_name="Test Device",
+            device_class="edge-cpu",
+            tdp_watts=5.0,
+            ram_gb=2.0,
+            cpu_cores=4,
+            description="A test device",
+        )
+        assert p.tdp_watts == 5.0
+        assert p.device_class == "edge-cpu"
+        assert p.has_gpu is False
+
+    def test_invalid_device_class_raises(self):
+        with pytest.raises(ValueError, match="device_class"):
+            DeviceProfile(
+                name="bad",
+                display_name="Bad",
+                device_class="quantum-computer",
+                tdp_watts=5.0,
+            )
+
+    def test_non_positive_tdp_raises(self):
+        with pytest.raises(ValueError, match="tdp_watts"):
+            DeviceProfile(
+                name="zero-tdp",
+                display_name="Zero TDP",
+                device_class="laptop",
+                tdp_watts=0.0,
+            )
+
+    def test_to_dict_keys(self):
+        p = DeviceProfile(
+            name="x",
+            display_name="X",
+            device_class="server",
+            tdp_watts=200.0,
+        )
+        d = p.to_dict()
+        for key in ("name", "display_name", "device_class", "tdp_watts",
+                    "peak_power_w", "ram_gb", "cpu_cores", "has_gpu",
+                    "typical_fps_target", "description"):
+            assert key in d
+
+    def test_str_representation(self):
+        p = DeviceProfile(
+            name="rpi4-copy",
+            display_name="RPi4 copy",
+            device_class="edge-cpu",
+            tdp_watts=6.0,
+            has_gpu=False,
+        )
+        s = str(p)
+        assert "rpi4-copy" in s
+        assert "6.0" in s
+
+
+# ---------------------------------------------------------------------------
+# Built-in registry
+# ---------------------------------------------------------------------------
+
+class TestBuiltinRegistry:
+    def test_rpi4_exists(self):
+        p = get_profile("rpi4")
+        assert p.tdp_watts == 6.0
+        assert p.device_class == "edge-cpu"
+        assert p.has_gpu is False
+
+    def test_jetson_nano_exists(self):
+        p = get_profile("jetson-nano")
+        assert p.tdp_watts == 10.0
+        assert p.has_gpu is True
+        assert p.device_class == "edge-gpu"
+
+    def test_jetson_xavier_nx_exists(self):
+        p = get_profile("jetson-xavier-nx")
+        assert p.tdp_watts == 15.0
+        assert p.device_class == "edge-gpu"
+
+    def test_laptop_low_exists(self):
+        p = get_profile("laptop-low")
+        assert p.device_class == "laptop"
+        assert p.tdp_watts == 15.0
+
+    def test_desktop_cpu_exists(self):
+        p = get_profile("desktop-cpu")
+        assert p.device_class == "workstation"
+        assert p.tdp_watts >= 60.0
+
+    def test_server_cpu_exists(self):
+        p = get_profile("server-cpu")
+        assert p.device_class == "server"
+
+    def test_case_insensitive_lookup(self):
+        p1 = get_profile("RPI4")
+        p2 = get_profile("rpi4")
+        assert p1.name == p2.name
+
+    def test_unknown_profile_raises_key_error(self):
+        with pytest.raises(KeyError, match="not-a-real-device"):
+            get_profile("not-a-real-device")
+
+    def test_error_message_lists_available(self):
+        try:
+            get_profile("ghost-device")
+        except KeyError as exc:
+            assert "rpi4" in str(exc)
+
+    def test_all_built_in_profiles_are_valid(self):
+        for name, profile in list_profiles():
+            assert profile.tdp_watts > 0
+            assert profile.name == name
+            assert profile.display_name
+            assert profile.device_class in {
+                "edge-cpu", "edge-gpu", "laptop", "workstation", "server"
+            }
+
+    def test_list_profiles_returns_sorted(self):
+        names = [n for n, _ in list_profiles()]
+        assert names == sorted(names)
+
+    def test_list_profiles_non_empty(self):
+        assert len(list_profiles()) >= 10
+
+
+# ---------------------------------------------------------------------------
+# Custom profile registration
+# ---------------------------------------------------------------------------
+
+class TestRegisterProfile:
+    def test_register_and_retrieve(self):
+        custom = DeviceProfile(
+            name="_test-custom-board",
+            display_name="Custom Board",
+            device_class="edge-cpu",
+            tdp_watts=3.5,
+            description="Ephemeral test device",
+        )
+        register_profile(custom)
+        retrieved = get_profile("_test-custom-board")
+        assert retrieved.tdp_watts == 3.5
+        # Cleanup so other tests are not affected
+        del _REGISTRY["_test-custom-board"]
+
+    def test_duplicate_registration_raises(self):
+        dup = DeviceProfile(
+            name="rpi4",
+            display_name="Duplicate RPi4",
+            device_class="edge-cpu",
+            tdp_watts=6.0,
+        )
+        with pytest.raises(ValueError, match="already registered"):
+            register_profile(dup)


### PR DESCRIPTION
Closes #68

## What was added

### `eovot/profiling/device_profile.py` (new file)

**`DeviceProfile`** — dataclass encoding deployment constraints:
- `min_fps`, `max_memory_mb`, `tdp_watts`, `max_energy_per_frame_mj`
- `derived_max_latency_ms` property (computed from `min_fps` or explicit override)

**`DEVICE_PRESETS`** — registry of 6 built-in edge/desktop profiles:

| Key | Device | min FPS | max RAM | TDP |
|-----|--------|--------:|--------:|----:|
| `raspberry_pi4` | Raspberry Pi 4 | 15 | 256 MB | 6 W |
| `jetson_nano` | NVIDIA Jetson Nano | 25 | 512 MB | 10 W |
| `jetson_orin_nano` | NVIDIA Jetson Orin Nano | 30 | 1 GB | 15 W |
| `laptop_cpu` | Laptop CPU | 30 | 2 GB | 15 W |
| `desktop_cpu` | Desktop CPU | 60 | 8 GB | 65 W |
| `coral_usb` | Google Coral USB | 15 | 128 MB | 2.5 W |

**`DeployabilityChecker`** — evaluates a `BenchmarkResult` against a `DeviceProfile`:

```python
from eovot.profiling.device_profile import DEVICE_PRESETS, DeployabilityChecker

checker = DeployabilityChecker()
report = checker.check(result, DEVICE_PRESETS["raspberry_pi4"])
print(report)
```

```
DeployabilityReport — MOSSE on Raspberry Pi 4
  Verdict: DEPLOYABLE
  Constraints:
    [PASS] Mean FPS: measured=523.4 fps  limit=15.0 fps
    [PASS] Mean Latency: measured=1.9 ms  limit=66.7 ms
    [PASS] Peak Memory: measured=48.3 MB  limit=256.0 MB
  Notes:
    • All constraints satisfied — tracker is compatible with Raspberry Pi 4.
```

**`check_all()`** — sweeps all presets in a single call:
```python
reports = checker.check_all(result)
for device_key, report in reports.items():
    print(f"{device_key}: {'OK' if report.deployable else 'FAIL'}")
```

**`DeployabilityReport.summary_dict()`** — JSON-serialisable output for paper supplementary material.

### `configs/devices/` (new directory)

YAML profiles for three reference devices with deployment guidance, recommended trackers per device, and benchmark notes.

### `scripts/compare_trackers.py` (updated)

- Register all four trackers — CSRT and MedianFlow were previously missing
- Add `--device` flag: runs `DeployabilityChecker` and prints per-tracker + cross-tracker deployability table
- Integrate with existing `--device-profile` (sets TDP) and `--list-devices` flags
- Fix duplicate dataset construction inside the tracker loop

## Example CLI usage

```bash
# Compare all four trackers and check deployability on RPi4
python scripts/compare_trackers.py \
    --trackers MOSSE KCF CSRT MedianFlow \
    --dataset-root /data/OTB100 \
    --device raspberry_pi4

# Output at end:
# ============================================================
#   Deployability Summary for Raspberry Pi 4
# ============================================================
#   [OK  ]  MOSSE             FPS=523.4  mem=48 MB
#   [OK  ]  KCF               FPS=198.1  mem=51 MB
#   [FAIL]  CSRT              FPS=11.3   mem=55 MB
#   [OK  ]  MedianFlow        FPS=87.4   mem=49 MB
```

## Files changed

| File | Change |
|------|--------|
| `eovot/profiling/device_profile.py` | **New** — `DeviceProfile`, `DEVICE_PRESETS`, `DeployabilityChecker` |
| `tests/test_device_profile.py` | **New** — 35 tests |
| `configs/devices/raspberry_pi4.yaml` | **New** |
| `configs/devices/jetson_nano.yaml` | **New** |
| `configs/devices/laptop_cpu.yaml` | **New** |
| `scripts/compare_trackers.py` | Register all trackers; `--device` flag; fix duplicate dataset init |

## Test results

```
tests/test_device_profile.py    35 passed
tests/test_device_profiles.py   19 passed  (existing tests, still passing)
```

## Relation to existing `device_profiles.py`

The existing `device_profiles.py` provides `get_profile()` and `list_profiles()` — a lookup-oriented API for TDP auto-configuration. This PR adds the orthogonal *evaluation* API: given a finished benchmark result, does the tracker meet the device's constraints? Both modules coexist and complement each other.