### PR TITLE
[core] Fix energy profiling crash + add VOT-style robustness metrics

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ..datasets.base import BaseDataset, Sequence
 from ..metrics.accuracy import MetricsEngine, center_distance
+from ..profiling.energy import EnergyProfiler, EnergyResult
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
 
@@ -21,6 +22,7 @@ class SequenceResult:
     predictions: Optional[np.ndarray] = None       # shape (N, 4) — predicted boxes
     ground_truths: Optional[np.ndarray] = None     # shape (N, 4) — GT boxes aligned to predictions
     center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
+    energy: Optional[EnergyResult] = None          # energy estimate; None when TDP not configured
 
     @property
     def mean_iou(self) -> float:
@@ -92,52 +94,13 @@ class BenchmarkResult:
         mcd = self.mean_center_distance
         if mcd is not None:
             d["mean_center_distance_px"] = round(mcd, 3)
+        e_total = self.total_energy_j
+        if e_total is not None:
+            d["total_energy_j"] = round(e_total, 4)
+        e_frame = self.mean_energy_per_frame_mj
+        if e_frame is not None:
+            d["mean_energy_per_frame_mj"] = round(e_frame, 4)
         return d
-
-    def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        sequences = []
-        for sr in self.sequence_results:
-            entry: Dict = {
-                "sequence_name": sr.sequence_name,
-                "mean_iou": round(sr.mean_iou, 4),
-                "fps": round(sr.profiling.fps, 2),
-                "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-            }
-            if sr.energy is not None:
-                entry["energy_j"] = round(sr.energy.total_energy_j, 6)
-                entry["energy_per_frame_mj"] = round(sr.energy.energy_per_frame_mj, 4)
-            sequences.append(entry)
-        return {"summary": self.summary(), "sequences": sequences}
-
-    def to_dict(self) -> Dict:
-        """Serialise to the dict format consumed by :class:`~eovot.reporting.reporter.BenchmarkReporter`.
-
-        Returns a dict with two keys:
-
-        * ``"summary"`` — aggregate scalar metrics (same as :meth:`summary`).
-        * ``"sequences"`` — list of per-sequence metric dicts.
-        """
-        return {
-            "summary": self.summary(),
-            "sequences": [
-                {
-                    "sequence_name": sr.sequence_name,
-                    "mean_iou": round(sr.mean_iou, 4),
-                    "fps": round(sr.profiling.fps, 2),
-                    "mean_latency_ms": round(sr.profiling.latency_mean_ms, 3),
-                    "peak_memory_mb": round(sr.profiling.peak_memory_mb, 2),
-                }
-                for sr in self.sequence_results
-            ],
-        }
 
     def to_dict(self) -> Dict:
         """Serialize the full result to a dict compatible with :class:`~eovot.reporting.reporter.BenchmarkReporter`.
@@ -146,16 +109,19 @@ class BenchmarkResult:
         and ``"sequences"`` (per-sequence breakdown), suitable for JSON
         export and Markdown table generation.
         """
-        sequences = [
-            {
+        sequences = []
+        for r in self.sequence_results:
+            entry: Dict = {
                 "sequence_name": r.sequence_name,
                 "mean_iou": round(r.mean_iou, 4),
                 "fps": round(r.profiling.fps, 2),
                 "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
                 "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
             }
-            for r in self.sequence_results
-        ]
+            if r.energy is not None:
+                entry["energy_j"] = round(r.energy.total_energy_j, 6)
+                entry["energy_per_frame_mj"] = round(r.energy.energy_per_frame_mj, 4)
+            sequences.append(entry)
         return {"summary": self.summary(), "sequences": sequences}
 
     def __str__(self) -> str:
@@ -278,4 +244,5 @@ class BenchmarkEngine:
             predictions=preds_eval,
             ground_truths=gt_eval,
             center_distances=dists,
+            energy=energy,
         )

--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -6,5 +6,13 @@ from .accuracy import (
     AccuracyMetrics,
     MetricsEngine,
 )
+from .robustness import RobustnessAnalyzer, RobustnessResult
 
-__all__ = ["iou", "center_distance", "AccuracyMetrics", "MetricsEngine"]
+__all__ = [
+    "iou",
+    "center_distance",
+    "AccuracyMetrics",
+    "MetricsEngine",
+    "RobustnessAnalyzer",
+    "RobustnessResult",
+]

--- a/eovot/metrics/robustness.py
+++ b/eovot/metrics/robustness.py
@@ -1,0 +1,287 @@
+"""Robustness metrics for visual object tracking evaluation.
+
+Implements VOT-challenge-style robustness analysis on top of per-frame IoU
+arrays produced by :class:`~eovot.benchmark.engine.BenchmarkEngine`:
+
+- **Failure detection** — a frame is a "failure" when IoU drops below
+  ``failure_threshold`` and the tracker was previously alive.
+- **Recovery lag** — number of frames until IoU rises back above
+  ``recovery_threshold`` after a failure.
+- **Expected Average Overlap (EAO)** — mean IoU over all non-burn-in frames,
+  a simplified scalar that combines accuracy and robustness into one number
+  (full VOT-protocol EAO requires re-initialization; this is the raw version).
+- **Survival curve** — probability that the tracker is "alive" (IoU ≥ threshold)
+  at each normalized time step across a sequence collection.
+
+Typical usage::
+
+    from eovot.metrics.robustness import RobustnessAnalyzer
+
+    analyzer = RobustnessAnalyzer()
+
+    # Per-sequence analysis
+    result = analyzer.analyze_sequence(ious, tracker_name="MOSSE", sequence_name="car1")
+    print(result.num_failures, result.eao)
+
+    # Aggregate over a whole benchmark run
+    seq_ious = {r.sequence_name: r.ious for r in benchmark_result.sequence_results}
+    agg = analyzer.analyze_benchmark(seq_ious, tracker_name="MOSSE")
+    print(agg["aggregate"]["mean_eao"])
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+
+
+@dataclass
+class RobustnessResult:
+    """Per-sequence robustness summary."""
+
+    tracker_name: str
+    sequence_name: str
+    num_failures: int
+    """Number of distinct tracking failures detected."""
+
+    failure_frames: List[int]
+    """Frame indices at which failures begin."""
+
+    recovery_lags: List[int]
+    """Frames-to-recovery for each failure; equals ``len(ious) - failure_frame``
+    when the tracker never recovers."""
+
+    mean_recovery_lag: float
+    """Mean of ``recovery_lags``, or 0.0 if no failures occurred."""
+
+    eao: float
+    """Expected Average Overlap — mean IoU over non-burn-in frames."""
+
+    survival_rate: float
+    """Fraction of non-burn-in frames where IoU ≥ failure_threshold."""
+
+    def __str__(self) -> str:
+        return (
+            f"RobustnessResult[{self.tracker_name} on {self.sequence_name}] "
+            f"failures={self.num_failures}  EAO={self.eao:.4f}  "
+            f"survival={self.survival_rate:.3f}  "
+            f"mean_recovery_lag={self.mean_recovery_lag:.1f} fr"
+        )
+
+
+class RobustnessAnalyzer:
+    """Analyze tracker robustness from per-frame IoU sequences.
+
+    Args:
+        failure_threshold: IoU below which a frame is counted as a failure.
+            Default: ``0.1`` (standard VOT threshold).
+        recovery_threshold: IoU above which the tracker is considered recovered.
+            Default: ``0.1`` (same as failure threshold, hysteresis-free).
+        burn_in_frames: Frames at the start of each sequence to skip before
+            looking for failures.  The first frame is initialization and its
+            IoU is usually 1.0 by construction; a small burn-in avoids
+            counting the stabilization period.  Default: ``5``.
+    """
+
+    def __init__(
+        self,
+        failure_threshold: float = 0.1,
+        recovery_threshold: float = 0.1,
+        burn_in_frames: int = 5,
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_threshold = recovery_threshold
+        self.burn_in_frames = burn_in_frames
+
+    # ------------------------------------------------------------------
+    # Core computations
+    # ------------------------------------------------------------------
+
+    def detect_failures(self, ious: np.ndarray) -> List[int]:
+        """Return the frame indices where tracking failures begin.
+
+        A failure starts on the first frame (after burn-in) where IoU drops
+        below ``failure_threshold``.  Subsequent below-threshold frames are
+        part of the same failure and are not double-counted.  The tracker is
+        considered recovered when IoU rises back to ``recovery_threshold``.
+
+        Args:
+            ious: Per-frame IoU array, shape ``(N,)``.
+
+        Returns:
+            List of frame indices (int) at which new failures begin.
+        """
+        failures: List[int] = []
+        in_failure = False
+
+        for i in range(self.burn_in_frames, len(ious)):
+            iou = float(ious[i])
+            if not in_failure and iou < self.failure_threshold:
+                failures.append(i)
+                in_failure = True
+            elif in_failure and iou >= self.recovery_threshold:
+                in_failure = False
+
+        return failures
+
+    def compute_recovery_lags(
+        self, ious: np.ndarray, failure_frames: List[int]
+    ) -> List[int]:
+        """Compute frames-to-recovery for each detected failure.
+
+        Args:
+            ious:           Per-frame IoU array.
+            failure_frames: Output of :meth:`detect_failures`.
+
+        Returns:
+            List of integers, one per failure.  If the tracker never recovers
+            from a failure at frame ``f``, the lag is ``len(ious) - f``.
+        """
+        lags: List[int] = []
+        for f in failure_frames:
+            lag = 0
+            for i in range(f + 1, len(ious)):
+                lag += 1
+                if float(ious[i]) >= self.recovery_threshold:
+                    break
+            else:
+                # Loop completed without recovery.
+                lag = len(ious) - f
+            lags.append(lag)
+        return lags
+
+    def compute_eao(self, ious: np.ndarray) -> float:
+        """Compute a simplified Expected Average Overlap.
+
+        EAO is the mean IoU over all frames after the burn-in period.
+        This is the "raw" EAO without the VOT re-initialization protocol.
+        For fully VOT-compliant EAO, sequences must be sub-sampled and
+        trackers re-initialized on failure.
+
+        Args:
+            ious: Per-frame IoU array.
+
+        Returns:
+            Mean IoU in ``[0, 1]``, or ``0.0`` for very short sequences.
+        """
+        if len(ious) <= self.burn_in_frames:
+            return 0.0
+        return float(np.mean(ious[self.burn_in_frames:]))
+
+    def survival_curve(
+        self, ious_list: List[np.ndarray], n_points: int = 100
+    ) -> np.ndarray:
+        """Estimate the tracker survival curve across a collection of sequences.
+
+        The survival curve gives the probability that the tracker is "alive"
+        (IoU ≥ ``failure_threshold``) at normalized time ``t ∈ [0, 1]``.
+
+        Args:
+            ious_list: List of per-frame IoU arrays (one per sequence).
+            n_points:  Number of evenly-spaced time points.  Default: ``100``.
+
+        Returns:
+            ``(n_points,)`` float array with values in ``[0, 1]``.
+        """
+        curve = np.zeros(n_points, dtype=np.float64)
+        valid = [s for s in ious_list if len(s) > 0]
+        if not valid:
+            return curve
+
+        ts = np.linspace(0.0, 1.0, n_points)
+        for ious in valid:
+            n = len(ious)
+            for j, t in enumerate(ts):
+                frame = min(int(t * (n - 1)), n - 1)
+                if float(ious[frame]) >= self.failure_threshold:
+                    curve[j] += 1.0
+
+        curve /= len(valid)
+        return curve
+
+    # ------------------------------------------------------------------
+    # High-level analysis entry points
+    # ------------------------------------------------------------------
+
+    def analyze_sequence(
+        self,
+        ious: np.ndarray,
+        tracker_name: str = "",
+        sequence_name: str = "",
+    ) -> RobustnessResult:
+        """Run full robustness analysis on a single sequence.
+
+        Args:
+            ious:          Per-frame IoU array, shape ``(N,)``.
+            tracker_name:  Identifier stored in the result.
+            sequence_name: Identifier stored in the result.
+
+        Returns:
+            :class:`RobustnessResult` populated with all statistics.
+        """
+        ious = np.asarray(ious, dtype=np.float64)
+
+        failure_frames = self.detect_failures(ious)
+        recovery_lags = self.compute_recovery_lags(ious, failure_frames)
+        eao = self.compute_eao(ious)
+
+        n_active = int(np.sum(ious[self.burn_in_frames:] >= self.failure_threshold))
+        denom = max(len(ious) - self.burn_in_frames, 1)
+        survival_rate = n_active / denom
+
+        return RobustnessResult(
+            tracker_name=tracker_name,
+            sequence_name=sequence_name,
+            num_failures=len(failure_frames),
+            failure_frames=failure_frames,
+            recovery_lags=recovery_lags,
+            mean_recovery_lag=float(np.mean(recovery_lags)) if recovery_lags else 0.0,
+            eao=eao,
+            survival_rate=survival_rate,
+        )
+
+    def analyze_benchmark(
+        self,
+        sequence_ious: Dict[str, np.ndarray],
+        tracker_name: str = "",
+    ) -> Dict:
+        """Aggregate robustness analysis across all sequences in a benchmark run.
+
+        Args:
+            sequence_ious: Mapping ``{sequence_name: ious_array}``.
+            tracker_name:  Identifier for the tracker under evaluation.
+
+        Returns:
+            Dict with two keys:
+
+            * ``"per_sequence"`` — ``{seq_name: RobustnessResult}``
+            * ``"aggregate"`` — summary scalars across all sequences
+        """
+        per_seq: Dict[str, RobustnessResult] = {}
+        for seq_name, ious in sequence_ious.items():
+            per_seq[seq_name] = self.analyze_sequence(
+                ious, tracker_name=tracker_name, sequence_name=seq_name
+            )
+
+        n = len(per_seq)
+        total_failures = sum(r.num_failures for r in per_seq.values())
+        mean_eao = float(np.mean([r.eao for r in per_seq.values()])) if n else 0.0
+        mean_survival = float(np.mean([r.survival_rate for r in per_seq.values()])) if n else 0.0
+        mean_lag = float(
+            np.mean([r.mean_recovery_lag for r in per_seq.values() if r.num_failures > 0])
+        ) if any(r.num_failures > 0 for r in per_seq.values()) else 0.0
+
+        return {
+            "per_sequence": per_seq,
+            "aggregate": {
+                "tracker_name": tracker_name,
+                "num_sequences": n,
+                "total_failures": total_failures,
+                "mean_failures_per_sequence": total_failures / n if n else 0.0,
+                "mean_eao": round(mean_eao, 4),
+                "mean_survival_rate": round(mean_survival, 4),
+                "mean_recovery_lag_frames": round(mean_lag, 2),
+            },
+        }

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,236 @@
+"""Tests for eovot.metrics.robustness."""
+
+import numpy as np
+import pytest
+
+from eovot.metrics.robustness import RobustnessAnalyzer, RobustnessResult
+
+
+@pytest.fixture
+def analyzer():
+    """Analyzer with burn_in=2 for short synthetic sequences."""
+    return RobustnessAnalyzer(
+        failure_threshold=0.1,
+        recovery_threshold=0.1,
+        burn_in_frames=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# detect_failures
+# ---------------------------------------------------------------------------
+
+class TestDetectFailures:
+    def test_no_failures_all_high(self, analyzer):
+        ious = np.array([1.0, 1.0, 0.8, 0.7, 0.9])
+        assert analyzer.detect_failures(ious) == []
+
+    def test_single_failure(self, analyzer):
+        # burn_in=2 → indices 0,1 ignored; failure at index 3
+        ious = np.array([1.0, 1.0, 0.8, 0.05, 0.8])
+        failures = analyzer.detect_failures(ious)
+        assert failures == [3]
+
+    def test_burn_in_respected(self, analyzer):
+        # First 2 frames (burn-in) are sub-threshold but must not count
+        ious = np.array([0.0, 0.0, 0.8, 0.9])
+        assert analyzer.detect_failures(ious) == []
+
+    def test_two_separate_failures(self, analyzer):
+        # failure at 2 (recover at 4), failure again at 6
+        ious = np.array([1.0, 1.0, 0.05, 0.05, 0.8, 0.8, 0.05])
+        failures = analyzer.detect_failures(ious)
+        assert failures == [2, 6]
+
+    def test_failure_at_last_frame(self, analyzer):
+        ious = np.array([1.0, 1.0, 0.8, 0.8, 0.05])
+        failures = analyzer.detect_failures(ious)
+        assert failures == [4]
+
+    def test_no_failure_exactly_at_threshold(self, analyzer):
+        # IoU == threshold is NOT a failure (strict less-than)
+        ious = np.array([1.0, 1.0, 0.1, 0.1])
+        assert analyzer.detect_failures(ious) == []
+
+    def test_entire_sequence_below_threshold(self, analyzer):
+        ious = np.zeros(8)
+        failures = analyzer.detect_failures(ious)
+        # Only one failure event (burn_in=2, first sub-threshold frame is index 2)
+        assert len(failures) == 1
+        assert failures[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# compute_recovery_lags
+# ---------------------------------------------------------------------------
+
+class TestRecoveryLags:
+    def test_recovers_quickly(self, analyzer):
+        ious = np.array([1.0, 1.0, 0.8, 0.05, 0.05, 0.05, 0.8])
+        failures = analyzer.detect_failures(ious)
+        lags = analyzer.compute_recovery_lags(ious, failures)
+        assert lags == [3]  # frames 4, 5, 6 → lag = 3
+
+    def test_immediate_recovery(self, analyzer):
+        ious = np.array([1.0, 1.0, 0.05, 0.8])
+        failures = analyzer.detect_failures(ious)
+        lags = analyzer.compute_recovery_lags(ious, failures)
+        assert lags == [1]  # recovers on very next frame
+
+    def test_never_recovers(self, analyzer):
+        ious = np.array([1.0, 1.0, 0.8, 0.05, 0.05, 0.05])
+        failures = analyzer.detect_failures(ious)
+        lags = analyzer.compute_recovery_lags(ious, failures)
+        # len(ious) - failure_frame = 6 - 3 = 3
+        assert lags == [3]
+
+    def test_no_failures_empty_lags(self, analyzer):
+        ious = np.ones(10)
+        failures = analyzer.detect_failures(ious)
+        lags = analyzer.compute_recovery_lags(ious, failures)
+        assert lags == []
+
+
+# ---------------------------------------------------------------------------
+# compute_eao
+# ---------------------------------------------------------------------------
+
+class TestComputeEAO:
+    def test_perfect_tracking(self, analyzer):
+        ious = np.ones(10)
+        assert abs(analyzer.compute_eao(ious) - 1.0) < 1e-9
+
+    def test_zero_tracking(self, analyzer):
+        ious = np.zeros(10)
+        assert abs(analyzer.compute_eao(ious) - 0.0) < 1e-9
+
+    def test_known_mean(self, analyzer):
+        # burn_in=2: mean over indices 2..9 of a ramp
+        ious = np.array([0.0, 0.0, 0.2, 0.4, 0.6, 0.8])
+        expected = np.mean([0.2, 0.4, 0.6, 0.8])
+        assert abs(analyzer.compute_eao(ious) - expected) < 1e-9
+
+    def test_too_short_returns_zero(self, analyzer):
+        ious = np.array([1.0])  # shorter than burn_in=2
+        assert analyzer.compute_eao(ious) == 0.0
+
+    def test_exactly_burn_in_length_returns_zero(self, analyzer):
+        ious = np.array([1.0, 1.0])  # len == burn_in
+        assert analyzer.compute_eao(ious) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# survival_curve
+# ---------------------------------------------------------------------------
+
+class TestSurvivalCurve:
+    def test_shape(self, analyzer):
+        ious_list = [np.ones(20), np.ones(20)]
+        curve = analyzer.survival_curve(ious_list)
+        assert curve.shape == (100,)
+
+    def test_perfect_tracker_all_ones(self, analyzer):
+        ious_list = [np.ones(50)]
+        curve = analyzer.survival_curve(ious_list)
+        np.testing.assert_allclose(curve, 1.0)
+
+    def test_failed_tracker_all_zeros(self, analyzer):
+        ious_list = [np.zeros(50)]
+        curve = analyzer.survival_curve(ious_list)
+        np.testing.assert_allclose(curve, 0.0)
+
+    def test_empty_list(self, analyzer):
+        curve = analyzer.survival_curve([])
+        assert curve.shape == (100,)
+        np.testing.assert_allclose(curve, 0.0)
+
+    def test_custom_n_points(self, analyzer):
+        ious_list = [np.ones(30)]
+        curve = analyzer.survival_curve(ious_list, n_points=50)
+        assert curve.shape == (50,)
+
+    def test_values_in_range(self, analyzer):
+        rng = np.random.default_rng(0)
+        ious_list = [rng.uniform(0, 1, 40) for _ in range(5)]
+        curve = analyzer.survival_curve(ious_list)
+        assert np.all(curve >= 0.0)
+        assert np.all(curve <= 1.0)
+
+
+# ---------------------------------------------------------------------------
+# analyze_sequence
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeSequence:
+    def test_returns_dataclass(self, analyzer):
+        ious = np.array([1.0, 0.9, 0.8, 0.7, 0.6, 0.5])
+        result = analyzer.analyze_sequence(ious, tracker_name="T", sequence_name="S")
+        assert isinstance(result, RobustnessResult)
+        assert result.tracker_name == "T"
+        assert result.sequence_name == "S"
+
+    def test_perfect_tracker_no_failures(self, analyzer):
+        ious = np.ones(20)
+        result = analyzer.analyze_sequence(ious)
+        assert result.num_failures == 0
+        assert result.failure_frames == []
+        assert result.recovery_lags == []
+        assert result.mean_recovery_lag == 0.0
+        assert abs(result.eao - 1.0) < 1e-9
+        assert abs(result.survival_rate - 1.0) < 1e-9
+
+    def test_known_failure_counted(self, analyzer):
+        ious = np.array([1.0, 1.0, 0.8, 0.05, 0.8, 0.9, 0.8])
+        result = analyzer.analyze_sequence(ious)
+        assert result.num_failures == 1
+
+    def test_survival_rate_partial(self, analyzer):
+        # burn_in=2 → 4 active frames; 2 are above threshold
+        ious = np.array([1.0, 1.0, 0.8, 0.05, 0.8, 0.05])
+        result = analyzer.analyze_sequence(ious)
+        assert abs(result.survival_rate - 0.5) < 1e-9
+
+    def test_str_representation(self, analyzer):
+        ious = np.ones(10)
+        result = analyzer.analyze_sequence(ious, tracker_name="MOSSE", sequence_name="car1")
+        s = str(result)
+        assert "MOSSE" in s
+        assert "car1" in s
+        assert "EAO" in s
+
+
+# ---------------------------------------------------------------------------
+# analyze_benchmark
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeBenchmark:
+    def test_aggregate_keys_present(self, analyzer):
+        seq_ious = {
+            "seq1": np.ones(10),
+            "seq2": np.array([1.0, 1.0, 0.8, 0.05, 0.8, 0.9]),
+        }
+        out = analyzer.analyze_benchmark(seq_ious, tracker_name="KCF")
+        agg = out["aggregate"]
+        assert "mean_eao" in agg
+        assert "total_failures" in agg
+        assert "mean_failures_per_sequence" in agg
+        assert "mean_survival_rate" in agg
+        assert "mean_recovery_lag_frames" in agg
+        assert agg["num_sequences"] == 2
+        assert agg["tracker_name"] == "KCF"
+
+    def test_per_sequence_populated(self, analyzer):
+        seq_ious = {"s1": np.ones(8), "s2": np.ones(8)}
+        out = analyzer.analyze_benchmark(seq_ious)
+        assert set(out["per_sequence"].keys()) == {"s1", "s2"}
+
+    def test_empty_input(self, analyzer):
+        out = analyzer.analyze_benchmark({})
+        assert out["aggregate"]["num_sequences"] == 0
+        assert out["aggregate"]["total_failures"] == 0
+
+    def test_all_perfect_zero_failures(self, analyzer):
+        seq_ious = {f"s{i}": np.ones(15) for i in range(5)}
+        out = analyzer.analyze_benchmark(seq_ious)
+        assert out["aggregate"]["total_failures"] == 0
+        assert abs(out["aggregate"]["mean_eao"] - 1.0) < 1e-6


### PR DESCRIPTION
Closes #54

## What was added

### Bug fixes — `eovot/benchmark/engine.py`

Four silent bugs that had accumulated across previous commits, all fixed in one pass:

| # | Bug | Impact |
|---|-----|--------|
| 1 | `EnergyProfiler` / `EnergyResult` used but never imported | `NameError` crash when `tdp_watts` is set |
| 2 | `SequenceResult` had no `energy` field | `AttributeError` in `BenchmarkResult.total_energy_j` |
| 3 | `_run_sequence` computed `energy` but never stored it | Energy data silently dropped every run |
| 4 | `to_dict()` defined 3 times; last definition won, dropping energy fields | Energy absent from all JSON/CSV exports |

All four are now resolved. The surviving `to_dict()` includes energy fields conditionally (when `tdp_watts` is configured).

### New module — `eovot/metrics/robustness.py`

`RobustnessAnalyzer` brings VOT-challenge-style robustness analysis to the framework:

```python
from eovot.metrics.robustness import RobustnessAnalyzer

analyzer = RobustnessAnalyzer(failure_threshold=0.1, burn_in_frames=5)

# Single sequence
result = analyzer.analyze_sequence(ious, tracker_name="MOSSE", sequence_name="car1")
print(result.num_failures)  # int
print(result.eao)           # float ∈ [0, 1]
print(result.survival_rate) # fraction of frames tracker is "alive"

# Full benchmark run
seq_ious = {r.sequence_name: r.ious for r in benchmark_result.sequence_results}
agg = analyzer.analyze_benchmark(seq_ious, tracker_name="MOSSE")
print(agg["aggregate"])
# {'mean_eao': 0.4231, 'total_failures': 12, 'mean_survival_rate': 0.847, ...}

# Survival curve for plotting
curve = analyzer.survival_curve([r.ious for r in benchmark_result.sequence_results])
# shape (100,) — probability alive at each normalized time step
```

**Methods:**
- `detect_failures(ious)` — VOT-style failure detection with configurable burn-in
- `compute_recovery_lags(ious, failure_frames)` — frames until recovery per failure
- `compute_eao(ious)` — simplified Expected Average Overlap (mean IoU post burn-in)
- `survival_curve(ious_list)` — population-level survival probability at each time step
- `analyze_sequence(ious, ...)` → `RobustnessResult` dataclass
- `analyze_benchmark(seq_ious_dict, ...)` → aggregate dict ready for JSON export

### Tests

`tests/test_robustness.py` — 31 tests covering all methods and edge cases (zero-length sequences, never-recovering trackers, burn-in boundary, threshold hysteresis). All pass.

## Why it matters

Without the engine fixes any user enabling energy profiling received an immediate crash. The robustness module enables VOT-comparable evaluation — a stated project goal — by quantifying not just accuracy but how often and how severely the tracker loses the target.

## No breaking changes

All existing code paths are unaffected. The `energy` field on `SequenceResult` defaults to `None`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PtkBQZY4sfTHFCfBKiA4fd)_