### PR TITLE
[feat] Edge hardware profiles + deployment feasibility analysis

### DIFF
--- a/eovot/profiling/__init__.py
+++ b/eovot/profiling/__init__.py
@@ -1,6 +1,15 @@
-"""Profiling sub-package — hardware-aware latency, memory, and energy measurement."""
+"""Profiling sub-package — hardware-aware latency, memory, energy, and device profiles."""
 
 from .profiler import Profiler, ProfilingResult
 from .energy import EnergyProfiler, EnergyResult
+from .hardware_profiles import HardwareProfile, get_profile, PROFILES
 
-__all__ = ["Profiler", "ProfilingResult", "EnergyProfiler", "EnergyResult"]
+__all__ = [
+    "Profiler",
+    "ProfilingResult",
+    "EnergyProfiler",
+    "EnergyResult",
+    "HardwareProfile",
+    "get_profile",
+    "PROFILES",
+]

--- a/eovot/profiling/hardware_profiles.py
+++ b/eovot/profiling/hardware_profiles.py
@@ -1,0 +1,163 @@
+"""Predefined edge hardware profiles for EOVOT deployment feasibility analysis.
+
+Each :class:`HardwareProfile` encodes the key constraints of a real edge
+deployment target: power budget, available RAM, minimum acceptable FPS, and
+CPU core count.  These profiles let researchers ask "can tracker X run on
+device Y?" without owning the physical hardware.
+
+Usage::
+
+    from eovot.profiling.hardware_profiles import get_profile, PROFILES
+
+    profile = get_profile("jetson-nano")
+    print(profile.target_fps)   # 30.0
+    print(profile.memory_limit_mb)  # 4096
+
+    for slug, p in PROFILES.items():
+        print(slug, p.tdp_watts)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class HardwareProfile:
+    """Specification for an edge deployment target.
+
+    Args:
+        name: Human-readable device name (e.g., ``"Jetson Nano"``).
+        tdp_watts: Thermal design power in Watts.  Used by
+            :class:`~eovot.profiling.energy.EnergyProfiler` as the TDP
+            argument when profiling on this device.
+        memory_limit_mb: Maximum RAM available to the tracker process (MiB).
+            Includes both model weights and working buffers.
+        target_fps: Minimum acceptable frame rate for real-time deployment.
+        cpu_cores: Number of physical CPU cores available to the process.
+        description: Free-text hardware notes for report headers.
+    """
+
+    name: str
+    tdp_watts: float
+    memory_limit_mb: int
+    target_fps: float
+    cpu_cores: int
+    description: str = ""
+
+    def __str__(self) -> str:
+        return (
+            f"HardwareProfile({self.name!r}  "
+            f"TDP={self.tdp_watts}W  "
+            f"mem≤{self.memory_limit_mb}MiB  "
+            f"target≥{self.target_fps}fps  "
+            f"cores={self.cpu_cores})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Built-in device profiles
+# ---------------------------------------------------------------------------
+
+JETSON_NANO = HardwareProfile(
+    name="Jetson Nano",
+    tdp_watts=10.0,
+    memory_limit_mb=4096,
+    target_fps=30.0,
+    cpu_cores=4,
+    description="NVIDIA Jetson Nano 4GB — quad-core Cortex-A57 @ 1.43 GHz, 128-core Maxwell GPU",
+)
+
+RASPBERRY_PI_4 = HardwareProfile(
+    name="Raspberry Pi 4",
+    tdp_watts=6.0,
+    memory_limit_mb=4096,
+    target_fps=15.0,
+    cpu_cores=4,
+    description="Raspberry Pi 4 Model B 4GB — quad-core Cortex-A72 @ 1.5 GHz",
+)
+
+RASPBERRY_PI_ZERO_2W = HardwareProfile(
+    name="Raspberry Pi Zero 2W",
+    tdp_watts=2.5,
+    memory_limit_mb=512,
+    target_fps=5.0,
+    cpu_cores=4,
+    description="Raspberry Pi Zero 2W — quad-core Cortex-A53 @ 1 GHz, 512 MB RAM",
+)
+
+INTEL_NCS2 = HardwareProfile(
+    name="Intel NCS2",
+    tdp_watts=1.0,
+    memory_limit_mb=512,
+    target_fps=60.0,
+    cpu_cores=1,
+    description="Intel Neural Compute Stick 2 — Myriad X VPU, inference via OpenVINO",
+)
+
+CORAL_EDGE_TPU = HardwareProfile(
+    name="Coral Edge TPU",
+    tdp_watts=2.0,
+    memory_limit_mb=8192,
+    target_fps=100.0,
+    cpu_cores=4,
+    description="Google Coral Dev Board — NXP i.MX 8M + Edge TPU @ 4 TOPS",
+)
+
+LAPTOP_CPU = HardwareProfile(
+    name="Laptop CPU",
+    tdp_watts=28.0,
+    memory_limit_mb=16384,
+    target_fps=30.0,
+    cpu_cores=8,
+    description="Generic laptop — 8-core x86 CPU @ ~3 GHz, 16 GB RAM",
+)
+
+DESKTOP_GPU = HardwareProfile(
+    name="Desktop GPU",
+    tdp_watts=250.0,
+    memory_limit_mb=32768,
+    target_fps=120.0,
+    cpu_cores=16,
+    description="Desktop workstation — 16-core CPU + NVIDIA RTX GPU, 32 GB RAM",
+)
+
+
+#: Registry mapping short slug → :class:`HardwareProfile`.
+PROFILES: Dict[str, HardwareProfile] = {
+    "jetson-nano": JETSON_NANO,
+    "rpi4": RASPBERRY_PI_4,
+    "rpi-zero-2w": RASPBERRY_PI_ZERO_2W,
+    "intel-ncs2": INTEL_NCS2,
+    "coral-tpu": CORAL_EDGE_TPU,
+    "laptop": LAPTOP_CPU,
+    "desktop": DESKTOP_GPU,
+}
+
+
+def get_profile(name: str) -> HardwareProfile:
+    """Return a :class:`HardwareProfile` by slug key.
+
+    Args:
+        name: Case-sensitive slug from :data:`PROFILES`
+            (e.g., ``"jetson-nano"``, ``"rpi4"``).
+
+    Returns:
+        The corresponding :class:`HardwareProfile`.
+
+    Raises:
+        KeyError: If *name* is not in :data:`PROFILES`.
+
+    Example::
+
+        profile = get_profile("rpi4")
+        print(profile.target_fps)  # 15.0
+    """
+    if name not in PROFILES:
+        available = ", ".join(sorted(PROFILES))
+        raise KeyError(
+            f"Unknown hardware profile {name!r}. "
+            f"Available profiles: {available}"
+        )
+    return PROFILES[name]

--- a/eovot/reporting/__init__.py
+++ b/eovot/reporting/__init__.py
@@ -1,4 +1,11 @@
 from .reporter import BenchmarkReporter
 from .visualizer import BenchmarkVisualizer
+from .edge_report import EdgeDeploymentAnalyzer, EdgeDeploymentReport, ConstraintScore
 
-__all__ = ["BenchmarkReporter", "BenchmarkVisualizer"]
+__all__ = [
+    "BenchmarkReporter",
+    "BenchmarkVisualizer",
+    "EdgeDeploymentAnalyzer",
+    "EdgeDeploymentReport",
+    "ConstraintScore",
+]

--- a/eovot/reporting/edge_report.py
+++ b/eovot/reporting/edge_report.py
@@ -1,0 +1,327 @@
+"""Edge deployment feasibility analysis for EOVOT benchmark results.
+
+Given a :class:`~eovot.benchmark.engine.BenchmarkResult` and a
+:class:`~eovot.profiling.hardware_profiles.HardwareProfile`, the
+:class:`EdgeDeploymentAnalyzer` checks whether the tracker meets the
+device's FPS, memory, and (optionally) energy constraints and produces a
+structured :class:`EdgeDeploymentReport` with per-constraint pass/fail
+scores, margin percentages, and a letter grade.
+
+Typical usage::
+
+    from eovot.benchmark.engine import BenchmarkEngine
+    from eovot.profiling.hardware_profiles import get_profile
+    from eovot.reporting.edge_report import EdgeDeploymentAnalyzer
+
+    result = BenchmarkEngine(tdp_watts=10.0).run(tracker, dataset)
+
+    analyzer = EdgeDeploymentAnalyzer(energy_budget_mj_per_frame=0.5)
+    report   = analyzer.analyze(result, get_profile("jetson-nano"))
+
+    print(report.overall_grade)   # e.g. "B"
+    print(report.is_deployable)   # True / False
+    print(report.to_markdown())
+
+    # Compare multiple trackers on one device:
+    reports = analyzer.compare([result_mosse, result_kcf], get_profile("rpi4"))
+    print(EdgeDeploymentAnalyzer.leaderboard(reports))
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from ..benchmark.engine import BenchmarkResult
+from ..profiling.hardware_profiles import HardwareProfile
+
+# Grade thresholds: minimum headroom (%) across all passing constraints
+_GRADE_A_MARGIN = 50.0
+_GRADE_B_MARGIN = 20.0
+
+
+@dataclass
+class ConstraintScore:
+    """Pass/fail verdict and margin for a single deployment constraint.
+
+    Args:
+        metric: Human-readable constraint name (e.g., ``"FPS"``).
+        required: Threshold value the tracker must meet.
+        measured: Value observed in the benchmark result.
+        passed: Whether the constraint is satisfied.
+        margin_pct: Positive = headroom over the requirement;
+            negative = how far the tracker exceeds the limit.
+    """
+
+    metric: str
+    required: float
+    measured: float
+    passed: bool
+    margin_pct: float
+
+    def __str__(self) -> str:
+        status = "PASS" if self.passed else "FAIL"
+        sign = "+" if self.margin_pct >= 0 else ""
+        return (
+            f"[{status}] {self.metric}: "
+            f"measured={self.measured:.2f}, "
+            f"required={self.required:.2f} "
+            f"({sign}{self.margin_pct:.1f}%)"
+        )
+
+
+@dataclass
+class EdgeDeploymentReport:
+    """Deployment feasibility summary for one tracker / hardware target pair.
+
+    Produced by :meth:`EdgeDeploymentAnalyzer.analyze`.  All constraint
+    scores are stored as :class:`ConstraintScore` instances; the
+    :attr:`overall_grade` and :attr:`is_deployable` properties aggregate
+    them into human-readable verdicts.
+    """
+
+    tracker_name: str
+    dataset_name: str
+    profile: HardwareProfile
+    fps_score: ConstraintScore
+    memory_score: ConstraintScore
+    energy_score: Optional[ConstraintScore]
+
+    @property
+    def is_deployable(self) -> bool:
+        """``True`` only when *all* active constraints are satisfied."""
+        checks = [self.fps_score.passed, self.memory_score.passed]
+        if self.energy_score is not None:
+            checks.append(self.energy_score.passed)
+        return all(checks)
+
+    @property
+    def overall_grade(self) -> str:
+        """Letter grade summarising deployment readiness.
+
+        * **A** — all constraints pass with ≥50% margin.
+        * **B** — all constraints pass with ≥20% margin.
+        * **C** — all constraints pass but with thin margin (<20%).
+        * **D** — exactly one constraint fails.
+        * **F** — two or more constraints fail.
+        """
+        scores = [s for s in (self.fps_score, self.memory_score, self.energy_score) if s is not None]
+        failed = sum(1 for s in scores if not s.passed)
+
+        if failed >= 2:
+            return "F"
+        if failed == 1:
+            return "D"
+
+        min_margin = min(s.margin_pct for s in scores)
+        if min_margin >= _GRADE_A_MARGIN:
+            return "A"
+        if min_margin >= _GRADE_B_MARGIN:
+            return "B"
+        return "C"
+
+    def summary(self) -> Dict:
+        """Return a flat dict suitable for JSON export."""
+        d: Dict = {
+            "tracker": self.tracker_name,
+            "dataset": self.dataset_name,
+            "hardware_profile": self.profile.name,
+            "deployable": self.is_deployable,
+            "grade": self.overall_grade,
+            "fps_required": self.profile.target_fps,
+            "fps_measured": round(self.fps_score.measured, 2),
+            "fps_margin_pct": round(self.fps_score.margin_pct, 1),
+            "memory_limit_mb": self.profile.memory_limit_mb,
+            "memory_measured_mb": round(self.memory_score.measured, 2),
+            "memory_margin_pct": round(self.memory_score.margin_pct, 1),
+        }
+        if self.energy_score is not None:
+            d["energy_budget_mj_per_frame"] = self.energy_score.required
+            d["energy_measured_mj_per_frame"] = round(self.energy_score.measured, 4)
+            d["energy_margin_pct"] = round(self.energy_score.margin_pct, 1)
+        return d
+
+    def to_markdown(self) -> str:
+        """Render the full report as a Markdown block."""
+        deployable_str = "YES" if self.is_deployable else "NO"
+        lines = [
+            f"## Edge Deployment Report",
+            f"",
+            f"**Tracker**: {self.tracker_name}  ",
+            f"**Dataset**: {self.dataset_name}  ",
+            f"**Target device**: {self.profile.name}  ",
+            f"**Device notes**: {self.profile.description}  ",
+            f"",
+            f"**Deployable**: {deployable_str}  ",
+            f"**Overall grade**: {self.overall_grade}",
+            f"",
+            f"### Constraint Checks",
+            f"",
+            f"| Constraint | Required | Measured | Margin | Status |",
+            f"|-----------|---------|---------|--------|--------|",
+        ]
+        for score in (self.fps_score, self.memory_score, self.energy_score):
+            if score is None:
+                continue
+            status = "PASS" if score.passed else "FAIL"
+            sign = "+" if score.margin_pct >= 0 else ""
+            lines.append(
+                f"| {score.metric} | {score.required:.2f} | {score.measured:.2f} "
+                f"| {sign}{score.margin_pct:.1f}% | {status} |"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+    def save(self, path: str) -> None:
+        """Write the Markdown report to *path*, creating parent dirs if needed."""
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self.to_markdown())
+
+
+class EdgeDeploymentAnalyzer:
+    """Evaluate whether a :class:`~eovot.benchmark.engine.BenchmarkResult`
+    meets a :class:`~eovot.profiling.hardware_profiles.HardwareProfile`'s
+    deployment constraints.
+
+    Args:
+        energy_budget_mj_per_frame: Maximum allowed energy per frame in
+            milli-Joules.  When ``None`` (default) no energy constraint is
+            applied, even if energy data is present in the result.
+    """
+
+    def __init__(self, energy_budget_mj_per_frame: Optional[float] = None) -> None:
+        self._energy_budget = energy_budget_mj_per_frame
+
+    def analyze(
+        self,
+        result: BenchmarkResult,
+        profile: HardwareProfile,
+    ) -> EdgeDeploymentReport:
+        """Produce an :class:`EdgeDeploymentReport` for *result* on *profile*.
+
+        Args:
+            result: Output from
+                :class:`~eovot.benchmark.engine.BenchmarkEngine`.
+            profile: Target hardware specification.
+
+        Returns:
+            :class:`EdgeDeploymentReport` with per-constraint pass/fail
+            scores, margins, and an overall letter grade.
+        """
+        return EdgeDeploymentReport(
+            tracker_name=result.tracker_name,
+            dataset_name=result.dataset_name,
+            profile=profile,
+            fps_score=self._score_fps(result.mean_fps, profile.target_fps),
+            memory_score=self._score_memory(
+                result.peak_memory_mb, float(profile.memory_limit_mb)
+            ),
+            energy_score=self._score_energy(result.mean_energy_per_frame_mj),
+        )
+
+    def compare(
+        self,
+        results: List[BenchmarkResult],
+        profile: HardwareProfile,
+    ) -> List[EdgeDeploymentReport]:
+        """Analyze multiple trackers on one hardware profile.
+
+        Returns reports sorted by grade (A best), then FPS margin descending.
+
+        Args:
+            results: List of :class:`~eovot.benchmark.engine.BenchmarkResult`
+                objects, one per tracker.
+            profile: Shared hardware target.
+
+        Returns:
+            Sorted list of :class:`EdgeDeploymentReport` objects.
+        """
+        reports = [self.analyze(r, profile) for r in results]
+        reports.sort(key=lambda r: (_GRADE_ORDER[r.overall_grade], -r.fps_score.margin_pct))
+        return reports
+
+    # ------------------------------------------------------------------
+    # Per-constraint scoring
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _score_fps(measured: float, required: float) -> ConstraintScore:
+        margin_pct = (measured - required) / required * 100.0
+        return ConstraintScore(
+            metric="FPS",
+            required=required,
+            measured=measured,
+            passed=measured >= required,
+            margin_pct=margin_pct,
+        )
+
+    @staticmethod
+    def _score_memory(measured_mb: float, limit_mb: float) -> ConstraintScore:
+        margin_pct = (limit_mb - measured_mb) / limit_mb * 100.0
+        return ConstraintScore(
+            metric="Memory (MiB)",
+            required=limit_mb,
+            measured=measured_mb,
+            passed=measured_mb <= limit_mb,
+            margin_pct=margin_pct,
+        )
+
+    def _score_energy(self, measured_mj: Optional[float]) -> Optional[ConstraintScore]:
+        if measured_mj is None or self._energy_budget is None:
+            return None
+        margin_pct = (self._energy_budget - measured_mj) / self._energy_budget * 100.0
+        return ConstraintScore(
+            metric="Energy (mJ/frame)",
+            required=self._energy_budget,
+            measured=measured_mj,
+            passed=measured_mj <= self._energy_budget,
+            margin_pct=margin_pct,
+        )
+
+    # ------------------------------------------------------------------
+    # Leaderboard helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def leaderboard(reports: List[EdgeDeploymentReport]) -> str:
+        """Render a Markdown leaderboard table from a list of reports.
+
+        Reports are sorted by grade (A → F), then FPS margin descending.
+
+        Args:
+            reports: List of :class:`EdgeDeploymentReport` objects,
+                typically from :meth:`compare`.
+
+        Returns:
+            Multi-line Markdown string containing the leaderboard table.
+        """
+        sorted_reports = sorted(
+            reports,
+            key=lambda r: (_GRADE_ORDER[r.overall_grade], -r.fps_score.margin_pct),
+        )
+        lines = [
+            "| Rank | Tracker | FPS | FPS Margin | Memory (MiB) | Memory Margin | Grade | Deployable |",
+            "|-----|--------|-----|-----------|-------------|--------------|-------|-----------|",
+        ]
+        for rank, r in enumerate(sorted_reports, start=1):
+            fps_sign = "+" if r.fps_score.margin_pct >= 0 else ""
+            mem_sign = "+" if r.memory_score.margin_pct >= 0 else ""
+            deployable = "YES" if r.is_deployable else "NO"
+            lines.append(
+                f"| {rank} "
+                f"| {r.tracker_name} "
+                f"| {r.fps_score.measured:.1f} "
+                f"| {fps_sign}{r.fps_score.margin_pct:.1f}% "
+                f"| {r.memory_score.measured:.0f} "
+                f"| {mem_sign}{r.memory_score.margin_pct:.1f}% "
+                f"| {r.overall_grade} "
+                f"| {deployable} |"
+            )
+        return "\n".join(lines)
+
+
+_GRADE_ORDER = {"A": 0, "B": 1, "C": 2, "D": 3, "F": 4}

--- a/tests/test_edge_report.py
+++ b/tests/test_edge_report.py
@@ -1,0 +1,321 @@
+"""Unit tests for EdgeDeploymentAnalyzer and EdgeDeploymentReport."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from eovot.profiling.hardware_profiles import (
+    JETSON_NANO,
+    LAPTOP_CPU,
+    RASPBERRY_PI_4,
+    HardwareProfile,
+    get_profile,
+)
+from eovot.reporting.edge_report import (
+    ConstraintScore,
+    EdgeDeploymentAnalyzer,
+    EdgeDeploymentReport,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_result(
+    tracker_name: str = "MOSSE",
+    dataset_name: str = "OTB100",
+    mean_fps: float = 500.0,
+    peak_memory_mb: float = 128.0,
+    mean_energy_per_frame_mj: float | None = None,
+) -> MagicMock:
+    """Build a minimal mock of BenchmarkResult."""
+    r = MagicMock()
+    r.tracker_name = tracker_name
+    r.dataset_name = dataset_name
+    r.mean_fps = mean_fps
+    r.peak_memory_mb = peak_memory_mb
+    r.mean_energy_per_frame_mj = mean_energy_per_frame_mj
+    return r
+
+
+# ---------------------------------------------------------------------------
+# ConstraintScore
+# ---------------------------------------------------------------------------
+
+def test_constraint_score_pass():
+    s = ConstraintScore("FPS", required=30.0, measured=500.0, passed=True, margin_pct=1566.7)
+    assert s.passed
+    assert "PASS" in str(s)
+
+
+def test_constraint_score_fail():
+    s = ConstraintScore("FPS", required=30.0, measured=5.0, passed=False, margin_pct=-83.3)
+    assert not s.passed
+    assert "FAIL" in str(s)
+
+
+# ---------------------------------------------------------------------------
+# EdgeDeploymentAnalyzer.analyze — basic
+# ---------------------------------------------------------------------------
+
+def test_analyze_returns_report():
+    result = _mock_result()
+    analyzer = EdgeDeploymentAnalyzer()
+    report = analyzer.analyze(result, JETSON_NANO)
+    assert isinstance(report, EdgeDeploymentReport)
+
+
+def test_analyze_tracker_and_dataset_names_propagated():
+    result = _mock_result(tracker_name="KCF", dataset_name="GOT10k")
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.tracker_name == "KCF"
+    assert report.dataset_name == "GOT10k"
+
+
+def test_analyze_profile_stored():
+    result = _mock_result()
+    report = EdgeDeploymentAnalyzer().analyze(result, RASPBERRY_PI_4)
+    assert report.profile is RASPBERRY_PI_4
+
+
+# ---------------------------------------------------------------------------
+# FPS constraint
+# ---------------------------------------------------------------------------
+
+def test_fps_passes_when_above_target(tmp_path):
+    result = _mock_result(mean_fps=60.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)  # target = 30
+    assert report.fps_score.passed
+    assert report.fps_score.margin_pct > 0
+
+
+def test_fps_fails_when_below_target():
+    result = _mock_result(mean_fps=5.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)  # target = 30
+    assert not report.fps_score.passed
+    assert report.fps_score.margin_pct < 0
+
+
+def test_fps_margin_exact_target():
+    result = _mock_result(mean_fps=30.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.fps_score.passed
+    assert report.fps_score.margin_pct == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Memory constraint
+# ---------------------------------------------------------------------------
+
+def test_memory_passes_when_within_limit():
+    result = _mock_result(peak_memory_mb=256.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)  # limit = 4096
+    assert report.memory_score.passed
+    assert report.memory_score.margin_pct > 0
+
+
+def test_memory_fails_when_exceeds_limit():
+    result = _mock_result(peak_memory_mb=8192.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)  # limit = 4096
+    assert not report.memory_score.passed
+    assert report.memory_score.margin_pct < 0
+
+
+# ---------------------------------------------------------------------------
+# Energy constraint
+# ---------------------------------------------------------------------------
+
+def test_energy_score_none_when_no_budget_set():
+    result = _mock_result(mean_energy_per_frame_mj=0.1)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.energy_score is None
+
+
+def test_energy_score_none_when_no_energy_data():
+    result = _mock_result(mean_energy_per_frame_mj=None)
+    report = EdgeDeploymentAnalyzer(energy_budget_mj_per_frame=1.0).analyze(
+        result, JETSON_NANO
+    )
+    assert report.energy_score is None
+
+
+def test_energy_passes_when_within_budget():
+    result = _mock_result(mean_energy_per_frame_mj=0.1)
+    report = EdgeDeploymentAnalyzer(energy_budget_mj_per_frame=1.0).analyze(
+        result, JETSON_NANO
+    )
+    assert report.energy_score is not None
+    assert report.energy_score.passed
+
+
+def test_energy_fails_when_over_budget():
+    result = _mock_result(mean_energy_per_frame_mj=2.0)
+    report = EdgeDeploymentAnalyzer(energy_budget_mj_per_frame=1.0).analyze(
+        result, JETSON_NANO
+    )
+    assert report.energy_score is not None
+    assert not report.energy_score.passed
+
+
+# ---------------------------------------------------------------------------
+# is_deployable
+# ---------------------------------------------------------------------------
+
+def test_deployable_when_all_pass():
+    result = _mock_result(mean_fps=500.0, peak_memory_mb=128.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.is_deployable
+
+
+def test_not_deployable_when_fps_fails():
+    result = _mock_result(mean_fps=1.0, peak_memory_mb=128.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert not report.is_deployable
+
+
+def test_not_deployable_when_memory_fails():
+    result = _mock_result(mean_fps=500.0, peak_memory_mb=999999.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert not report.is_deployable
+
+
+# ---------------------------------------------------------------------------
+# overall_grade
+# ---------------------------------------------------------------------------
+
+def test_grade_a_for_high_margin():
+    result = _mock_result(mean_fps=10000.0, peak_memory_mb=1.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.overall_grade == "A"
+
+
+def test_grade_f_for_multiple_failures():
+    result = _mock_result(mean_fps=0.1, peak_memory_mb=999999.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.overall_grade == "F"
+
+
+def test_grade_d_for_one_failure():
+    result = _mock_result(mean_fps=0.1, peak_memory_mb=1.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.overall_grade == "D"
+
+
+def test_grade_c_for_tight_pass():
+    result = _mock_result(mean_fps=30.5, peak_memory_mb=4000.0)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert report.overall_grade == "C"
+
+
+# ---------------------------------------------------------------------------
+# summary dict
+# ---------------------------------------------------------------------------
+
+def test_summary_keys_present():
+    result = _mock_result()
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    s = report.summary()
+    for key in ("tracker", "dataset", "hardware_profile", "deployable", "grade",
+                "fps_required", "fps_measured", "fps_margin_pct",
+                "memory_limit_mb", "memory_measured_mb", "memory_margin_pct"):
+        assert key in s, f"Missing key: {key}"
+
+
+def test_summary_energy_keys_present_when_profiled():
+    result = _mock_result(mean_energy_per_frame_mj=0.2)
+    report = EdgeDeploymentAnalyzer(energy_budget_mj_per_frame=1.0).analyze(
+        result, JETSON_NANO
+    )
+    s = report.summary()
+    assert "energy_budget_mj_per_frame" in s
+    assert "energy_measured_mj_per_frame" in s
+    assert "energy_margin_pct" in s
+
+
+# ---------------------------------------------------------------------------
+# to_markdown
+# ---------------------------------------------------------------------------
+
+def test_to_markdown_contains_tracker_name():
+    result = _mock_result(tracker_name="MOSSE")
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    md = report.to_markdown()
+    assert "MOSSE" in md
+
+
+def test_to_markdown_contains_profile_name():
+    result = _mock_result()
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    md = report.to_markdown()
+    assert "Jetson Nano" in md
+
+
+def test_to_markdown_contains_pass_fail():
+    result = _mock_result(mean_fps=0.1)
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    md = report.to_markdown()
+    assert "FAIL" in md
+
+
+def test_to_markdown_is_string():
+    result = _mock_result()
+    report = EdgeDeploymentAnalyzer().analyze(result, JETSON_NANO)
+    assert isinstance(report.to_markdown(), str)
+
+
+# ---------------------------------------------------------------------------
+# save to file
+# ---------------------------------------------------------------------------
+
+def test_save_writes_file(tmp_path):
+    result = _mock_result()
+    report = EdgeDeploymentAnalyzer().analyze(result, LAPTOP_CPU)
+    out = str(tmp_path / "report.md")
+    report.save(out)
+    with open(out) as f:
+        content = f.read()
+    assert "MOSSE" in content
+    assert "Laptop" in content
+
+
+# ---------------------------------------------------------------------------
+# compare + leaderboard
+# ---------------------------------------------------------------------------
+
+def test_compare_returns_sorted_list():
+    results = [
+        _mock_result("MOSSE", mean_fps=600.0, peak_memory_mb=50.0),
+        _mock_result("KCF", mean_fps=200.0, peak_memory_mb=80.0),
+        _mock_result("SlowTracker", mean_fps=5.0, peak_memory_mb=200.0),
+    ]
+    reports = EdgeDeploymentAnalyzer().compare(results, JETSON_NANO)
+    assert len(reports) == 3
+    grades = [r.overall_grade for r in reports]
+    grade_order = {"A": 0, "B": 1, "C": 2, "D": 3, "F": 4}
+    assert all(
+        grade_order[grades[i]] <= grade_order[grades[i + 1]]
+        for i in range(len(grades) - 1)
+    )
+
+
+def test_leaderboard_is_string():
+    results = [
+        _mock_result("MOSSE", mean_fps=600.0, peak_memory_mb=50.0),
+        _mock_result("KCF", mean_fps=10.0, peak_memory_mb=80.0),
+    ]
+    reports = EdgeDeploymentAnalyzer().compare(results, RASPBERRY_PI_4)
+    lb = EdgeDeploymentAnalyzer.leaderboard(reports)
+    assert isinstance(lb, str)
+    assert "MOSSE" in lb
+    assert "KCF" in lb
+
+
+def test_leaderboard_contains_rank_column():
+    results = [_mock_result("MOSSE")]
+    reports = EdgeDeploymentAnalyzer().compare(results, LAPTOP_CPU)
+    lb = EdgeDeploymentAnalyzer.leaderboard(reports)
+    assert "Rank" in lb

--- a/tests/test_hardware_profiles.py
+++ b/tests/test_hardware_profiles.py
@@ -1,0 +1,127 @@
+"""Unit tests for eovot.profiling.hardware_profiles."""
+
+import pytest
+
+from eovot.profiling.hardware_profiles import (
+    HardwareProfile,
+    PROFILES,
+    get_profile,
+    JETSON_NANO,
+    RASPBERRY_PI_4,
+    RASPBERRY_PI_ZERO_2W,
+    LAPTOP_CPU,
+    DESKTOP_GPU,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry completeness
+# ---------------------------------------------------------------------------
+
+def test_profiles_registry_not_empty():
+    assert len(PROFILES) > 0
+
+
+def test_all_expected_slugs_present():
+    expected = {"jetson-nano", "rpi4", "rpi-zero-2w", "intel-ncs2", "coral-tpu", "laptop", "desktop"}
+    assert expected.issubset(set(PROFILES))
+
+
+def test_all_profiles_are_hardware_profile_instances():
+    for slug, p in PROFILES.items():
+        assert isinstance(p, HardwareProfile), f"{slug} is not a HardwareProfile"
+
+
+# ---------------------------------------------------------------------------
+# get_profile
+# ---------------------------------------------------------------------------
+
+def test_get_profile_known_slug():
+    p = get_profile("jetson-nano")
+    assert p is JETSON_NANO
+
+
+def test_get_profile_unknown_slug_raises_key_error():
+    with pytest.raises(KeyError, match="Unknown hardware profile"):
+        get_profile("nonexistent-device")
+
+
+def test_get_profile_error_message_lists_available():
+    with pytest.raises(KeyError) as exc_info:
+        get_profile("invalid")
+    assert "jetson-nano" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Profile field constraints
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("slug", list(PROFILES))
+def test_tdp_positive(slug):
+    assert PROFILES[slug].tdp_watts > 0
+
+
+@pytest.mark.parametrize("slug", list(PROFILES))
+def test_memory_limit_positive(slug):
+    assert PROFILES[slug].memory_limit_mb > 0
+
+
+@pytest.mark.parametrize("slug", list(PROFILES))
+def test_target_fps_positive(slug):
+    assert PROFILES[slug].target_fps > 0
+
+
+@pytest.mark.parametrize("slug", list(PROFILES))
+def test_cpu_cores_positive(slug):
+    assert PROFILES[slug].cpu_cores >= 1
+
+
+@pytest.mark.parametrize("slug", list(PROFILES))
+def test_name_non_empty(slug):
+    assert PROFILES[slug].name.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# Ordering sanity: resource-constrained devices have stricter specs
+# ---------------------------------------------------------------------------
+
+def test_rpi_zero_has_less_memory_than_rpi4():
+    assert RASPBERRY_PI_ZERO_2W.memory_limit_mb < RASPBERRY_PI_4.memory_limit_mb
+
+
+def test_laptop_has_more_memory_than_jetson_nano():
+    assert LAPTOP_CPU.memory_limit_mb > JETSON_NANO.memory_limit_mb
+
+
+def test_desktop_has_higher_tdp_than_laptop():
+    assert DESKTOP_GPU.tdp_watts > LAPTOP_CPU.tdp_watts
+
+
+def test_rpi_zero_has_lower_fps_target_than_rpi4():
+    assert RASPBERRY_PI_ZERO_2W.target_fps < RASPBERRY_PI_4.target_fps
+
+
+# ---------------------------------------------------------------------------
+# Immutability (frozen dataclass)
+# ---------------------------------------------------------------------------
+
+def test_profiles_are_immutable():
+    p = get_profile("rpi4")
+    with pytest.raises((AttributeError, TypeError)):
+        p.target_fps = 999.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# __str__ representation
+# ---------------------------------------------------------------------------
+
+def test_str_contains_name():
+    p = get_profile("laptop")
+    s = str(p)
+    assert "Laptop" in s
+
+
+def test_str_contains_fps():
+    p = get_profile("jetson-nano")
+    s = str(p)
+    assert "30" in s


### PR DESCRIPTION
## What was added

Two new modules that answer the question: **"can tracker X actually run on device Y?"** — turning benchmark numbers into actionable deployment decisions.

---

### `eovot/profiling/hardware_profiles.py`

Defines `HardwareProfile` (frozen dataclass) with four fields: `tdp_watts`, `memory_limit_mb`, `target_fps`, `cpu_cores`.

Ships seven built-in profiles covering the common edge-deployment landscape:

| Slug | Device | TDP | RAM | Target FPS |
|------|--------|-----|-----|-----------|
| `jetson-nano` | NVIDIA Jetson Nano 4GB | 10 W | 4096 MiB | 30 fps |
| `rpi4` | Raspberry Pi 4 (4GB) | 6 W | 4096 MiB | 15 fps |
| `rpi-zero-2w` | Raspberry Pi Zero 2W | 2.5 W | 512 MiB | 5 fps |
| `intel-ncs2` | Intel Neural Compute Stick 2 | 1 W | 512 MiB | 60 fps |
| `coral-tpu` | Google Coral Dev Board | 2 W | 8192 MiB | 100 fps |
| `laptop` | Generic 8-core laptop | 28 W | 16384 MiB | 30 fps |
| `desktop` | Workstation + GPU | 250 W | 32768 MiB | 120 fps |

`get_profile(slug)` provides typed lookup with a descriptive error listing all available slugs.

---

### `eovot/reporting/edge_report.py`

`EdgeDeploymentAnalyzer.analyze(result, profile)` maps a `BenchmarkResult` onto three `ConstraintScore` objects:

- **FPS**: `measured >= profile.target_fps`
- **Memory**: `peak_memory_mb <= profile.memory_limit_mb`
- **Energy** *(optional)*: `mean_energy_per_frame_mj <= budget` — only checked when both an `energy_budget_mj_per_frame` is set on the analyzer AND the result contains energy data.

Each `ConstraintScore` records: `passed` (bool), `margin_pct` (positive = headroom, negative = over-budget).

The `EdgeDeploymentReport` aggregates these into:
- `is_deployable` — True only when all active constraints pass
- `overall_grade` (A–F) based on worst-case margin headroom
- `to_markdown()` — publication-ready constraint table
- `save(path)` — write report to file

`compare(results, profile)` and `leaderboard(reports)` rank multiple trackers on a single device target.

---

## Why it matters for EOVOT

A benchmark run produces FPS and memory numbers, but "is 200 FPS on a laptop fast enough for the Jetson Nano?" requires a separate comparison step that researchers currently do by hand. These modules make deployment feasibility a first-class output of the benchmark pipeline, enabling automated pass/fail gating in CI or experiment scripts.

## Files changed

| File | Change |
|------|--------|
| `eovot/profiling/hardware_profiles.py` | New module — 7 profiles, `get_profile()` |
| `eovot/profiling/__init__.py` | Export `HardwareProfile`, `get_profile`, `PROFILES` |
| `eovot/reporting/edge_report.py` | New module — `ConstraintScore`, `EdgeDeploymentReport`, `EdgeDeploymentAnalyzer` |
| `eovot/reporting/__init__.py` | Export new reporting classes |
| `tests/test_hardware_profiles.py` | 48 tests — registry, field constraints, ordering, immutability |
| `tests/test_edge_report.py` | 31 tests — all constraint paths, grading, markdown, file I/O, leaderboard |

All 79 tests pass. No existing tests broken.

## Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.profiling.hardware_profiles import get_profile
from eovot.reporting.edge_report import EdgeDeploymentAnalyzer

# Run benchmark with energy profiling
result = BenchmarkEngine(tdp_watts=10.0).run(tracker, dataset)

# Analyze against Jetson Nano with 0.5 mJ/frame energy budget
analyzer = EdgeDeploymentAnalyzer(energy_budget_mj_per_frame=0.5)
report = analyzer.analyze(result, get_profile("jetson-nano"))

print(report.overall_grade)   # "A", "B", "C", "D", or "F"
print(report.is_deployable)   # True / False
print(report.to_markdown())

# Compare multiple trackers
results = [mosse_result, kcf_result, csrt_result]
reports = analyzer.compare(results, get_profile("rpi4"))
print(EdgeDeploymentAnalyzer.leaderboard(reports))
```

**Sample leaderboard output:**
```
| Rank | Tracker | FPS   | FPS Margin | Memory (MiB) | Memory Margin | Grade | Deployable |
|------|---------|-------|-----------|-------------|--------------|-------|-----------|
| 1    | MOSSE   | 612.3 | +3982.0%  | 48          | +98.8%       | A     | YES        |
| 2    | KCF     | 220.1 | +1367.3%  | 72          | +98.2%       | A     | YES        |
| 3    | CSRT    | 42.0  | +180.0%   | 95          | +97.7%       | A     | YES        |
```

## No breaking changes

- All existing modules, APIs, and tests are unchanged
- New exports are purely additive

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFU8LRw7nFT2DtDHpGPmJk)_