### PR TITLE
[feat] Sequence difficulty profiler for per-dataset characterisation

### DIFF
--- a/eovot/__init__.py
+++ b/eovot/__init__.py
@@ -2,6 +2,14 @@
 
 __version__ = "0.1.0"
 
-from eovot import benchmark, datasets, metrics, profiling, reporting, trackers
+from eovot import analysis, benchmark, datasets, metrics, profiling, reporting, trackers
 
-__all__ = ["benchmark", "datasets", "metrics", "profiling", "reporting", "trackers"]
+__all__ = [
+    "analysis",
+    "benchmark",
+    "datasets",
+    "metrics",
+    "profiling",
+    "reporting",
+    "trackers",
+]

--- a/eovot/analysis/__init__.py
+++ b/eovot/analysis/__init__.py
@@ -1,0 +1,26 @@
+"""Analysis sub-package — dataset and sequence characterisation tools.
+
+Provides utilities for understanding dataset properties and sequence
+difficulty without requiring any tracker inference.
+
+Modules
+-------
+sequence_profiler
+    :class:`~eovot.analysis.sequence_profiler.SequenceDifficultyProfiler`
+    and :class:`~eovot.analysis.sequence_profiler.SequenceDifficulty` —
+    characterise sequences by motion, scale change, and deformation, then
+    rank them by composite difficulty score.
+
+Quick start::
+
+    from eovot.analysis import SequenceDifficultyProfiler
+
+    profiler = SequenceDifficultyProfiler()
+    diffs    = profiler.profile_dataset(dataset)
+    ranked   = profiler.sort_by_difficulty(diffs)   # hardest first
+    stats    = profiler.summary_stats(diffs)
+"""
+
+from .sequence_profiler import SequenceDifficulty, SequenceDifficultyProfiler
+
+__all__ = ["SequenceDifficulty", "SequenceDifficultyProfiler"]

--- a/eovot/analysis/sequence_profiler.py
+++ b/eovot/analysis/sequence_profiler.py
@@ -1,0 +1,389 @@
+"""Sequence difficulty profiler for EOVOT datasets.
+
+Characterises each tracking sequence by its intrinsic difficulty along five
+dimensions derived solely from ground-truth bounding box trajectories — no
+tracker inference is needed.
+
+Difficulty dimensions
+---------------------
+* **Scale change** (``target_area_cv``) — coefficient of variation of the
+  target area; high means the target grows or shrinks drastically.
+* **Target size** (``target_area_mean``) — small targets are harder; expressed
+  as a fraction of total frame area so the metric is resolution-independent.
+* **Motion magnitude** (``motion_mean``) — mean frame-to-frame centre
+  displacement normalised by the frame diagonal.
+* **Motion irregularity** (``motion_cv``) — coefficient of variation of
+  per-frame displacement; high means the target moves erratically.
+* **Deformation** (``aspect_ratio_std``) — standard deviation of the target's
+  width/height ratio; high means the target changes shape (e.g. a person
+  turning sideways).
+
+A weighted composite ``difficulty_score ∈ [0, 1]`` combines all five
+dimensions: 0 = trivially easy, 1 = maximally hard.
+
+Typical usage::
+
+    from eovot.analysis.sequence_profiler import SequenceDifficultyProfiler
+    from eovot.datasets.base import OTBDataset
+
+    dataset  = OTBDataset("/data/OTB100")
+    profiler = SequenceDifficultyProfiler()
+
+    difficulties = profiler.profile_dataset(dataset)
+    ranked       = profiler.sort_by_difficulty(difficulties)   # hardest first
+    stats        = profiler.summary_stats(difficulties)
+
+    print(f"Hardest sequence: {ranked[0].sequence_name}  "
+          f"(score={ranked[0].difficulty_score:.3f})")
+    print(stats)
+
+References
+----------
+* Wu et al., "Object Tracking Benchmark." TPAMI 2015 — OTB attribute taxonomy.
+* Müller et al., "TrackingNet: A Large-Scale Dataset …" ECCV 2018 — motion
+  and size analysis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from ..datasets.base import BaseDataset, Sequence
+
+# ---------------------------------------------------------------------------
+# Composite score weights — must sum to 1.0
+# ---------------------------------------------------------------------------
+_W_SCALE_CHANGE   = 0.30
+_W_MOTION_MAG     = 0.35
+_W_MOTION_CV      = 0.20
+_W_DEFORMATION    = 0.15
+
+# Normalisation constants for mapping raw metrics to [0, 1]
+_NORM_MOTION_MAG  = 0.20   # frame-diagonal fraction above which motion is "fast"
+_NORM_AR_STD      = 0.50   # aspect-ratio std above which deformation is "severe"
+
+
+# ---------------------------------------------------------------------------
+# Public dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SequenceDifficulty:
+    """Difficulty characterisation of a single tracking sequence.
+
+    All spatial measurements are normalised by frame dimensions so that
+    metrics are comparable across datasets with different resolutions.
+
+    Attributes:
+        sequence_name: Identifier of the sequence.
+        num_frames:    Number of frames (= rows in ground-truth array).
+        target_area_mean: Mean target area as a fraction of total frame area.
+            Small values (< 0.01) indicate tiny-target challenge.
+        target_area_cv: Coefficient of variation of target area in [0, ∞).
+            High values indicate significant scale change.
+        motion_mean: Mean per-frame centre displacement normalised by frame
+            diagonal.  Values > 0.05 are considered fast-motion.
+        motion_cv:  Coefficient of variation of per-frame displacement.
+            High values indicate erratic / unpredictable motion.
+        aspect_ratio_std: Standard deviation of the target width/height ratio.
+            Values > 0.2 indicate significant shape deformation.
+        difficulty_score: Weighted composite difficulty in [0, 1].
+            Higher → harder for most standard trackers.
+    """
+
+    sequence_name: str
+    num_frames: int
+
+    target_area_mean: float
+    target_area_cv: float
+    motion_mean: float
+    motion_cv: float
+    aspect_ratio_std: float
+    difficulty_score: float
+
+    def __str__(self) -> str:
+        return (
+            f"SequenceDifficulty({self.sequence_name!r}  "
+            f"frames={self.num_frames}  "
+            f"score={self.difficulty_score:.3f}  "
+            f"area={self.target_area_mean:.4f}  "
+            f"motion={self.motion_mean:.4f})"
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise to a plain dict suitable for JSON export or pandas."""
+        return {
+            "sequence_name":   self.sequence_name,
+            "num_frames":      self.num_frames,
+            "target_area_mean": round(self.target_area_mean, 6),
+            "target_area_cv":  round(self.target_area_cv,   4),
+            "motion_mean":     round(self.motion_mean,      6),
+            "motion_cv":       round(self.motion_cv,        4),
+            "aspect_ratio_std": round(self.aspect_ratio_std, 4),
+            "difficulty_score": round(self.difficulty_score, 4),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _first_frame_size(sequence: Sequence) -> tuple:
+    """Return ``(width, height)`` by loading only the first frame."""
+    frame = next(iter(sequence))
+    h, w = frame.shape[:2]
+    return w, h
+
+
+def _compute_metrics(
+    gt: np.ndarray,
+    frame_w: int,
+    frame_h: int,
+) -> Dict[str, float]:
+    """Compute raw difficulty metrics from a GT array and frame dimensions.
+
+    Args:
+        gt:      Ground-truth array, shape ``(N, 4)`` in ``(x, y, w, h)`` format.
+        frame_w: Frame width in pixels.
+        frame_h: Frame height in pixels.
+
+    Returns:
+        Dict with keys ``target_area_mean``, ``target_area_cv``, ``motion_mean``,
+        ``motion_cv``, ``aspect_ratio_std``.
+    """
+    n = len(gt)
+    frame_area = float(frame_w * frame_h)
+    frame_diag = float(np.sqrt(frame_w ** 2 + frame_h ** 2))
+
+    # ---- target area (normalised) ----
+    areas = gt[:, 2] * gt[:, 3]                          # w * h per frame
+    valid = areas[areas > 0]
+    if len(valid) == 0:
+        return _zero_metrics()
+
+    target_area_mean = float(valid.mean()) / frame_area
+    mean_area = float(valid.mean())
+    target_area_cv = float(valid.std() / mean_area) if mean_area > 0 else 0.0
+
+    # ---- motion (normalised by frame diagonal) ----
+    cx = gt[:, 0] + gt[:, 2] / 2.0
+    cy = gt[:, 1] + gt[:, 3] / 2.0
+    if n > 1:
+        displacements = np.sqrt(np.diff(cx) ** 2 + np.diff(cy) ** 2) / frame_diag
+        motion_mean = float(displacements.mean())
+        motion_cv   = float(displacements.std() / motion_mean) if motion_mean > 0 else 0.0
+    else:
+        motion_mean = 0.0
+        motion_cv   = 0.0
+
+    # ---- aspect ratio deformation ----
+    valid_boxes = (gt[:, 2] > 0) & (gt[:, 3] > 0)
+    if valid_boxes.sum() > 1:
+        ars = gt[valid_boxes, 2] / gt[valid_boxes, 3]
+        aspect_ratio_std = float(ars.std())
+    else:
+        aspect_ratio_std = 0.0
+
+    return {
+        "target_area_mean": target_area_mean,
+        "target_area_cv":   target_area_cv,
+        "motion_mean":      motion_mean,
+        "motion_cv":        motion_cv,
+        "aspect_ratio_std": aspect_ratio_std,
+    }
+
+
+def _zero_metrics() -> Dict[str, float]:
+    return {
+        "target_area_mean": 0.0,
+        "target_area_cv":   0.0,
+        "motion_mean":      0.0,
+        "motion_cv":        0.0,
+        "aspect_ratio_std": 0.0,
+    }
+
+
+def _composite_score(m: Dict[str, float]) -> float:
+    """Map raw difficulty metrics to a scalar score in [0, 1].
+
+    Each component is independently clipped to [0, 1] before weighting so
+    extreme outliers in one dimension don't dominate the overall score.
+
+    Weights::
+
+        scale_change  0.30   (target_area_cv)
+        motion_mag    0.35   (motion_mean / _NORM_MOTION_MAG)
+        motion_cv     0.20   (motion_cv, capped at 1)
+        deformation   0.15   (aspect_ratio_std / _NORM_AR_STD)
+    """
+    scale_ch  = min(1.0, m["target_area_cv"])
+    motion_mg = min(1.0, m["motion_mean"] / _NORM_MOTION_MAG)
+    motion_cv = min(1.0, m["motion_cv"])
+    deform    = min(1.0, m["aspect_ratio_std"] / _NORM_AR_STD)
+
+    return float(
+        _W_SCALE_CHANGE * scale_ch
+        + _W_MOTION_MAG * motion_mg
+        + _W_MOTION_CV  * motion_cv
+        + _W_DEFORMATION * deform
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public profiler class
+# ---------------------------------------------------------------------------
+
+class SequenceDifficultyProfiler:
+    """Profile the difficulty of tracking sequences in a dataset.
+
+    Computes five difficulty dimensions per sequence from ground-truth box
+    trajectories alone — no tracker inference is required.  Results can be
+    used to:
+
+    * Rank sequences from hardest to easiest for ablation studies.
+    * Correlate per-sequence tracker accuracy with difficulty dimensions.
+    * Characterise dataset difficulty distributions for paper tables.
+
+    Args:
+        verbose: If ``True``, print per-sequence progress to stdout.
+
+    Example::
+
+        profiler    = SequenceDifficultyProfiler()
+        diffs       = profiler.profile_dataset(dataset)
+        ranked      = profiler.sort_by_difficulty(diffs)           # hardest first
+        stats       = profiler.summary_stats(diffs)
+
+        hard = [d for d in diffs if d.difficulty_score > 0.6]
+        easy = [d for d in diffs if d.difficulty_score < 0.2]
+    """
+
+    def __init__(self, verbose: bool = False) -> None:
+        self.verbose = verbose
+
+    def profile_sequence(self, sequence: Sequence) -> SequenceDifficulty:
+        """Profile the difficulty of a single sequence.
+
+        Reads only the first frame to determine resolution; all remaining
+        metrics come from the ground-truth array.
+
+        Args:
+            sequence: :class:`~eovot.datasets.base.Sequence` to characterise.
+
+        Returns:
+            :class:`SequenceDifficulty` with all five dimension metrics and
+            the composite ``difficulty_score``.
+        """
+        gt       = np.asarray(sequence.ground_truth, dtype=np.float64)
+        if gt.ndim == 1:
+            gt = gt[np.newaxis, :]
+
+        frame_w, frame_h = _first_frame_size(sequence)
+        raw_metrics      = _compute_metrics(gt, frame_w, frame_h)
+        score            = _composite_score(raw_metrics)
+
+        return SequenceDifficulty(
+            sequence_name=sequence.name,
+            num_frames=len(gt),
+            difficulty_score=round(score, 6),
+            **{k: round(v, 8) for k, v in raw_metrics.items()},
+        )
+
+    def profile_dataset(
+        self,
+        dataset: BaseDataset,
+        max_sequences: Optional[int] = None,
+    ) -> List[SequenceDifficulty]:
+        """Profile all sequences in *dataset*.
+
+        Args:
+            dataset:       Dataset whose sequences to profile.
+            max_sequences: Analyse only the first *N* sequences.
+                           ``None`` (default) profiles all.
+
+        Returns:
+            List of :class:`SequenceDifficulty`, one per sequence, in
+            dataset order.
+        """
+        n = min(len(dataset), max_sequences) if max_sequences is not None else len(dataset)
+        results: List[SequenceDifficulty] = []
+        for i in range(n):
+            seq  = dataset[i]
+            diff = self.profile_sequence(seq)
+            results.append(diff)
+            if self.verbose:
+                print(f"  [{i + 1:>3}/{n}] {diff}")
+        return results
+
+    def sort_by_difficulty(
+        self,
+        difficulties: List[SequenceDifficulty],
+        descending: bool = True,
+    ) -> List[SequenceDifficulty]:
+        """Return a copy of *difficulties* sorted by composite score.
+
+        Args:
+            difficulties: Output of :meth:`profile_dataset` or a curated list.
+            descending:   ``True`` (default) → hardest sequences first.
+
+        Returns:
+            New sorted list; the original is not modified.
+        """
+        return sorted(
+            difficulties,
+            key=lambda d: d.difficulty_score,
+            reverse=descending,
+        )
+
+    def summary_stats(
+        self,
+        difficulties: List[SequenceDifficulty],
+    ) -> Dict[str, object]:
+        """Compute aggregate statistics over all profiled sequences.
+
+        Useful for characterising overall dataset difficulty in a paper table.
+
+        Args:
+            difficulties: Output of :meth:`profile_dataset`.
+
+        Returns:
+            Dict with ``num_sequences`` and per-dimension dicts each containing
+            ``mean``, ``std``, ``min``, ``max``.  Returns ``{}`` for an empty list.
+
+        Example output::
+
+            {
+                "num_sequences": 100,
+                "difficulty_score": {"mean": 0.31, "std": 0.14, "min": 0.03, "max": 0.89},
+                "motion_mean":      {"mean": 0.021, "std": 0.018},
+                "target_area_mean": {"mean": 0.032, "std": 0.027},
+            }
+        """
+        if not difficulties:
+            return {}
+
+        def _stat(arr: np.ndarray) -> Dict[str, float]:
+            return {
+                "mean": round(float(arr.mean()), 6),
+                "std":  round(float(arr.std()),  6),
+                "min":  round(float(arr.min()),  6),
+                "max":  round(float(arr.max()),  6),
+            }
+
+        scores  = np.array([d.difficulty_score  for d in difficulties])
+        motions = np.array([d.motion_mean        for d in difficulties])
+        areas   = np.array([d.target_area_mean   for d in difficulties])
+        scale   = np.array([d.target_area_cv     for d in difficulties])
+        deform  = np.array([d.aspect_ratio_std   for d in difficulties])
+
+        return {
+            "num_sequences":    len(difficulties),
+            "difficulty_score": _stat(scores),
+            "motion_mean":      _stat(motions),
+            "target_area_mean": _stat(areas),
+            "target_area_cv":   _stat(scale),
+            "aspect_ratio_std": _stat(deform),
+        }

--- a/tests/test_sequence_profiler.py
+++ b/tests/test_sequence_profiler.py
@@ -1,0 +1,292 @@
+"""Tests for eovot.analysis.sequence_profiler."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.analysis.sequence_profiler import (
+    SequenceDifficulty,
+    SequenceDifficultyProfiler,
+    _composite_score,
+    _compute_metrics,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Sequence stub — no disk I/O
+# ---------------------------------------------------------------------------
+
+class _MockSequence:
+    """Minimal sequence stub for profiler tests.
+
+    Yields synthetic numpy frames without touching the filesystem.
+    """
+
+    def __init__(
+        self,
+        gt: np.ndarray,
+        frame_w: int = 320,
+        frame_h: int = 240,
+        name: str = "mock_seq",
+    ) -> None:
+        self.ground_truth = gt
+        self.name = name
+        self._frame = np.zeros((frame_h, frame_w, 3), dtype=np.uint8)
+
+    def __iter__(self):
+        for _ in range(len(self.ground_truth)):
+            yield self._frame
+
+    def __len__(self) -> int:
+        return len(self.ground_truth)
+
+    @property
+    def init_bbox(self):
+        return tuple(self.ground_truth[0])
+
+
+# ---------------------------------------------------------------------------
+# GT factories
+# ---------------------------------------------------------------------------
+
+def _static_gt(n: int = 50, x=50, y=50, w=40, h=30) -> np.ndarray:
+    """Target stationary at a fixed location and size."""
+    return np.tile([x, y, w, h], (n, 1)).astype(np.float64)
+
+
+def _moving_gt(n: int = 50, speed: float = 5.0) -> np.ndarray:
+    """Target moving right at constant speed."""
+    gt = np.zeros((n, 4), dtype=np.float64)
+    for i in range(n):
+        gt[i] = [50 + speed * i, 50, 40, 30]
+    return gt
+
+
+def _erratic_gt(n: int = 50, seed: int = 0) -> np.ndarray:
+    """Target moving with random per-frame displacements."""
+    rng = np.random.default_rng(seed)
+    gt = np.zeros((n, 4), dtype=np.float64)
+    x, y = 100.0, 100.0
+    for i in range(n):
+        x += rng.uniform(-20, 20)
+        y += rng.uniform(-20, 20)
+        gt[i] = [max(0, x), max(0, y), 40, 30]
+    return gt
+
+
+def _scaling_gt(n: int = 50) -> np.ndarray:
+    """Target that grows 5% per frame (scale change)."""
+    gt = np.zeros((n, 4), dtype=np.float64)
+    for i in range(n):
+        scale = 1.0 + 0.05 * i
+        gt[i] = [50, 50, 40 * scale, 30 * scale]
+    return gt
+
+
+def _deforming_gt(n: int = 50) -> np.ndarray:
+    """Target that changes aspect ratio each frame (deformation)."""
+    gt = np.zeros((n, 4), dtype=np.float64)
+    for i in range(n):
+        w = 20 + 2 * (i % 20)    # oscillates 20 → 60
+        h = 60 - 2 * (i % 20)    # oscillates 60 → 20
+        gt[i] = [50, 50, max(1, w), max(1, h)]
+    return gt
+
+
+# ---------------------------------------------------------------------------
+# TestComputeMetrics — internal helper
+# ---------------------------------------------------------------------------
+
+class TestComputeMetrics:
+    def test_static_target_zero_motion(self):
+        m = _compute_metrics(_static_gt(), 320, 240)
+        assert m["motion_mean"] == pytest.approx(0.0)
+
+    def test_static_target_zero_scale_change(self):
+        m = _compute_metrics(_static_gt(), 320, 240)
+        assert m["target_area_cv"] == pytest.approx(0.0)
+
+    def test_static_target_zero_deformation(self):
+        m = _compute_metrics(_static_gt(), 320, 240)
+        assert m["aspect_ratio_std"] == pytest.approx(0.0)
+
+    def test_target_area_normalised_by_frame(self):
+        # 40×30 box in a 320×240 frame → 1200 / 76800 = 0.015625
+        m = _compute_metrics(_static_gt(w=40, h=30), 320, 240)
+        assert m["target_area_mean"] == pytest.approx(1200.0 / 76800.0, rel=1e-4)
+
+    def test_moving_target_nonzero_motion(self):
+        m = _compute_metrics(_moving_gt(speed=10.0), 320, 240)
+        assert m["motion_mean"] > 0.0
+
+    def test_scaling_target_nonzero_area_cv(self):
+        m = _compute_metrics(_scaling_gt(), 640, 480)
+        assert m["target_area_cv"] > 0.0
+
+    def test_deforming_target_nonzero_ar_std(self):
+        m = _compute_metrics(_deforming_gt(), 320, 240)
+        assert m["aspect_ratio_std"] > 0.0
+
+    def test_single_frame_zero_motion(self):
+        m = _compute_metrics(_static_gt(n=1), 320, 240)
+        assert m["motion_mean"] == pytest.approx(0.0)
+        assert m["motion_cv"] == pytest.approx(0.0)
+
+    def test_all_zero_area_returns_zeros(self):
+        gt = np.zeros((10, 4), dtype=np.float64)
+        m = _compute_metrics(gt, 320, 240)
+        assert m["target_area_mean"] == pytest.approx(0.0)
+        assert m["motion_mean"] == pytest.approx(0.0)
+
+    def test_motion_normalised_by_diagonal(self):
+        # Speed 10px/frame, diagonal = sqrt(320²+240²) = 400
+        m = _compute_metrics(_moving_gt(speed=10.0), 320, 240)
+        assert m["motion_mean"] == pytest.approx(10.0 / 400.0, rel=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# TestCompositeScore
+# ---------------------------------------------------------------------------
+
+class TestCompositeScore:
+    def test_all_zero_gives_zero(self):
+        m = {"target_area_cv": 0.0, "motion_mean": 0.0,
+             "motion_cv": 0.0, "aspect_ratio_std": 0.0}
+        assert _composite_score(m) == pytest.approx(0.0)
+
+    def test_score_in_unit_interval_random(self):
+        rng = np.random.default_rng(42)
+        for _ in range(50):
+            m = {
+                "target_area_cv":   rng.uniform(0, 3),
+                "motion_mean":      rng.uniform(0, 0.5),
+                "motion_cv":        rng.uniform(0, 3),
+                "aspect_ratio_std": rng.uniform(0, 2),
+            }
+            s = _composite_score(m)
+            assert 0.0 <= s <= 1.0, f"score {s} out of [0, 1] for metrics {m}"
+
+    def test_max_inputs_give_one(self):
+        m = {"target_area_cv": 10.0, "motion_mean": 10.0,
+             "motion_cv": 10.0, "aspect_ratio_std": 10.0}
+        assert _composite_score(m) == pytest.approx(1.0)
+
+    def test_motion_dominated_sequences_score_higher(self):
+        fast   = {"target_area_cv": 0.0, "motion_mean": 0.4,
+                  "motion_cv": 0.0, "aspect_ratio_std": 0.0}
+        slow   = {"target_area_cv": 0.0, "motion_mean": 0.01,
+                  "motion_cv": 0.0, "aspect_ratio_std": 0.0}
+        assert _composite_score(fast) > _composite_score(slow)
+
+
+# ---------------------------------------------------------------------------
+# TestSequenceDifficultyProfiler
+# ---------------------------------------------------------------------------
+
+class TestSequenceDifficultyProfiler:
+    def test_profile_sequence_returns_dataclass(self):
+        seq = _MockSequence(_static_gt())
+        d = SequenceDifficultyProfiler().profile_sequence(seq)
+        assert isinstance(d, SequenceDifficulty)
+
+    def test_profile_sequence_name_preserved(self):
+        seq = _MockSequence(_static_gt(), name="ball")
+        d = SequenceDifficultyProfiler().profile_sequence(seq)
+        assert d.sequence_name == "ball"
+
+    def test_profile_sequence_frame_count(self):
+        seq = _MockSequence(_static_gt(n=75))
+        d = SequenceDifficultyProfiler().profile_sequence(seq)
+        assert d.num_frames == 75
+
+    def test_static_sequence_low_score(self):
+        seq = _MockSequence(_static_gt())
+        d = SequenceDifficultyProfiler().profile_sequence(seq)
+        assert d.difficulty_score == pytest.approx(0.0)
+
+    def test_fast_motion_higher_than_static(self):
+        static  = _MockSequence(_static_gt())
+        moving  = _MockSequence(_moving_gt(speed=30.0))
+        p = SequenceDifficultyProfiler()
+        assert p.profile_sequence(moving).difficulty_score > \
+               p.profile_sequence(static).difficulty_score
+
+    def test_scale_change_higher_than_static(self):
+        static  = _MockSequence(_static_gt())
+        scaling = _MockSequence(_scaling_gt())
+        p = SequenceDifficultyProfiler()
+        assert p.profile_sequence(scaling).difficulty_score > \
+               p.profile_sequence(static).difficulty_score
+
+    def test_deformation_higher_than_static(self):
+        static   = _MockSequence(_static_gt())
+        deforming = _MockSequence(_deforming_gt())
+        p = SequenceDifficultyProfiler()
+        assert p.profile_sequence(deforming).difficulty_score > \
+               p.profile_sequence(static).difficulty_score
+
+    def test_sort_hardest_first(self):
+        p = SequenceDifficultyProfiler()
+        seqs = [
+            _MockSequence(_static_gt(),        name="easy"),
+            _MockSequence(_moving_gt(speed=30), name="hard"),
+        ]
+        diffs  = [p.profile_sequence(s) for s in seqs]
+        ranked = p.sort_by_difficulty(diffs, descending=True)
+        assert ranked[0].sequence_name == "hard"
+        assert ranked[-1].sequence_name == "easy"
+
+    def test_sort_easiest_first(self):
+        p = SequenceDifficultyProfiler()
+        seqs = [
+            _MockSequence(_static_gt(),        name="easy"),
+            _MockSequence(_moving_gt(speed=30), name="hard"),
+        ]
+        diffs  = [p.profile_sequence(s) for s in seqs]
+        ranked = p.sort_by_difficulty(diffs, descending=False)
+        assert ranked[0].sequence_name == "easy"
+
+    def test_sort_does_not_modify_original(self):
+        p = SequenceDifficultyProfiler()
+        diffs = [
+            p.profile_sequence(_MockSequence(_static_gt(),        name="easy")),
+            p.profile_sequence(_MockSequence(_moving_gt(speed=30), name="hard")),
+        ]
+        original_order = [d.sequence_name for d in diffs]
+        p.sort_by_difficulty(diffs)
+        assert [d.sequence_name for d in diffs] == original_order
+
+    def test_summary_stats_keys(self):
+        p = SequenceDifficultyProfiler()
+        diffs = [
+            p.profile_sequence(_MockSequence(_static_gt())),
+            p.profile_sequence(_MockSequence(_moving_gt())),
+        ]
+        stats = p.summary_stats(diffs)
+        assert stats["num_sequences"] == 2
+        for key in ("difficulty_score", "motion_mean", "target_area_mean"):
+            assert key in stats
+            assert "mean" in stats[key] and "std" in stats[key]
+
+    def test_summary_stats_empty_input(self):
+        assert SequenceDifficultyProfiler().summary_stats([]) == {}
+
+    def test_to_dict_is_serialisable(self):
+        seq = _MockSequence(_moving_gt())
+        d = SequenceDifficultyProfiler().profile_sequence(seq)
+        dd = d.to_dict()
+        assert isinstance(dd, dict)
+        assert "difficulty_score" in dd
+        assert "sequence_name"    in dd
+        assert isinstance(dd["num_frames"], int)
+
+    def test_difficulty_score_bounded(self):
+        """Regardless of the input, score must stay in [0, 1]."""
+        p = SequenceDifficultyProfiler()
+        for gt_factory in [_static_gt, _moving_gt, _scaling_gt, _erratic_gt, _deforming_gt]:
+            seq = _MockSequence(gt_factory())
+            d   = p.profile_sequence(seq)
+            assert 0.0 <= d.difficulty_score <= 1.0, (
+                f"score {d.difficulty_score} out of [0, 1] for {gt_factory.__name__}"
+            )


### PR DESCRIPTION
## What was added

Introduces `eovot/analysis/` — a new sub-package with `SequenceDifficultyProfiler` that characterises every tracking sequence along five difficulty dimensions using only ground-truth bounding box trajectories. **No tracker inference is required.**

### Files

| File | Purpose |
|---|---|
| `eovot/analysis/sequence_profiler.py` | `SequenceDifficulty` dataclass + `SequenceDifficultyProfiler` |
| `eovot/analysis/__init__.py` | Clean public API re-export |
| `tests/test_sequence_profiler.py` | **28 tests** — metrics, edge cases, sorting, serialisation |

## Difficulty dimensions

| Metric | Captures | Normalisation |
|---|---|---|
| `target_area_mean` | Small-target challenge | Fraction of frame area |
| `target_area_cv` | Scale-change challenge | Coefficient of variation |
| `motion_mean` | Fast-motion challenge | Fraction of frame diagonal |
| `motion_cv` | Erratic-motion challenge | Coefficient of variation |
| `aspect_ratio_std` | Deformation challenge | Raw std of w/h ratio |
| `difficulty_score` | Composite in [0, 1] | Weighted combination |

**Composite score weights:** motion magnitude 35%, scale change 30%, motion irregularity 20%, deformation 15%.

## Usage

```python
from eovot.analysis import SequenceDifficultyProfiler
from eovot.datasets.base import OTBDataset

dataset  = OTBDataset("/data/OTB100")
profiler = SequenceDifficultyProfiler()

difficulties = profiler.profile_dataset(dataset)
ranked       = profiler.sort_by_difficulty(difficulties)   # hardest first
stats        = profiler.summary_stats(difficulties)

print(f"Hardest: {ranked[0].sequence_name}  score={ranked[0].difficulty_score:.3f}")
print(stats)
# {'num_sequences': 100,
#  'difficulty_score': {'mean': 0.31, 'std': 0.14, 'min': 0.03, 'max': 0.89},
#  'motion_mean':      {'mean': 0.021, 'std': 0.018, ...}, ...}
```

Export per-sequence data to a DataFrame for correlation analysis:

```python
import pandas as pd

df = pd.DataFrame([d.to_dict() for d in difficulties])

# Correlate tracker accuracy with difficulty
df["tracker_iou"] = [seq_results[d.sequence_name].mean_iou for d in difficulties]
print(df[["difficulty_score", "motion_mean", "tracker_iou"]].corr())
```

## Research impact

A researcher can now answer questions like:

> "Our tracker degrades significantly on sequences with `motion_mean > 0.05`."  
> "This dataset has mean difficulty 0.31 vs. LaSOT's 0.47 — a fairer comparison requires stratified sampling."  
> "Ablation shows the attention module helps most on high-deformation sequences (aspect_ratio_std > 0.3)."

These are exactly the claims expected in a CVPR/ECCV paper and were previously impossible to support quantitatively.

## No breaking changes

All new code lives in `eovot/analysis/`. The only change to existing files is adding `analysis` to the public `__all__` list in `eovot/__init__.py`.

## Test results

```
28 passed in 0.18s
```

Closes #63

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyPap9qJGJDRhSC6ddEVPh)_