### PR TITLE
[agent] Fix critical engine bugs and add hardware device profiles

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine, center_distance
+from ..profiling.energy import EnergyProfiler, EnergyResult
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
 
@@ -18,6 +19,7 @@ class SequenceResult:
     sequence_name: str
     ious: np.ndarray
     profiling: ProfilingResult
+    energy: Optional[EnergyResult] = None          # CPU energy estimate; None if not profiled
     predictions: Optional[np.ndarray] = None       # shape (N, 4) — predicted boxes
     ground_truths: Optional[np.ndarray] = None     # shape (N, 4) — GT boxes aligned to predictions
     center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
@@ -117,46 +119,6 @@ class BenchmarkResult:
             sequences.append(entry)
         return {"summary": self.summary(), "sequences": sequences}
 
-    def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        return {
-            "summary": self.summary(),
-            "sequences": [
-                {
-                    "sequence_name": sr.sequence_name,
-                    "mean_iou": round(sr.mean_iou, 4),
-                    "fps": round(sr.profiling.fps, 2),
-                    "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                    "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-                }
-                for sr in self.sequence_results
-            ],
-        }
-
-    def to_dict(self) -> Dict:
-        """Serialize the full result to a dict compatible with :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a nested dict with keys ``"summary"`` (aggregate metrics)
-        and ``"sequences"`` (per-sequence breakdown), suitable for JSON
-        export and Markdown table generation.
-        """
-        sequences = [
-            {
-                "sequence_name": r.sequence_name,
-                "mean_iou": round(r.mean_iou, 4),
-                "fps": round(r.profiling.fps, 2),
-                "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
-                "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
-            }
-            for r in self.sequence_results
-        ]
-        return {"summary": self.summary(), "sequences": sequences}
 
     def __str__(self) -> str:
         s = self.summary()
@@ -275,6 +237,7 @@ class BenchmarkEngine:
             sequence_name=seq.name,
             ious=ious,
             profiling=self._profiler.summary(tracker.name),
+            energy=energy,
             predictions=preds_eval,
             ground_truths=gt_eval,
             center_distances=dists,

--- a/eovot/datasets/got10k.py
+++ b/eovot/datasets/got10k.py
@@ -162,8 +162,6 @@ class GOT10kDataset(BaseDataset):
     def name(self) -> str:
         return f"GOT-10k-{self.split}"
 
-        return Sequence(name=seq_name, frame_paths=frame_paths_str, ground_truth=gt_array)
-
     @staticmethod
     def _load_groundtruth(gt_file: Path) -> List[BBox]:
         """Parse ``groundtruth.txt`` into a list of ``(x, y, w, h)`` tuples.

--- a/eovot/profiling/__init__.py
+++ b/eovot/profiling/__init__.py
@@ -2,5 +2,40 @@
 
 from .profiler import Profiler, ProfilingResult
 from .energy import EnergyProfiler, EnergyResult
+from .device_profiles import (
+    DeviceProfile,
+    EdgeComplianceReport,
+    Criterion,
+    ALL_PROFILES,
+    PROFILE_REGISTRY,
+    RASPBERRY_PI_4B,
+    JETSON_NANO,
+    JETSON_ORIN_NANO,
+    INTEL_NUC,
+    LAPTOP_MID,
+    DESKTOP_SERVER,
+    get_profile,
+    assess_edge_compliance,
+    compliance_matrix,
+)
 
-__all__ = ["Profiler", "ProfilingResult", "EnergyProfiler", "EnergyResult"]
+__all__ = [
+    "Profiler",
+    "ProfilingResult",
+    "EnergyProfiler",
+    "EnergyResult",
+    "DeviceProfile",
+    "EdgeComplianceReport",
+    "Criterion",
+    "ALL_PROFILES",
+    "PROFILE_REGISTRY",
+    "RASPBERRY_PI_4B",
+    "JETSON_NANO",
+    "JETSON_ORIN_NANO",
+    "INTEL_NUC",
+    "LAPTOP_MID",
+    "DESKTOP_SERVER",
+    "get_profile",
+    "assess_edge_compliance",
+    "compliance_matrix",
+]

--- a/eovot/profiling/device_profiles.py
+++ b/eovot/profiling/device_profiles.py
@@ -1,0 +1,306 @@
+"""Hardware device profiles for edge-aware benchmarking.
+
+Pre-configured profiles for common edge and embedded computing platforms.
+Use :func:`assess_edge_compliance` to evaluate whether a tracker's measured
+performance fits within the resource envelope of a target device.
+
+Example::
+
+    from eovot.profiling.device_profiles import JETSON_NANO, assess_edge_compliance
+
+    report = assess_edge_compliance(benchmark_result, JETSON_NANO)
+    print(report)
+    if report.compliant:
+        print(f"{benchmark_result.tracker_name} is deployable on {JETSON_NANO.name}")
+
+Reference:
+    Redmon & Farhadi, "YOLO9000: Better, Faster, Stronger." CVPR 2017 —
+    motivates FPS-first design for real-time embedded vision systems.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class DeviceProfile:
+    """Hardware specification for an edge or embedded computing device.
+
+    Attributes:
+        name: Human-readable device name (e.g. ``"Raspberry Pi 4B"``).
+        tdp_watts: CPU/SoC Thermal Design Power (W).
+        ram_mb: Total available system RAM (MB).
+        target_fps: Minimum acceptable tracking throughput (frames/sec).
+        max_memory_mb: Maximum allowable peak RSS memory for the tracker (MB).
+        max_energy_per_frame_mj: Per-frame energy budget (mJ).
+            ``None`` means this device imposes no energy constraint.
+        description: Optional free-form notes (ISA, OS, typical use-case).
+    """
+
+    name: str
+    tdp_watts: float
+    ram_mb: int
+    target_fps: float
+    max_memory_mb: float
+    max_energy_per_frame_mj: Optional[float] = None
+    description: str = ""
+
+    def __str__(self) -> str:
+        return (
+            f"DeviceProfile[{self.name}] "
+            f"TDP={self.tdp_watts}W  RAM={self.ram_mb}MB  "
+            f"target_fps≥{self.target_fps}  mem≤{self.max_memory_mb}MB"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pre-configured device profiles (ordered most → least constrained)
+# ---------------------------------------------------------------------------
+
+RASPBERRY_PI_4B = DeviceProfile(
+    name="Raspberry Pi 4B",
+    tdp_watts=6.4,
+    ram_mb=4096,
+    target_fps=15.0,
+    max_memory_mb=512.0,
+    max_energy_per_frame_mj=5.0,
+    description="ARM Cortex-A72 quad-core @ 1.5 GHz, 4 GB LPDDR4",
+)
+
+JETSON_NANO = DeviceProfile(
+    name="NVIDIA Jetson Nano",
+    tdp_watts=10.0,
+    ram_mb=4096,
+    target_fps=25.0,
+    max_memory_mb=768.0,
+    max_energy_per_frame_mj=8.0,
+    description="ARM Cortex-A57 quad-core + 128-core Maxwell GPU, 4 GB LPDDR4",
+)
+
+JETSON_ORIN_NANO = DeviceProfile(
+    name="NVIDIA Jetson Orin Nano",
+    tdp_watts=15.0,
+    ram_mb=8192,
+    target_fps=60.0,
+    max_memory_mb=1536.0,
+    max_energy_per_frame_mj=4.0,
+    description="6-core Cortex-A78AE + 1024-core Ampere GPU, 8 GB LPDDR5",
+)
+
+INTEL_NUC = DeviceProfile(
+    name="Intel NUC (Core i5)",
+    tdp_watts=28.0,
+    ram_mb=16384,
+    target_fps=60.0,
+    max_memory_mb=2048.0,
+    max_energy_per_frame_mj=20.0,
+    description="Intel Core i5-1235U, 16 GB DDR4, compact embedded PC",
+)
+
+LAPTOP_MID = DeviceProfile(
+    name="Mid-range Laptop",
+    tdp_watts=45.0,
+    ram_mb=16384,
+    target_fps=60.0,
+    max_memory_mb=4096.0,
+    max_energy_per_frame_mj=40.0,
+    description="Intel Core i7 / Ryzen 7 class, typical research workstation",
+)
+
+DESKTOP_SERVER = DeviceProfile(
+    name="Desktop / Server",
+    tdp_watts=125.0,
+    ram_mb=65536,
+    target_fps=120.0,
+    max_memory_mb=16384.0,
+    max_energy_per_frame_mj=None,
+    description="High-end desktop or cloud instance — no energy budget constraint",
+)
+
+ALL_PROFILES: List[DeviceProfile] = [
+    RASPBERRY_PI_4B,
+    JETSON_NANO,
+    JETSON_ORIN_NANO,
+    INTEL_NUC,
+    LAPTOP_MID,
+    DESKTOP_SERVER,
+]
+
+PROFILE_REGISTRY: Dict[str, DeviceProfile] = {p.name: p for p in ALL_PROFILES}
+
+
+def get_profile(name: str) -> DeviceProfile:
+    """Look up a device profile by name (case-insensitive substring match).
+
+    Args:
+        name: Device name or unambiguous substring (e.g. ``"jetson nano"``).
+
+    Returns:
+        Matching :class:`DeviceProfile`.
+
+    Raises:
+        KeyError: If no profile matches.
+    """
+    key = name.strip().lower()
+    for profile_name, profile in PROFILE_REGISTRY.items():
+        if key == profile_name.lower() or key in profile_name.lower():
+            return profile
+    raise KeyError(
+        f"No device profile matches '{name}'. "
+        f"Available: {list(PROFILE_REGISTRY.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compliance assessment
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Criterion:
+    """Result of a single edge-compliance check."""
+
+    name: str
+    passed: bool
+    measured: float
+    threshold: float
+    unit: str
+
+    def __str__(self) -> str:
+        status = "PASS" if self.passed else "FAIL"
+        op = "≥" if "fps" in self.name.lower() else "≤"
+        return (
+            f"[{status}] {self.name}: "
+            f"{self.measured:.2f} {self.unit} "
+            f"(required {op} {self.threshold:.2f} {self.unit})"
+        )
+
+
+@dataclass
+class EdgeComplianceReport:
+    """Summary of whether a tracker satisfies a device's resource constraints.
+
+    Attributes:
+        tracker_name: Name of the evaluated tracker.
+        device: Target :class:`DeviceProfile`.
+        criteria: Individual pass/fail results for each constraint.
+    """
+
+    tracker_name: str
+    device: DeviceProfile
+    criteria: List[Criterion] = field(default_factory=list)
+
+    @property
+    def compliant(self) -> bool:
+        """``True`` if every criterion passed."""
+        return all(c.passed for c in self.criteria)
+
+    @property
+    def n_passed(self) -> int:
+        return sum(c.passed for c in self.criteria)
+
+    def __str__(self) -> str:
+        status = "COMPLIANT ✓" if self.compliant else "NON-COMPLIANT ✗"
+        lines = [
+            f"EdgeComplianceReport — {self.tracker_name} on {self.device.name}",
+            f"Overall: {status} ({self.n_passed}/{len(self.criteria)} criteria passed)",
+            "-" * 60,
+        ]
+        for c in self.criteria:
+            lines.append(f"  {c}")
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        return {
+            "tracker_name": self.tracker_name,
+            "device": self.device.name,
+            "compliant": self.compliant,
+            "n_passed": self.n_passed,
+            "n_criteria": len(self.criteria),
+            "criteria": [
+                {
+                    "name": c.name,
+                    "passed": c.passed,
+                    "measured": round(c.measured, 4),
+                    "threshold": c.threshold,
+                    "unit": c.unit,
+                }
+                for c in self.criteria
+            ],
+        }
+
+
+def assess_edge_compliance(benchmark_result, device: DeviceProfile) -> EdgeComplianceReport:
+    """Assess whether a benchmark result satisfies *device*'s constraints.
+
+    Checks the following criteria:
+
+    1. **Throughput** — mean FPS ≥ ``device.target_fps``
+    2. **Peak Memory** — peak RSS ≤ ``device.max_memory_mb``
+    3. **Energy/Frame** — mean energy per frame ≤ ``device.max_energy_per_frame_mj``
+       (only when the result contains energy data *and* the device specifies a budget)
+
+    Args:
+        benchmark_result: A :class:`~eovot.benchmark.engine.BenchmarkResult`
+            returned by :class:`~eovot.benchmark.engine.BenchmarkEngine`.
+        device: Target :class:`DeviceProfile`.
+
+    Returns:
+        :class:`EdgeComplianceReport` with per-criterion verdicts.
+    """
+    report = EdgeComplianceReport(tracker_name=benchmark_result.tracker_name, device=device)
+
+    fps = benchmark_result.mean_fps
+    report.criteria.append(Criterion(
+        name="Throughput (FPS)",
+        passed=fps >= device.target_fps,
+        measured=fps,
+        threshold=device.target_fps,
+        unit="fps",
+    ))
+
+    mem = benchmark_result.peak_memory_mb
+    report.criteria.append(Criterion(
+        name="Peak Memory",
+        passed=mem <= device.max_memory_mb,
+        measured=mem,
+        threshold=device.max_memory_mb,
+        unit="MB",
+    ))
+
+    energy_mj = benchmark_result.mean_energy_per_frame_mj
+    if energy_mj is not None and device.max_energy_per_frame_mj is not None:
+        report.criteria.append(Criterion(
+            name="Energy/Frame",
+            passed=energy_mj <= device.max_energy_per_frame_mj,
+            measured=energy_mj,
+            threshold=device.max_energy_per_frame_mj,
+            unit="mJ",
+        ))
+
+    return report
+
+
+def compliance_matrix(
+    benchmark_results: list,
+    devices: Optional[List[DeviceProfile]] = None,
+) -> List[List[EdgeComplianceReport]]:
+    """Compute a compliance matrix for multiple trackers × multiple devices.
+
+    Args:
+        benchmark_results: List of
+            :class:`~eovot.benchmark.engine.BenchmarkResult` objects.
+        devices: Target :class:`DeviceProfile` list.
+            Defaults to :data:`ALL_PROFILES`.
+
+    Returns:
+        2-D list ``matrix[tracker_idx][device_idx]`` of
+        :class:`EdgeComplianceReport` objects.
+    """
+    if devices is None:
+        devices = ALL_PROFILES
+    return [
+        [assess_edge_compliance(br, dev) for dev in devices]
+        for br in benchmark_results
+    ]

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -1,0 +1,240 @@
+"""Tests for eovot.profiling.device_profiles."""
+from __future__ import annotations
+
+import pytest
+import numpy as np
+
+from eovot.profiling.device_profiles import (
+    ALL_PROFILES,
+    DESKTOP_SERVER,
+    INTEL_NUC,
+    JETSON_NANO,
+    JETSON_ORIN_NANO,
+    LAPTOP_MID,
+    PROFILE_REGISTRY,
+    RASPBERRY_PI_4B,
+    Criterion,
+    DeviceProfile,
+    EdgeComplianceReport,
+    assess_edge_compliance,
+    compliance_matrix,
+    get_profile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs — avoids importing the full benchmark engine in unit tests
+# ---------------------------------------------------------------------------
+
+class _ProfilingStub:
+    def __init__(self, fps: float = 30.0, peak_memory_mb: float = 256.0):
+        self.fps = fps
+        self.peak_memory_mb = peak_memory_mb
+        self.latency_mean_ms = 1000.0 / fps if fps > 0 else 0.0
+
+
+class _SequenceStub:
+    def __init__(self, fps: float = 30.0, peak_memory_mb: float = 256.0):
+        self.ious = np.array([0.6])
+        self.profiling = _ProfilingStub(fps, peak_memory_mb)
+        self.energy = None
+
+
+class _BenchmarkResultStub:
+    def __init__(
+        self,
+        tracker_name: str = "test_tracker",
+        fps: float = 30.0,
+        peak_memory_mb: float = 256.0,
+        energy_per_frame_mj: float | None = None,
+        n_seq: int = 5,
+    ):
+        self.tracker_name = tracker_name
+        self.dataset_name = "test"
+        self.sequence_results = [
+            _SequenceStub(fps=fps, peak_memory_mb=peak_memory_mb) for _ in range(n_seq)
+        ]
+        self._energy_per_frame_mj = energy_per_frame_mj
+
+    @property
+    def mean_fps(self) -> float:
+        return np.mean([s.profiling.fps for s in self.sequence_results])
+
+    @property
+    def peak_memory_mb(self) -> float:
+        return max(s.profiling.peak_memory_mb for s in self.sequence_results)
+
+    @property
+    def mean_energy_per_frame_mj(self) -> float | None:
+        return self._energy_per_frame_mj
+
+
+# ---------------------------------------------------------------------------
+# Tests — DeviceProfile
+# ---------------------------------------------------------------------------
+
+class TestDeviceProfile:
+    def test_all_profiles_count(self):
+        assert len(ALL_PROFILES) == 6
+
+    def test_registry_keys_match_names(self):
+        for name, profile in PROFILE_REGISTRY.items():
+            assert name == profile.name
+
+    def test_all_profiles_positive_tdp(self):
+        for p in ALL_PROFILES:
+            assert p.tdp_watts > 0, f"{p.name} has non-positive TDP"
+
+    def test_all_profiles_positive_target_fps(self):
+        for p in ALL_PROFILES:
+            assert p.target_fps > 0, f"{p.name} has non-positive target_fps"
+
+    def test_raspberry_pi_4b_values(self):
+        assert RASPBERRY_PI_4B.tdp_watts == pytest.approx(6.4)
+        assert RASPBERRY_PI_4B.ram_mb == 4096
+        assert RASPBERRY_PI_4B.target_fps == pytest.approx(15.0)
+        assert RASPBERRY_PI_4B.max_energy_per_frame_mj is not None
+
+    def test_jetson_nano_values(self):
+        assert JETSON_NANO.tdp_watts == pytest.approx(10.0)
+        assert JETSON_NANO.target_fps == pytest.approx(25.0)
+
+    def test_desktop_no_energy_budget(self):
+        assert DESKTOP_SERVER.max_energy_per_frame_mj is None
+
+    def test_device_profile_str(self):
+        s = str(RASPBERRY_PI_4B)
+        assert "Raspberry Pi" in s
+        assert "TDP=" in s
+
+    def test_profiles_are_frozen(self):
+        with pytest.raises((AttributeError, TypeError)):
+            RASPBERRY_PI_4B.tdp_watts = 999.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Tests — get_profile
+# ---------------------------------------------------------------------------
+
+class TestGetProfile:
+    def test_exact_match(self):
+        assert get_profile("Raspberry Pi 4B") is RASPBERRY_PI_4B
+
+    def test_substring_match_lower(self):
+        assert get_profile("jetson nano") is JETSON_NANO
+
+    def test_substring_orin(self):
+        assert get_profile("Orin") is JETSON_ORIN_NANO
+
+    def test_unknown_raises_keyerror(self):
+        with pytest.raises(KeyError):
+            get_profile("nonexistent device xyz")
+
+
+# ---------------------------------------------------------------------------
+# Tests — assess_edge_compliance
+# ---------------------------------------------------------------------------
+
+class TestEdgeCompliance:
+    def _result(self, fps: float = 50.0, mem: float = 200.0, energy_mj: float | None = None):
+        return _BenchmarkResultStub(fps=fps, peak_memory_mb=mem, energy_per_frame_mj=energy_mj)
+
+    def test_compliant_tracker(self):
+        result = self._result(fps=100.0, mem=100.0)
+        report = assess_edge_compliance(result, JETSON_NANO)
+        assert report.compliant is True
+        assert report.n_passed == len(report.criteria)
+
+    def test_fps_failure(self):
+        result = self._result(fps=5.0, mem=100.0)
+        report = assess_edge_compliance(result, JETSON_NANO)
+        assert report.compliant is False
+        fps_crit = next(c for c in report.criteria if "FPS" in c.name)
+        assert not fps_crit.passed
+
+    def test_memory_failure(self):
+        result = self._result(fps=100.0, mem=9999.0)
+        report = assess_edge_compliance(result, JETSON_NANO)
+        assert report.compliant is False
+        mem_crit = next(c for c in report.criteria if "Memory" in c.name)
+        assert not mem_crit.passed
+
+    def test_energy_criterion_included_when_available(self):
+        result = self._result(fps=100.0, mem=100.0, energy_mj=2.0)
+        report = assess_edge_compliance(result, RASPBERRY_PI_4B)
+        names = [c.name for c in report.criteria]
+        assert "Energy/Frame" in names
+
+    def test_energy_criterion_absent_without_energy_data(self):
+        result = self._result(fps=100.0, mem=100.0, energy_mj=None)
+        report = assess_edge_compliance(result, RASPBERRY_PI_4B)
+        names = [c.name for c in report.criteria]
+        assert "Energy/Frame" not in names
+
+    def test_energy_criterion_absent_when_device_unconstrained(self):
+        result = self._result(fps=200.0, mem=100.0, energy_mj=50.0)
+        report = assess_edge_compliance(result, DESKTOP_SERVER)
+        names = [c.name for c in report.criteria]
+        assert "Energy/Frame" not in names
+
+    def test_energy_failure(self):
+        result = self._result(fps=100.0, mem=100.0, energy_mj=100.0)
+        report = assess_edge_compliance(result, RASPBERRY_PI_4B)
+        e_crit = next(c for c in report.criteria if "Energy" in c.name)
+        assert e_crit.passed is False
+
+    def test_report_str_contains_status(self):
+        result = self._result(fps=50.0, mem=200.0)
+        report = assess_edge_compliance(result, RASPBERRY_PI_4B)
+        s = str(report)
+        assert "COMPLIANT" in s or "NON-COMPLIANT" in s
+
+    def test_report_to_dict_structure(self):
+        result = self._result(fps=50.0, mem=200.0)
+        report = assess_edge_compliance(result, LAPTOP_MID)
+        d = report.to_dict()
+        assert d["tracker_name"] == result.tracker_name
+        assert d["device"] == LAPTOP_MID.name
+        assert isinstance(d["compliant"], bool)
+        assert isinstance(d["criteria"], list)
+        assert d["n_criteria"] == len(report.criteria)
+
+
+# ---------------------------------------------------------------------------
+# Tests — compliance_matrix
+# ---------------------------------------------------------------------------
+
+class TestComplianceMatrix:
+    def test_shape(self):
+        results = [
+            _BenchmarkResultStub("fast", fps=100.0, peak_memory_mb=100.0),
+            _BenchmarkResultStub("slow", fps=5.0, peak_memory_mb=900.0),
+        ]
+        devices = [RASPBERRY_PI_4B, JETSON_NANO]
+        matrix = compliance_matrix(results, devices=devices)
+        assert len(matrix) == 2
+        assert all(len(row) == 2 for row in matrix)
+
+    def test_default_devices(self):
+        results = [_BenchmarkResultStub("tracker")]
+        matrix = compliance_matrix(results)
+        assert len(matrix[0]) == len(ALL_PROFILES)
+
+    def test_report_types(self):
+        results = [_BenchmarkResultStub("tracker")]
+        matrix = compliance_matrix(results, devices=[JETSON_NANO])
+        assert isinstance(matrix[0][0], EdgeComplianceReport)
+
+
+# ---------------------------------------------------------------------------
+# Tests — Criterion
+# ---------------------------------------------------------------------------
+
+class TestCriterion:
+    def test_pass_str(self):
+        c = Criterion("Throughput (FPS)", passed=True, measured=30.0, threshold=25.0, unit="fps")
+        assert "PASS" in str(c)
+
+    def test_fail_str(self):
+        c = Criterion("Peak Memory", passed=False, measured=900.0, threshold=512.0, unit="MB")
+        assert "FAIL" in str(c)


### PR DESCRIPTION
## What was added

### Bug Fixes (`eovot/benchmark/engine.py`)

Three bugs that caused silent runtime failures:

1. **Missing imports** — `EnergyProfiler` and `EnergyResult` were referenced in `BenchmarkEngine.__init__` and `_run_sequence` but never imported. Any call with `tdp_watts` set would raise `NameError`.

2. **Missing `energy` field on `SequenceResult`** — `BenchmarkResult.total_energy_j` and `mean_energy_per_frame_mj` iterate over `r.energy`, but `SequenceResult` had no such field. Added `energy: Optional[EnergyResult] = None` as a proper dataclass field.

3. **`_run_sequence` dropped energy data** — Even with the profiler running, the constructed `SequenceResult` never received the `energy` result. Added `energy=energy` to the constructor call.

4. **Three duplicate `to_dict()` methods** — Python silently uses the last definition, discarding the first two (including the one that serialises energy fields correctly). Removed the two redundant definitions, keeping the canonical implementation that correctly includes `energy_j` and `energy_per_frame_mj` in the output.

### Bug Fix (`eovot/datasets/got10k.py`)

5. **Unreachable code after `return`** — `GOT10kDataset.name` had a dead `return Sequence(...)` statement after its actual `return f"GOT-10k-{self.split}"`, which would raise a `NameError` if ever reached and confused linters/type-checkers. Removed the dead line.

---

### New Feature: Hardware Device Profiles (`eovot/profiling/device_profiles.py`)

Adds `DeviceProfile` — a frozen dataclass defining the resource envelope of an edge deployment target — and six pre-configured profiles:

| Device | TDP | RAM | Target FPS | Max Mem |
|--------|-----|-----|-----------|---------|
| Raspberry Pi 4B | 6.4 W | 4 GB | ≥ 15 fps | 512 MB |
| NVIDIA Jetson Nano | 10 W | 4 GB | ≥ 25 fps | 768 MB |
| NVIDIA Jetson Orin Nano | 15 W | 8 GB | ≥ 60 fps | 1536 MB |
| Intel NUC (Core i5) | 28 W | 16 GB | ≥ 60 fps | 2048 MB |
| Mid-range Laptop | 45 W | 16 GB | ≥ 60 fps | 4096 MB |
| Desktop / Server | 125 W | 64 GB | ≥ 120 fps | 16384 MB |

Key functions:
- `assess_edge_compliance(benchmark_result, device)` → `EdgeComplianceReport` with per-criterion PASS/FAIL verdicts for throughput, memory, and energy
- `compliance_matrix(results, devices)` → 2-D grid over trackers × devices
- `get_profile(name)` → case-insensitive substring lookup

All device profile symbols are exported from `eovot/profiling/__init__.py`.

---

## Why it matters

- The engine bugs meant energy profiling was silently broken: `BenchmarkEngine(tdp_watts=6.0).run(...)` would raise `NameError` or produce incorrect JSON output.
- `DeviceProfile` closes the "last mile" gap between benchmark numbers and deployment decisions: researchers can now programmatically answer "can this tracker run on a Jetson Nano?" without manual calculation.
- The compliance matrix enables systematic cross-platform evaluation tables for papers.

## Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.profiling.device_profiles import JETSON_NANO, assess_edge_compliance

engine = BenchmarkEngine(verbose=True, tdp_watts=JETSON_NANO.tdp_watts)
result = engine.run(tracker, dataset, dataset_name="OTB-100")

report = assess_edge_compliance(result, JETSON_NANO)
print(report)
# EdgeComplianceReport — MOSSE on NVIDIA Jetson Nano
# Overall: COMPLIANT ✓ (3/3 criteria passed)
# ----------------------------------------------------------
#   [PASS] Throughput (FPS): 482.30 fps (required ≥ 25.00 fps)
#   [PASS] Peak Memory: 38.12 MB (required ≤ 768.00 MB)
#   [PASS] Energy/Frame: 0.42 mJ (required ≤ 8.00 mJ)
```

## Tests

27 new unit tests in `tests/test_device_profiles.py` covering profiles, compliance assessment, and the compliance matrix. All pass.

## No breaking changes

All additions are purely additive. Existing public APIs are unchanged.