### PR TITLE
[fix] Energy profiling integration + normalized precision metric (LaSOT protocol)

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine, center_distance
+from ..profiling.energy import EnergyProfiler, EnergyResult
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
 
@@ -21,6 +22,7 @@ class SequenceResult:
     predictions: Optional[np.ndarray] = None       # shape (N, 4) — predicted boxes
     ground_truths: Optional[np.ndarray] = None     # shape (N, 4) — GT boxes aligned to predictions
     center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
+    energy: Optional[EnergyResult] = None          # CPU energy estimate (None when TDP not set)
 
     @property
     def mean_iou(self) -> float:
@@ -92,70 +94,35 @@ class BenchmarkResult:
         mcd = self.mean_center_distance
         if mcd is not None:
             d["mean_center_distance_px"] = round(mcd, 3)
+        total_e = self.total_energy_j
+        if total_e is not None:
+            d["total_energy_j"] = round(total_e, 4)
+        mean_e = self.mean_energy_per_frame_mj
+        if mean_e is not None:
+            d["mean_energy_per_frame_mj"] = round(mean_e, 4)
         return d
-
-    def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        sequences = []
-        for sr in self.sequence_results:
-            entry: Dict = {
-                "sequence_name": sr.sequence_name,
-                "mean_iou": round(sr.mean_iou, 4),
-                "fps": round(sr.profiling.fps, 2),
-                "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-            }
-            if sr.energy is not None:
-                entry["energy_j"] = round(sr.energy.total_energy_j, 6)
-                entry["energy_per_frame_mj"] = round(sr.energy.energy_per_frame_mj, 4)
-            sequences.append(entry)
-        return {"summary": self.summary(), "sequences": sequences}
-
-    def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        return {
-            "summary": self.summary(),
-            "sequences": [
-                {
-                    "sequence_name": sr.sequence_name,
-                    "mean_iou": round(sr.mean_iou, 4),
-                    "fps": round(sr.profiling.fps, 2),
-                    "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                    "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-                }
-                for sr in self.sequence_results
-            ],
-        }
 
     def to_dict(self) -> Dict:
         """Serialize the full result to a dict compatible with :class:`~eovot.reporting.reporter.BenchmarkReporter`.
 
         Returns a nested dict with keys ``"summary"`` (aggregate metrics)
         and ``"sequences"`` (per-sequence breakdown), suitable for JSON
-        export and Markdown table generation.
+        export and Markdown table generation.  Energy fields are included
+        per-sequence when energy profiling was enabled.
         """
-        sequences = [
-            {
+        sequences = []
+        for r in self.sequence_results:
+            entry: Dict = {
                 "sequence_name": r.sequence_name,
                 "mean_iou": round(r.mean_iou, 4),
                 "fps": round(r.profiling.fps, 2),
                 "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
                 "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
             }
-            for r in self.sequence_results
-        ]
+            if r.energy is not None:
+                entry["energy_j"] = round(r.energy.total_energy_j, 6)
+                entry["energy_per_frame_mj"] = round(r.energy.energy_per_frame_mj, 4)
+            sequences.append(entry)
         return {"summary": self.summary(), "sequences": sequences}
 
     def __str__(self) -> str:
@@ -278,4 +245,5 @@ class BenchmarkEngine:
             predictions=preds_eval,
             ground_truths=gt_eval,
             center_distances=dists,
+            energy=energy,
         )

--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -3,8 +3,15 @@
 from .accuracy import (
     iou,
     center_distance,
+    normalized_center_distance,
     AccuracyMetrics,
     MetricsEngine,
 )
 
-__all__ = ["iou", "center_distance", "AccuracyMetrics", "MetricsEngine"]
+__all__ = [
+    "iou",
+    "center_distance",
+    "normalized_center_distance",
+    "AccuracyMetrics",
+    "MetricsEngine",
+]

--- a/eovot/metrics/accuracy.py
+++ b/eovot/metrics/accuracy.py
@@ -66,6 +66,35 @@ def center_distance(pred: BBox, gt: BBox) -> float:
     return float(np.sqrt(dx * dx + dy * dy))
 
 
+def normalized_center_distance(pred: BBox, gt: BBox) -> float:
+    """Centre distance normalised by the GT box diagonal (LaSOT protocol).
+
+    Dividing by the GT diagonal makes the metric invariant to object size
+    and image resolution, enabling fair comparison across sequences with
+    differently-sized targets.
+
+    Args:
+        pred: Predicted box ``(x, y, w, h)``.
+        gt:   Ground-truth box ``(x, y, w, h)``.
+
+    Returns:
+        Normalised distance in ``[0, ∞)``.  Returns ``0.0`` when the GT
+        box has zero area (degenerate case).
+
+    Reference:
+        Fan et al., "LaSOT: A High-quality Benchmark for Large-scale
+        Single Object Tracking." CVPR 2019.
+    """
+    px, py, pw, ph = pred
+    gx, gy, gw, gh = gt
+    diagonal = float(np.sqrt(gw * gw + gh * gh))
+    if diagonal <= 0.0:
+        return 0.0
+    dx = (px + pw / 2) - (gx + gw / 2)
+    dy = (py + ph / 2) - (gy + gh / 2)
+    return float(np.sqrt(dx * dx + dy * dy) / diagonal)
+
+
 @dataclass
 class AccuracyMetrics:
     """Scalar accuracy summary for a tracker on a dataset or sequence."""
@@ -79,12 +108,18 @@ class AccuracyMetrics:
     precision_auc: float
     """Normalised AUC of the Precision Curve (distance thresholds 0 → 50 px)."""
 
+    norm_precision_auc: float = 0.0
+    """Normalised AUC of the Normalised Precision Curve (LaSOT protocol,
+    distance thresholds 0 → 0.5 of GT diagonal).  Comparable across
+    sequences with different target sizes and image resolutions."""
+
     def __str__(self) -> str:
         return (
             f"AccuracyMetrics("
             f"mIoU={self.mean_iou:.4f}, "
             f"success_AUC={self.success_auc:.4f}, "
-            f"precision_AUC={self.precision_auc:.4f})"
+            f"precision_AUC={self.precision_auc:.4f}, "
+            f"norm_precision_AUC={self.norm_precision_auc:.4f})"
         )
 
 
@@ -162,6 +197,40 @@ class MetricsEngine:
         rates = np.array([(dists < t).mean() for t in thresholds])
         return thresholds, rates
 
+    def norm_precision_curve(
+        self,
+        preds: np.ndarray,
+        gts: np.ndarray,
+        thresholds: Optional[np.ndarray] = None,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Normalised precision curve following the LaSOT evaluation protocol.
+
+        Centre distance is normalised by the diagonal of the GT bounding box,
+        making the metric independent of object size and image resolution.
+
+        Args:
+            preds:      ``(N, 4)`` predicted boxes in ``(x, y, w, h)`` format.
+            gts:        ``(N, 4)`` ground-truth boxes in ``(x, y, w, h)`` format.
+            thresholds: Normalised distance thresholds (default: 0 → 0.5 in
+                        51 steps, matching the LaSOT paper convention).
+
+        Returns:
+            ``(thresholds, precision_rates)`` — both shape ``(T,)``.
+
+        Reference:
+            Fan et al., "LaSOT: A High-quality Benchmark for Large-scale
+            Single Object Tracking." CVPR 2019.
+        """
+        if thresholds is None:
+            thresholds = np.linspace(0.0, 0.5, 51)
+        n = min(len(preds), len(gts))
+        norm_dists = np.array(
+            [normalized_center_distance(tuple(preds[i]), tuple(gts[i]))  # type: ignore[arg-type]
+             for i in range(n)]
+        )
+        rates = np.array([(norm_dists < t).mean() for t in thresholds])
+        return thresholds, rates
+
     def compute_all(
         self,
         preds: np.ndarray,
@@ -191,8 +260,12 @@ class MetricsEngine:
         thr_dist, pr = self.precision_curve(preds, gts)
         prec_auc = float(_trapz(pr, thr_dist) / thr_dist[-1]) if thr_dist[-1] > 0 else 0.0
 
+        thr_norm, npr = self.norm_precision_curve(preds, gts)
+        norm_prec_auc = float(_trapz(npr, thr_norm) / thr_norm[-1]) if thr_norm[-1] > 0 else 0.0
+
         return AccuracyMetrics(
             mean_iou=float(ious.mean()),
             success_auc=success_auc,
             precision_auc=prec_auc,
+            norm_precision_auc=norm_prec_auc,
         )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -209,3 +209,47 @@ class TestBenchmarkEngine:
         result = self.engine.run(tracker, self.dataset, dataset_name="Synthetic")
         assert result.mean_center_distance is not None
         assert result.mean_center_distance > 0.0
+
+
+class TestBenchmarkEngineEnergy:
+    """Tests for energy profiling integration (requires tdp_watts != None)."""
+
+    def setup_method(self):
+        self.tracker = ConstantTracker(FIXED_BOX)
+        self.dataset = SyntheticDataset(n_sequences=2)
+
+    def test_energy_none_without_tdp(self):
+        engine = BenchmarkEngine(verbose=False)
+        result = engine.run(self.tracker, self.dataset, dataset_name="Synthetic")
+        assert result.total_energy_j is None
+        for sr in result.sequence_results:
+            assert sr.energy is None
+
+    def test_energy_populated_with_tdp(self):
+        engine = BenchmarkEngine(verbose=False, tdp_watts=15.0)
+        result = engine.run(self.tracker, self.dataset, dataset_name="Synthetic")
+        assert result.total_energy_j is not None
+        assert result.total_energy_j >= 0.0
+        for sr in result.sequence_results:
+            assert sr.energy is not None
+
+    def test_energy_per_frame_populated(self):
+        engine = BenchmarkEngine(verbose=False, tdp_watts=10.0)
+        result = engine.run(self.tracker, self.dataset, dataset_name="Synthetic")
+        assert result.mean_energy_per_frame_mj is not None
+        assert result.mean_energy_per_frame_mj >= 0.0
+
+    def test_energy_included_in_summary(self):
+        engine = BenchmarkEngine(verbose=False, tdp_watts=15.0)
+        result = engine.run(self.tracker, self.dataset, dataset_name="Synthetic")
+        s = result.summary()
+        assert "total_energy_j" in s
+        assert "mean_energy_per_frame_mj" in s
+
+    def test_energy_included_in_to_dict(self):
+        engine = BenchmarkEngine(verbose=False, tdp_watts=15.0)
+        result = engine.run(self.tracker, self.dataset, dataset_name="Synthetic")
+        d = result.to_dict()
+        for entry in d["sequences"]:
+            assert "energy_j" in entry
+            assert "energy_per_frame_mj" in entry

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from eovot.metrics.accuracy import MetricsEngine, iou, center_distance
+from eovot.metrics.accuracy import MetricsEngine, iou, center_distance, normalized_center_distance
 
 
 class TestIoU:
@@ -51,6 +51,29 @@ class TestCenterDistance:
         a = (10.0, 10.0, 20.0, 20.0)
         b = (13.0, 14.0, 20.0, 20.0)
         assert center_distance(a, b) == pytest.approx(5.0)
+
+
+class TestNormalizedCenterDistance:
+    def test_same_box_is_zero(self):
+        box = (0.0, 0.0, 30.0, 40.0)
+        assert normalized_center_distance(box, box) == pytest.approx(0.0)
+
+    def test_zero_diagonal_returns_zero(self):
+        pred = (5.0, 5.0, 10.0, 10.0)
+        gt = (0.0, 0.0, 0.0, 0.0)  # degenerate box
+        assert normalized_center_distance(pred, gt) == pytest.approx(0.0)
+
+    def test_known_normalised_value(self):
+        # GT box: w=30, h=40 → diagonal = 50
+        # pred center shifted by (30, 40) → raw dist = 50, norm dist = 50/50 = 1.0
+        gt = (0.0, 0.0, 30.0, 40.0)
+        pred = (30.0, 40.0, 30.0, 40.0)
+        assert normalized_center_distance(pred, gt) == pytest.approx(1.0)
+
+    def test_result_is_non_negative(self):
+        a = (5.0, 5.0, 20.0, 20.0)
+        b = (100.0, 100.0, 20.0, 20.0)
+        assert normalized_center_distance(a, b) >= 0.0
 
 
 class TestBatchIoU:
@@ -129,3 +152,30 @@ class TestMetricsEngine:
         assert 0.0 <= result.mean_iou <= 1.0
         assert 0.0 <= result.success_auc <= 1.0
         assert 0.0 <= result.precision_auc <= 1.0
+
+    def test_norm_precision_curve_perfect(self):
+        # Identical boxes → normalised distance = 0 → precision = 1 at all thresholds > 0
+        preds = np.array([[5.0, 5.0, 30.0, 40.0]] * 10)
+        gts = np.array([[5.0, 5.0, 30.0, 40.0]] * 10)
+        thresholds, rates = self.engine.norm_precision_curve(preds, gts)
+        assert rates[-1] == pytest.approx(1.0)
+
+    def test_norm_precision_curve_shape(self):
+        preds = np.tile([0.0, 0.0, 20.0, 20.0], (20, 1))
+        gts = np.tile([5.0, 5.0, 20.0, 20.0], (20, 1))
+        thresholds, rates = self.engine.norm_precision_curve(preds, gts)
+        assert len(thresholds) == len(rates)
+        assert np.all(rates >= 0.0) and np.all(rates <= 1.0)
+
+    def test_compute_all_includes_norm_precision(self):
+        preds = np.tile([0.0, 0.0, 30.0, 40.0], (20, 1))
+        gts = np.tile([0.0, 0.0, 30.0, 40.0], (20, 1))
+        result = self.engine.compute_all(preds, gts)
+        assert 0.0 <= result.norm_precision_auc <= 1.0
+
+    def test_compute_all_perfect_tracker_norm_precision(self):
+        # Perfect predictions → norm_precision_auc should be high (close to 1)
+        preds = np.tile([0.0, 0.0, 30.0, 40.0], (30, 1))
+        gts = np.tile([0.0, 0.0, 30.0, 40.0], (30, 1))
+        result = self.engine.compute_all(preds, gts)
+        assert result.norm_precision_auc > 0.9


### PR DESCRIPTION
## What was added

### Bug fixes — `eovot/benchmark/engine.py`

Three silent runtime bugs that caused energy profiling data to be silently discarded:

1. **Missing imports** — `EnergyProfiler` and `EnergyResult` were referenced throughout `engine.py` but never imported, causing `NameError` at runtime whenever `tdp_watts` was set.
2. **Missing dataclass field** — `SequenceResult` had no `energy` field, so the computed `EnergyResult` object was thrown away at the end of `_run_sequence`.
3. **Missing constructor argument** — `_run_sequence` did not pass `energy=energy` to the `SequenceResult` constructor.
4. **Triplicate `to_dict()` overloads** — Three identical method bodies shadowed each other; consolidated into one canonical implementation that serialises energy fields when present.
5. **`summary()` missing energy** — `BenchmarkResult.summary()` now surfaces `total_energy_j` and `mean_energy_per_frame_mj` when energy profiling is active.

### New feature — Normalized Precision metric (`eovot/metrics/accuracy.py`)

Implements the **normalized centre-distance precision curve** from the LaSOT evaluation protocol (Fan et al., CVPR 2019):

```
norm_dist(pred, gt) = centre_distance(pred, gt) / diagonal(gt_box)
```

Dividing by the GT diagonal makes the metric **invariant to object size and image resolution**, enabling fair comparison across sequences targeting objects at different scales.

| New symbol | Description |
|---|---|
| `normalized_center_distance(pred, gt)` | Single-frame normalised distance |
| `MetricsEngine.norm_precision_curve(preds, gts)` | Curve over thresholds 0 → 0.5 |
| `AccuracyMetrics.norm_precision_auc` | AUC of the normalised precision curve |

`compute_all()` automatically populates `norm_precision_auc`.

## Why it matters

- Energy profiling was completely broken for any run with `tdp_watts` set — the data was computed but immediately discarded.  This PR makes the edge-deployment efficiency story actually work end to end.
- Normalized precision is the **canonical metric on LaSOT** and many recent SOTA papers.  Without it the framework could not produce results comparable to published work on that dataset.

## How it fits the project

Both fixes directly advance the core mission: a reproducible, hardware-aware benchmark whose results are comparable to the academic literature.

## Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.metrics import MetricsEngine

# Energy profiling now works correctly
engine = BenchmarkEngine(verbose=True, tdp_watts=10.0)  # Jetson Nano TDP
result = engine.run(tracker, dataset, dataset_name="GOT-10k-val")
print(result.total_energy_j)          # was None before this fix
print(result.mean_energy_per_frame_mj)

# Normalized precision
me = MetricsEngine()
thresholds, rates = me.norm_precision_curve(preds, gts)
metrics = me.compute_all(preds, gts)
print(metrics.norm_precision_auc)     # LaSOT-comparable scalar
```

## Tests

- 5 new tests in `TestBenchmarkEngineEnergy` verifying energy is populated, propagated to summary/to_dict, and absent when `tdp_watts` is not set.
- 8 new tests in `TestNormalizedCenterDistance` and `TestMetricsEngine` covering edge cases and AUC range.
- All **49 tests pass**.

## No breaking changes

All existing APIs are unchanged.  `norm_precision_auc` defaults to `0.0` on `AccuracyMetrics` for backward compatibility.


---
_Generated by [Claude Code](https://claude.ai/code/session_011rDzZNs6uTMZmCMcrW55QX)_