### PR TITLE
[feat] Sequence attribute-stratified performance analysis

### DIFF
--- a/eovot/__init__.py
+++ b/eovot/__init__.py
@@ -2,6 +2,14 @@
 
 __version__ = "0.1.0"
 
-from eovot import benchmark, datasets, metrics, profiling, reporting, trackers
+from eovot import analysis, benchmark, datasets, metrics, profiling, reporting, trackers
 
-__all__ = ["benchmark", "datasets", "metrics", "profiling", "reporting", "trackers"]
+__all__ = [
+    "analysis",
+    "benchmark",
+    "datasets",
+    "metrics",
+    "profiling",
+    "reporting",
+    "trackers",
+]

--- a/eovot/analysis/__init__.py
+++ b/eovot/analysis/__init__.py
@@ -1,0 +1,15 @@
+"""Analysis sub-package — attribute-stratified benchmarking and diagnostics."""
+
+from eovot.analysis.attribute import (
+    STANDARD_ATTRIBUTES,
+    AttributeAnalysis,
+    AttributeAnalyzer,
+    AttributeResult,
+)
+
+__all__ = [
+    "AttributeAnalyzer",
+    "AttributeAnalysis",
+    "AttributeResult",
+    "STANDARD_ATTRIBUTES",
+]

--- a/eovot/analysis/__init__.py
+++ b/eovot/analysis/__init__.py
@@ -1,15 +1,43 @@
-"""Analysis sub-package — attribute-stratified benchmarking and diagnostics."""
+"""Analysis sub-package — sequence attribute analysis and per-attribute reporting.
 
-from eovot.analysis.attribute import (
+Two complementary attribute systems are provided:
+
+1. **Auto-detection** (``sequence_attributes``, ``attribute_report``):
+   Computes difficulty flags directly from ground-truth bounding boxes.
+   Useful when no external annotation file is available.
+
+2. **Annotation-based** (``attribute``):
+   Loads attribute tags from OTB-style CSV files or manual registration,
+   then stratifies accuracy metrics (IoU, success AUC, precision AUC) by
+   attribute across one or more trackers.
+"""
+
+from .attribute import (
     STANDARD_ATTRIBUTES,
     AttributeAnalysis,
     AttributeAnalyzer,
     AttributeResult,
 )
+from .attribute_report import AttributeReport, generate_attribute_report
+from .sequence_attributes import (
+    AttributeFlags,
+    SequenceAttributes,
+    compute_sequence_attributes,
+    tag_sequences,
+)
 
 __all__ = [
+    # Annotation-based analyser
     "AttributeAnalyzer",
     "AttributeAnalysis",
     "AttributeResult",
     "STANDARD_ATTRIBUTES",
+    # Auto-detection
+    "AttributeFlags",
+    "SequenceAttributes",
+    "compute_sequence_attributes",
+    "tag_sequences",
+    # Per-attribute report
+    "AttributeReport",
+    "generate_attribute_report",
 ]

--- a/eovot/analysis/attribute.py
+++ b/eovot/analysis/attribute.py
@@ -1,0 +1,388 @@
+"""Sequence attribute-based performance analysis for VOT benchmarks.
+
+Most VOT datasets (OTB, LaSOT, GOT-10k) tag sequences with visual challenge
+attributes such as fast motion, occlusion, or scale variation.  Stratifying
+results by attribute exposes *where* a tracker degrades, enabling targeted
+improvement and fair comparison between methods with different strengths.
+
+Typical usage::
+
+    from eovot.analysis import AttributeAnalyzer
+    from eovot.benchmark.engine import BenchmarkResult
+
+    # Build attribute map from an OTB-style annotation file or manually:
+    analyzer = AttributeAnalyzer()
+    analyzer.load_otb_attributes("data/otb_attributes.txt")
+
+    # Analyse a benchmark result:
+    analysis = analyzer.from_benchmark_result(result)
+
+    # Print per-attribute table for one tracker:
+    print(analyzer.format_comparison_table([analysis]))
+
+    # Compare two trackers:
+    cmp = analyzer.compare([analysis_mosse, analysis_kcf])
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from eovot.metrics.accuracy import AccuracyMetrics
+
+# ---------------------------------------------------------------------------
+# Standard attribute vocabulary
+# ---------------------------------------------------------------------------
+
+STANDARD_ATTRIBUTES: List[str] = [
+    "illumination_variation",
+    "scale_variation",
+    "occlusion",
+    "deformation",
+    "motion_blur",
+    "fast_motion",
+    "in_plane_rotation",
+    "out_of_plane_rotation",
+    "out_of_view",
+    "background_clutter",
+    "low_resolution",
+]
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AttributeResult:
+    """Per-attribute accuracy summary for one tracker."""
+
+    attribute: str
+    num_sequences: int
+    mean_iou: float
+    success_auc: float
+    precision_auc: float
+    sequence_names: List[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return (
+            f"AttributeResult({self.attribute!r}  "
+            f"n={self.num_sequences}  "
+            f"mIoU={self.mean_iou:.3f}  "
+            f"succ_AUC={self.success_auc:.3f}  "
+            f"prec_AUC={self.precision_auc:.3f})"
+        )
+
+
+@dataclass
+class AttributeAnalysis:
+    """Attribute-stratified performance report for a single tracker."""
+
+    tracker_name: str
+    attribute_results: Dict[str, AttributeResult]
+    overall: AccuracyMetrics
+
+    @property
+    def sorted_by_difficulty(self) -> List[AttributeResult]:
+        """Attributes sorted by mean IoU ascending (hardest challenge first)."""
+        return sorted(self.attribute_results.values(), key=lambda r: r.mean_iou)
+
+    @property
+    def hardest_attribute(self) -> Optional[AttributeResult]:
+        """The attribute with the lowest mean IoU, or None if no data."""
+        results = self.sorted_by_difficulty
+        return results[0] if results else None
+
+    @property
+    def easiest_attribute(self) -> Optional[AttributeResult]:
+        """The attribute with the highest mean IoU, or None if no data."""
+        results = self.sorted_by_difficulty
+        return results[-1] if results else None
+
+
+# ---------------------------------------------------------------------------
+# Core analyser
+# ---------------------------------------------------------------------------
+
+
+class AttributeAnalyzer:
+    """Analyse tracker performance stratified by sequence attributes.
+
+    Args:
+        attribute_map: Optional pre-loaded mapping
+            ``{sequence_name: [attr1, attr2, ...]}``.  Can be extended later
+            via :meth:`register_sequence` or :meth:`load_otb_attributes`.
+    """
+
+    def __init__(
+        self, attribute_map: Optional[Dict[str, List[str]]] = None
+    ) -> None:
+        self._attribute_map: Dict[str, List[str]] = {}
+        if attribute_map:
+            for seq, attrs in attribute_map.items():
+                self._attribute_map[seq] = [a.lower() for a in attrs]
+
+    # ------------------------------------------------------------------
+    # Attribute registration
+    # ------------------------------------------------------------------
+
+    def register_sequence(self, sequence_name: str, attributes: List[str]) -> None:
+        """Tag a sequence with a list of attribute strings.
+
+        Args:
+            sequence_name: Name of the sequence (must match keys used in
+                :meth:`analyze`).
+            attributes: List of attribute strings (case-insensitive).
+        """
+        self._attribute_map[sequence_name] = [a.lower() for a in attributes]
+
+    def load_otb_attributes(self, attribute_file: str) -> None:
+        """Load OTB-style attribute annotations from a CSV text file.
+
+        Expected format — one sequence per line::
+
+            sequence_name,attr1,attr2,...
+
+        Lines starting with ``#`` and blank lines are ignored.
+
+        Args:
+            attribute_file: Path to the attribute annotation file.
+
+        Raises:
+            FileNotFoundError: If *attribute_file* does not exist.
+        """
+        if not os.path.isfile(attribute_file):
+            raise FileNotFoundError(f"Attribute file not found: {attribute_file}")
+        with open(attribute_file, "r") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = [p.strip() for p in line.split(",")]
+                if len(parts) >= 2:
+                    self._attribute_map[parts[0]] = [a.lower() for a in parts[1:]]
+
+    # ------------------------------------------------------------------
+    # Analysis
+    # ------------------------------------------------------------------
+
+    def analyze(
+        self,
+        tracker_name: str,
+        sequence_ious: Dict[str, np.ndarray],
+        sequence_distances: Optional[Dict[str, np.ndarray]] = None,
+    ) -> AttributeAnalysis:
+        """Compute per-attribute metrics for one tracker.
+
+        Args:
+            tracker_name: Display name for the tracker (e.g. ``"MOSSE"``).
+            sequence_ious: Mapping ``{sequence_name: per_frame_iou_array}``.
+                Each array has shape ``(N,)`` with values in ``[0, 1]``.
+            sequence_distances: Optional mapping
+                ``{sequence_name: per_frame_centre_distance_array}`` in pixels.
+                When provided, precision AUC is computed; otherwise it is 0.
+
+        Returns:
+            :class:`AttributeAnalysis` with per-attribute results and overall
+            aggregate metrics.
+        """
+        if sequence_distances is None:
+            sequence_distances = {}
+
+        # Overall metrics across all sequences
+        all_ious = np.concatenate(list(sequence_ious.values()))
+        all_dists = (
+            np.concatenate(
+                [sequence_distances[s] for s in sequence_ious if s in sequence_distances]
+            )
+            if sequence_distances
+            else None
+        )
+        overall = self._compute_metrics(all_ious, all_dists)
+
+        # Group sequences by attribute
+        attr_to_seqs: Dict[str, List[str]] = {}
+        for seq_name, attrs in self._attribute_map.items():
+            if seq_name not in sequence_ious:
+                continue
+            for attr in attrs:
+                attr_to_seqs.setdefault(attr, []).append(seq_name)
+
+        attribute_results: Dict[str, AttributeResult] = {}
+        for attr, seq_names in attr_to_seqs.items():
+            attr_ious = np.concatenate([sequence_ious[s] for s in seq_names])
+            attr_dists: Optional[np.ndarray] = None
+            dists_parts = [
+                sequence_distances[s] for s in seq_names if s in sequence_distances
+            ]
+            if dists_parts:
+                attr_dists = np.concatenate(dists_parts)
+
+            metrics = self._compute_metrics(attr_ious, attr_dists)
+            attribute_results[attr] = AttributeResult(
+                attribute=attr,
+                num_sequences=len(seq_names),
+                mean_iou=metrics.mean_iou,
+                success_auc=metrics.success_auc,
+                precision_auc=metrics.precision_auc,
+                sequence_names=list(seq_names),
+            )
+
+        return AttributeAnalysis(
+            tracker_name=tracker_name,
+            attribute_results=attribute_results,
+            overall=overall,
+        )
+
+    def from_benchmark_result(self, result: object) -> AttributeAnalysis:
+        """Build an :class:`AttributeAnalysis` directly from a :class:`~eovot.benchmark.engine.BenchmarkResult`.
+
+        This is the recommended integration point when running the full
+        benchmark pipeline.  Sequence IoU arrays and centre-distance arrays
+        are extracted from the result's :class:`~eovot.benchmark.engine.SequenceResult`
+        objects.
+
+        Args:
+            result: A :class:`~eovot.benchmark.engine.BenchmarkResult` instance.
+
+        Returns:
+            :class:`AttributeAnalysis` for the tracker embedded in *result*.
+        """
+        seq_ious: Dict[str, np.ndarray] = {}
+        seq_dists: Dict[str, np.ndarray] = {}
+
+        for sr in result.sequence_results:  # type: ignore[attr-defined]
+            seq_ious[sr.sequence_name] = sr.ious
+            if sr.center_distances is not None:
+                seq_dists[sr.sequence_name] = sr.center_distances
+
+        return self.analyze(
+            tracker_name=result.tracker_name,  # type: ignore[attr-defined]
+            sequence_ious=seq_ious,
+            sequence_distances=seq_dists if seq_dists else None,
+        )
+
+    # ------------------------------------------------------------------
+    # Multi-tracker comparison
+    # ------------------------------------------------------------------
+
+    def compare(
+        self,
+        analyses: List[AttributeAnalysis],
+        metric: str = "mean_iou",
+    ) -> Dict[str, Dict[str, float]]:
+        """Build an attribute × tracker metric table.
+
+        Args:
+            analyses: One :class:`AttributeAnalysis` per tracker.
+            metric: Which scalar to populate — ``"mean_iou"``,
+                ``"success_auc"``, or ``"precision_auc"``.
+
+        Returns:
+            ``{attribute: {tracker_name: value}}`` nested dict.
+        """
+        table: Dict[str, Dict[str, float]] = {}
+        for analysis in analyses:
+            for attr, result in analysis.attribute_results.items():
+                table.setdefault(attr, {})[analysis.tracker_name] = float(
+                    getattr(result, metric)
+                )
+        return table
+
+    def format_comparison_table(
+        self,
+        analyses: List[AttributeAnalysis],
+        metric: str = "mean_iou",
+    ) -> str:
+        """Render a Markdown table of per-attribute metrics.
+
+        Args:
+            analyses: One :class:`AttributeAnalysis` per tracker.
+            metric: Metric column to display (``"mean_iou"`` by default).
+
+        Returns:
+            Markdown-formatted comparison table string.
+        """
+        tracker_names = [a.tracker_name for a in analyses]
+        all_attrs = sorted(
+            {attr for a in analyses for attr in a.attribute_results}
+        )
+
+        header = "| Attribute | " + " | ".join(tracker_names) + " |"
+        sep = "|---|" + "|".join(["---"] * len(tracker_names)) + "|"
+        rows = [header, sep]
+
+        for attr in all_attrs:
+            row = f"| {attr} |"
+            for analysis in analyses:
+                result = analysis.attribute_results.get(attr)
+                row += f" {getattr(result, metric):.3f} |" if result else " — |"
+            rows.append(row)
+
+        # Overall row
+        overall_row = "| **Overall** |"
+        for analysis in analyses:
+            val = getattr(analysis.overall, metric)
+            overall_row += f" **{val:.3f}** |"
+        rows.append(overall_row)
+
+        return "\n".join(rows)
+
+    def difficulty_ranking(
+        self,
+        analyses: List[AttributeAnalysis],
+        metric: str = "mean_iou",
+    ) -> List[Tuple[str, float]]:
+        """Rank attributes by average difficulty across all trackers.
+
+        Difficulty is measured as *mean metric across trackers* — lower
+        values indicate harder challenges.
+
+        Args:
+            analyses: One :class:`AttributeAnalysis` per tracker.
+            metric: Metric to average (default ``"mean_iou"``).
+
+        Returns:
+            List of ``(attribute, average_metric_value)`` tuples sorted
+            ascending (hardest first).
+        """
+        table = self.compare(analyses, metric=metric)
+        ranking = [
+            (attr, float(np.mean(list(tracker_vals.values()))))
+            for attr, tracker_vals in table.items()
+        ]
+        return sorted(ranking, key=lambda x: x[1])
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_metrics(
+        ious: np.ndarray,
+        dists: Optional[np.ndarray] = None,
+    ) -> AccuracyMetrics:
+        """Compute AccuracyMetrics from pre-computed IoU (and optional dist) arrays."""
+        _trapz = np.trapezoid if hasattr(np, "trapezoid") else np.trapz  # type: ignore[attr-defined]
+
+        thresholds_iou = np.linspace(0.0, 1.0, 101)
+        sr = np.array([(ious > t).mean() for t in thresholds_iou])
+        success_auc = float(_trapz(sr, thresholds_iou))
+
+        if dists is not None and len(dists) > 0:
+            thresholds_dist = np.linspace(0.0, 50.0, 51)
+            pr = np.array([(dists < t).mean() for t in thresholds_dist])
+            prec_auc = float(_trapz(pr, thresholds_dist) / thresholds_dist[-1])
+        else:
+            prec_auc = 0.0
+
+        return AccuracyMetrics(
+            mean_iou=float(ious.mean()),
+            success_auc=success_auc,
+            precision_auc=prec_auc,
+        )

--- a/eovot/analysis/attribute_report.py
+++ b/eovot/analysis/attribute_report.py
@@ -1,0 +1,251 @@
+"""Per-attribute performance breakdown for benchmark results.
+
+Given a set of :class:`~eovot.benchmark.engine.BenchmarkResult` objects and
+a dict of :class:`~eovot.analysis.sequence_attributes.SequenceAttributes`,
+this module slices tracker performance by difficulty attribute and produces
+a research-grade breakdown table showing where each tracker succeeds or fails.
+
+Example::
+
+    from eovot.analysis.sequence_attributes import tag_sequences
+    from eovot.analysis.attribute_report import generate_attribute_report
+
+    tagged  = tag_sequences(dataset)
+    report  = generate_attribute_report({"MOSSE": result_mosse}, tagged)
+    print(report.markdown_table())
+    report.save_json("results/attribute_breakdown.json")
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from ..benchmark.engine import BenchmarkResult
+from .sequence_attributes import SequenceAttributes
+
+_ALL_FLAGS = ["SV", "ARC", "FM", "LR", "PO", "DEF"]
+
+_FLAG_DESCRIPTIONS = {
+    "SV":  "Scale Variation",
+    "ARC": "Aspect Ratio Change",
+    "FM":  "Fast Motion",
+    "LR":  "Low Resolution",
+    "PO":  "Partial Occlusion",
+    "DEF": "Deformation",
+}
+
+
+@dataclass
+class TrackerAttributeSlice:
+    """Mean IoU for one tracker on one attribute subset of sequences.
+
+    Attributes:
+        tracker_name:   Tracker identifier.
+        attribute:      Short attribute code (e.g. ``"FM"``).
+        num_sequences:  Number of sequences in this attribute subset.
+        mean_iou:       Mean IoU across all sequences that have the attribute.
+        mean_fps:       Mean FPS across those sequences.
+    """
+
+    tracker_name: str
+    attribute: str
+    num_sequences: int
+    mean_iou: float
+    mean_fps: float
+
+    def to_dict(self) -> Dict:
+        return {
+            "tracker": self.tracker_name,
+            "attribute": self.attribute,
+            "num_sequences": self.num_sequences,
+            "mean_iou": round(self.mean_iou, 4),
+            "mean_fps": round(self.mean_fps, 2),
+        }
+
+
+@dataclass
+class AttributeReport:
+    """Full per-attribute breakdown for one or more trackers.
+
+    Built by :func:`generate_attribute_report`.
+
+    Attributes:
+        tracker_names:    Ordered list of tracker identifiers.
+        attribute_slices: Nested dict ``{attr_code: {tracker_name: slice}}``.
+        overall:          Overall (all-sequence) slice per tracker.
+    """
+
+    tracker_names: List[str]
+    attribute_slices: Dict[str, Dict[str, TrackerAttributeSlice]] = field(default_factory=dict)
+    overall: Dict[str, TrackerAttributeSlice] = field(default_factory=dict)
+
+    def markdown_table(self) -> str:
+        """Render a Markdown comparison table (attributes × trackers).
+
+        Returns:
+            Multi-line Markdown string suitable for GitHub PR descriptions or
+            Jupyter notebooks.
+        """
+        cols = self.tracker_names
+        header = "| Attribute | Sequences | " + " | ".join(f"{t} mIoU" for t in cols) + " |"
+        sep = "|" + "---|" * (len(cols) + 2)
+        rows = [header, sep]
+
+        # Overall row first
+        overall_cells = []
+        for t in cols:
+            sl = self.overall.get(t)
+            overall_cells.append(f"{sl.mean_iou:.4f}" if sl else "—")
+        rows.append(
+            f"| **Overall** | {next(iter(self.overall.values())).num_sequences if self.overall else 0} | "
+            + " | ".join(overall_cells)
+            + " |"
+        )
+
+        # Per-attribute rows
+        for flag in _ALL_FLAGS:
+            slices = self.attribute_slices.get(flag, {})
+            num_seqs = next(iter(slices.values())).num_sequences if slices else 0
+            cells = []
+            for t in cols:
+                sl = slices.get(t)
+                if sl is None or sl.num_sequences == 0:
+                    cells.append("—")
+                else:
+                    cells.append(f"{sl.mean_iou:.4f}")
+            desc = _FLAG_DESCRIPTIONS.get(flag, flag)
+            rows.append(f"| {desc} ({flag}) | {num_seqs} | " + " | ".join(cells) + " |")
+
+        return "\n".join(rows)
+
+    def to_dict(self) -> Dict:
+        """Serialise to a plain dict for JSON export."""
+        return {
+            "trackers": self.tracker_names,
+            "overall": {t: sl.to_dict() for t, sl in self.overall.items()},
+            "per_attribute": {
+                flag: {t: sl.to_dict() for t, sl in tracker_map.items()}
+                for flag, tracker_map in self.attribute_slices.items()
+            },
+        }
+
+    def save_json(self, path: str) -> None:
+        """Write the report to a JSON file.
+
+        Args:
+            path: Output file path (parent directories are created if needed).
+        """
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with open(out, "w") as fh:
+            json.dump(self.to_dict(), fh, indent=2)
+
+    def print_summary(self) -> None:
+        """Print the Markdown table to stdout."""
+        print(self.markdown_table())
+
+
+def generate_attribute_report(
+    results: Dict[str, BenchmarkResult],
+    sequence_attributes: Dict[str, SequenceAttributes],
+) -> AttributeReport:
+    """Build a per-attribute performance breakdown across multiple trackers.
+
+    For each difficulty attribute, selects the subset of sequences that have
+    that attribute flagged, then computes mean IoU and mean FPS for every
+    tracker on that subset.
+
+    Args:
+        results: Dict mapping tracker name → :class:`~eovot.benchmark.engine.BenchmarkResult`.
+            All results must share the same set of evaluated sequences for
+            the comparison to be valid.
+        sequence_attributes: Dict mapping sequence name → :class:`SequenceAttributes`.
+            Typically produced by :func:`~eovot.analysis.sequence_attributes.tag_sequences`.
+
+    Returns:
+        :class:`AttributeReport` ready for printing or JSON export.
+
+    Example::
+
+        report = generate_attribute_report(
+            {"MOSSE": result_mosse, "KCF": result_kcf},
+            tag_sequences(dataset),
+        )
+        print(report.markdown_table())
+    """
+    tracker_names = list(results.keys())
+    report = AttributeReport(tracker_names=tracker_names)
+
+    # Build overall slice
+    for tracker_name, bench_result in results.items():
+        if not bench_result.sequence_results:
+            continue
+        all_ious = np.concatenate([sr.ious for sr in bench_result.sequence_results])
+        all_fps = [sr.profiling.fps for sr in bench_result.sequence_results]
+        report.overall[tracker_name] = TrackerAttributeSlice(
+            tracker_name=tracker_name,
+            attribute="ALL",
+            num_sequences=len(bench_result.sequence_results),
+            mean_iou=float(all_ious.mean()) if len(all_ious) else 0.0,
+            mean_fps=float(np.mean(all_fps)) if all_fps else 0.0,
+        )
+
+    # Per-attribute slices
+    for flag_code in _ALL_FLAGS:
+        flag_attr = _flag_code_to_attr(flag_code)
+        flag_slices: Dict[str, TrackerAttributeSlice] = {}
+
+        # Find sequences with this flag present
+        flagged_sequences = {
+            name for name, attrs in sequence_attributes.items()
+            if getattr(attrs.flags, flag_attr)
+        }
+
+        for tracker_name, bench_result in results.items():
+            matching = [
+                sr for sr in bench_result.sequence_results
+                if sr.sequence_name in flagged_sequences
+            ]
+            if not matching:
+                flag_slices[tracker_name] = TrackerAttributeSlice(
+                    tracker_name=tracker_name,
+                    attribute=flag_code,
+                    num_sequences=0,
+                    mean_iou=0.0,
+                    mean_fps=0.0,
+                )
+                continue
+
+            ious = np.concatenate([sr.ious for sr in matching])
+            fps_vals = [sr.profiling.fps for sr in matching]
+            flag_slices[tracker_name] = TrackerAttributeSlice(
+                tracker_name=tracker_name,
+                attribute=flag_code,
+                num_sequences=len(matching),
+                mean_iou=float(ious.mean()) if len(ious) else 0.0,
+                mean_fps=float(np.mean(fps_vals)),
+            )
+
+        report.attribute_slices[flag_code] = flag_slices
+
+    return report
+
+
+def _flag_code_to_attr(code: str) -> str:
+    """Map short flag code to :class:`~eovot.analysis.sequence_attributes.AttributeFlags` field name."""
+    _map = {
+        "SV": "scale_variation",
+        "ARC": "aspect_ratio_change",
+        "FM": "fast_motion",
+        "LR": "low_resolution",
+        "PO": "partial_occlusion",
+        "DEF": "deformation",
+    }
+    if code not in _map:
+        raise KeyError(f"Unknown attribute code {code!r}. Valid codes: {list(_map)}")
+    return _map[code]

--- a/eovot/analysis/sequence_attributes.py
+++ b/eovot/analysis/sequence_attributes.py
@@ -1,0 +1,283 @@
+"""Sequence difficulty attribute analysis for VOT benchmarking.
+
+Computes per-sequence difficulty attributes from ground-truth bounding boxes,
+mirroring the attribute taxonomy used by OTB-100, LaSOT, and GOT-10k to enable
+fine-grained, per-attribute tracker comparisons.
+
+Attributes computed
+-------------------
+SV  — Scale Variation:     max/min box area ratio exceeds threshold.
+ARC — Aspect Ratio Change: width/height ratio varies significantly.
+FM  — Fast Motion:         per-frame centre displacement > box-size fraction.
+LR  — Low Resolution:      target bounding-box area falls below pixel threshold.
+PO  — Partial Occlusion:   abrupt box-area drop mid-sequence (proxy for occlusion).
+DEF — Deformation:         large intra-sequence aspect-ratio variance.
+
+Example::
+
+    from eovot.datasets.base import OTBDataset
+    from eovot.analysis.sequence_attributes import tag_sequences
+
+    dataset = OTBDataset("/data/OTB100")
+    tagged = tag_sequences(dataset)
+    for seq_name, attrs in tagged.items():
+        print(seq_name, attrs.active_flags())
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence as TypingSequence
+
+import numpy as np
+
+from ..datasets.base import BaseDataset
+
+
+# ---------------------------------------------------------------------------
+# Thresholds (matching OTB / GOT-10k annotation conventions)
+# ---------------------------------------------------------------------------
+
+_SV_RATIO_THRESHOLD: float = 2.0      # max/min area ratio for scale variation
+_ARC_RATIO_THRESHOLD: float = 0.5     # |max_ratio - min_ratio| for aspect-ratio change
+_FM_DISPLACEMENT_FRACTION: float = 0.2  # centre-displacement / sqrt(area) threshold
+_LR_AREA_THRESHOLD_PX: float = 400.0  # < 20×20 px considered low resolution
+_PO_AREA_DROP_FRACTION: float = 0.4   # area drops ≥ 40% in a single frame = occlusion proxy
+_DEF_AR_STD_THRESHOLD: float = 0.25   # std-dev of aspect-ratio sequence for deformation
+
+
+@dataclass
+class AttributeFlags:
+    """Boolean difficulty flags for a single tracking sequence.
+
+    Each flag is ``True`` when the corresponding attribute is present in the
+    sequence according to fixed thresholds (see module-level constants).
+
+    Attributes:
+        scale_variation:     Target area changes significantly across the sequence.
+        aspect_ratio_change: Width-to-height ratio changes significantly.
+        fast_motion:         Target moves faster than a fraction of its own size.
+        low_resolution:      Target bounding box is very small (< ~20×20 px).
+        partial_occlusion:   Abrupt mid-sequence area drop (proxy for occlusion).
+        deformation:         Aspect-ratio variance indicates non-rigid deformation.
+    """
+
+    scale_variation: bool = False
+    aspect_ratio_change: bool = False
+    fast_motion: bool = False
+    low_resolution: bool = False
+    partial_occlusion: bool = False
+    deformation: bool = False
+
+    def active_flags(self) -> List[str]:
+        """Return short abbreviations for all ``True`` flags."""
+        mapping = [
+            ("scale_variation", "SV"),
+            ("aspect_ratio_change", "ARC"),
+            ("fast_motion", "FM"),
+            ("low_resolution", "LR"),
+            ("partial_occlusion", "PO"),
+            ("deformation", "DEF"),
+        ]
+        return [abbr for attr, abbr in mapping if getattr(self, attr)]
+
+    def to_dict(self) -> Dict[str, bool]:
+        return {
+            "SV": self.scale_variation,
+            "ARC": self.aspect_ratio_change,
+            "FM": self.fast_motion,
+            "LR": self.low_resolution,
+            "PO": self.partial_occlusion,
+            "DEF": self.deformation,
+        }
+
+    def __str__(self) -> str:
+        active = self.active_flags()
+        return f"[{', '.join(active)}]" if active else "[none]"
+
+
+@dataclass
+class SequenceAttributes:
+    """Full attribute analysis result for a single sequence.
+
+    Attributes:
+        sequence_name:   Name of the analysed sequence.
+        num_frames:      Total frame count.
+        flags:           Per-attribute difficulty flags.
+        mean_area_px:    Mean target bounding-box area (pixels²).
+        mean_aspect_ratio: Mean width/height ratio across the sequence.
+        mean_fps_motion: Mean per-frame centre displacement normalised by
+            sqrt(area) — a dimensionless speed indicator.
+        scale_ratio:     Observed max/min area ratio (≥ 1.0).
+    """
+
+    sequence_name: str
+    num_frames: int
+    flags: AttributeFlags
+    mean_area_px: float
+    mean_aspect_ratio: float
+    mean_fps_motion: float
+    scale_ratio: float
+
+    def to_dict(self) -> Dict:
+        return {
+            "sequence_name": self.sequence_name,
+            "num_frames": self.num_frames,
+            "mean_area_px": round(self.mean_area_px, 2),
+            "mean_aspect_ratio": round(self.mean_aspect_ratio, 4),
+            "mean_fps_motion": round(self.mean_fps_motion, 4),
+            "scale_ratio": round(self.scale_ratio, 4),
+            "flags": self.flags.to_dict(),
+            "active_flags": self.flags.active_flags(),
+        }
+
+    def __str__(self) -> str:
+        return (
+            f"SequenceAttributes[{self.sequence_name}] "
+            f"frames={self.num_frames} "
+            f"area={self.mean_area_px:.0f}px² "
+            f"flags={self.flags}"
+        )
+
+
+def compute_sequence_attributes(
+    ground_truth: np.ndarray,
+    sequence_name: str = "unknown",
+    sv_threshold: float = _SV_RATIO_THRESHOLD,
+    arc_threshold: float = _ARC_RATIO_THRESHOLD,
+    fm_fraction: float = _FM_DISPLACEMENT_FRACTION,
+    lr_area_px: float = _LR_AREA_THRESHOLD_PX,
+    po_drop_fraction: float = _PO_AREA_DROP_FRACTION,
+    def_std_threshold: float = _DEF_AR_STD_THRESHOLD,
+) -> SequenceAttributes:
+    """Compute difficulty attribute flags from a ground-truth bounding-box array.
+
+    Args:
+        ground_truth: ``(N, 4)`` float array in ``(x, y, w, h)`` format.
+        sequence_name: Identifier embedded in the returned object.
+        sv_threshold:    Min max/min area ratio to trigger SV flag.
+        arc_threshold:   Min |max–min| aspect-ratio change to trigger ARC.
+        fm_fraction:     Centre-displacement / sqrt(area) fraction for FM.
+        lr_area_px:      Pixel-area threshold below which LR is flagged.
+        po_drop_fraction: Fractional area drop in a single frame to flag PO.
+        def_std_threshold: Aspect-ratio std-dev threshold for DEF.
+
+    Returns:
+        :class:`SequenceAttributes` with all computed metrics and flags.
+
+    Raises:
+        ValueError: If ``ground_truth`` is empty or has wrong shape.
+    """
+    if ground_truth.ndim != 2 or ground_truth.shape[1] != 4:
+        raise ValueError(
+            f"ground_truth must be shape (N, 4), got {ground_truth.shape}"
+        )
+    if len(ground_truth) == 0:
+        raise ValueError("ground_truth must not be empty.")
+
+    xs, ys, ws, hs = ground_truth[:, 0], ground_truth[:, 1], ground_truth[:, 2], ground_truth[:, 3]
+
+    # Guard against degenerate boxes.
+    ws = np.maximum(ws, 1e-6)
+    hs = np.maximum(hs, 1e-6)
+
+    areas = ws * hs
+    aspect_ratios = ws / hs
+
+    # Centre coordinates
+    cx = xs + ws / 2.0
+    cy = ys + hs / 2.0
+
+    # --- Scale Variation (SV) ---
+    min_area = float(areas.min())
+    max_area = float(areas.max())
+    scale_ratio = max_area / max(min_area, 1e-6)
+    sv_flag = scale_ratio >= sv_threshold
+
+    # --- Aspect Ratio Change (ARC) ---
+    arc_range = float(aspect_ratios.max() - aspect_ratios.min())
+    arc_flag = arc_range >= arc_threshold
+
+    # --- Fast Motion (FM) ---
+    if len(cx) > 1:
+        displacements = np.sqrt(np.diff(cx) ** 2 + np.diff(cy) ** 2)
+        sqrt_areas = np.sqrt(areas[:-1])
+        normalised = displacements / np.maximum(sqrt_areas, 1e-6)
+        mean_motion = float(normalised.mean())
+        fm_flag = mean_motion >= fm_fraction
+    else:
+        mean_motion = 0.0
+        fm_flag = False
+
+    # --- Low Resolution (LR) ---
+    lr_flag = bool(float(areas.min()) < lr_area_px)
+
+    # --- Partial Occlusion (PO) — proxy via abrupt area drop ---
+    if len(areas) > 1:
+        area_drops = (areas[:-1] - areas[1:]) / np.maximum(areas[:-1], 1e-6)
+        po_flag = bool(float(area_drops.max()) >= po_drop_fraction)
+    else:
+        po_flag = False
+
+    # --- Deformation (DEF) — aspect-ratio std-dev ---
+    ar_std = float(aspect_ratios.std())
+    def_flag = ar_std >= def_std_threshold
+
+    flags = AttributeFlags(
+        scale_variation=sv_flag,
+        aspect_ratio_change=arc_flag,
+        fast_motion=fm_flag,
+        low_resolution=lr_flag,
+        partial_occlusion=po_flag,
+        deformation=def_flag,
+    )
+
+    return SequenceAttributes(
+        sequence_name=sequence_name,
+        num_frames=len(ground_truth),
+        flags=flags,
+        mean_area_px=float(areas.mean()),
+        mean_aspect_ratio=float(aspect_ratios.mean()),
+        mean_fps_motion=mean_motion,
+        scale_ratio=scale_ratio,
+    )
+
+
+def tag_sequences(
+    dataset: BaseDataset,
+    **threshold_kwargs,
+) -> Dict[str, SequenceAttributes]:
+    """Compute attribute flags for every sequence in a dataset.
+
+    Iterates over the dataset using its :class:`~eovot.datasets.base.Sequence`
+    objects and computes :class:`SequenceAttributes` from each sequence's
+    ground-truth boxes.  Only the GT array is read — no image frames are
+    loaded.
+
+    Args:
+        dataset: Any :class:`~eovot.datasets.base.BaseDataset` instance.
+        **threshold_kwargs: Forwarded verbatim to
+            :func:`compute_sequence_attributes` for threshold overrides.
+
+    Returns:
+        Dict mapping sequence name → :class:`SequenceAttributes`.
+
+    Example::
+
+        from eovot.datasets.base import OTBDataset
+        from eovot.analysis.sequence_attributes import tag_sequences
+
+        dataset = OTBDataset("/data/OTB100")
+        tagged = tag_sequences(dataset)
+        fast_motion = [n for n, a in tagged.items() if a.flags.fast_motion]
+        print(f"{len(fast_motion)} sequences with fast motion")
+    """
+    results: Dict[str, SequenceAttributes] = {}
+    for seq in dataset:
+        attrs = compute_sequence_attributes(
+            seq.ground_truth,
+            sequence_name=seq.name,
+            **threshold_kwargs,
+        )
+        results[seq.name] = attrs
+    return results

--- a/scripts/analyze_attributes.py
+++ b/scripts/analyze_attributes.py
@@ -1,0 +1,143 @@
+"""CLI: compute and display sequence difficulty attributes for a dataset.
+
+Usage examples::
+
+    # Show attribute breakdown for all OTB-100 sequences
+    python scripts/analyze_attributes.py --dataset OTBDataset --root /data/OTB100
+
+    # GOT-10k validation split
+    python scripts/analyze_attributes.py --dataset GOT10kDataset --root /data/GOT-10k --split val
+
+    # Save full JSON report
+    python scripts/analyze_attributes.py --dataset OTBDataset --root /data/OTB100 \\
+        --output results/attributes.json
+
+    # Only show sequences with fast motion
+    python scripts/analyze_attributes.py --dataset OTBDataset --root /data/OTB100 --filter FM
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Ensure eovot package is importable when running from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eovot.analysis.sequence_attributes import tag_sequences, _ALL_FLAGS as ALL_FLAGS
+from eovot.datasets.base import OTBDataset
+from eovot.datasets.got10k import GOT10kDataset
+from eovot.datasets.lasot import LaSOTDataset
+
+_DATASET_REGISTRY = {
+    "OTBDataset": OTBDataset,
+    "GOT10kDataset": GOT10kDataset,
+    "LaSOTDataset": LaSOTDataset,
+}
+
+_FLAG_FULL = {
+    "SV": "Scale Variation",
+    "ARC": "Aspect Ratio Change",
+    "FM": "Fast Motion",
+    "LR": "Low Resolution",
+    "PO": "Partial Occlusion",
+    "DEF": "Deformation",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Compute sequence difficulty attributes for a VOT dataset.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument("--dataset", required=True, choices=list(_DATASET_REGISTRY),
+                   help="Dataset loader class name.")
+    p.add_argument("--root", required=True,
+                   help="Path to dataset root directory.")
+    p.add_argument("--split", default="val",
+                   help="Dataset split (for GOT-10k / LaSOT). Default: val.")
+    p.add_argument("--max-sequences", type=int, default=None,
+                   help="Limit number of sequences analysed.")
+    p.add_argument("--filter", choices=ALL_FLAGS, default=None,
+                   help="Only print sequences that have this attribute flag.")
+    p.add_argument("--output", default=None,
+                   help="Save full results as JSON to this path.")
+    p.add_argument("--summary-only", action="store_true",
+                   help="Print only the aggregate summary table, not per-sequence list.")
+    return p
+
+
+def load_dataset(args: argparse.Namespace):
+    cls = _DATASET_REGISTRY[args.dataset]
+    kwargs = {"root": args.root}
+    if args.dataset in ("GOT10kDataset", "LaSOTDataset"):
+        kwargs["split"] = args.split
+    if args.max_sequences is not None:
+        kwargs["max_sequences"] = args.max_sequences
+    return cls(**kwargs)
+
+
+def print_summary_table(tagged: dict) -> None:
+    counts = {f: 0 for f in ALL_FLAGS}
+    total = len(tagged)
+    for attrs in tagged.values():
+        for flag in ALL_FLAGS:
+            if attrs.flags.to_dict().get(flag, False):
+                counts[flag] += 1
+
+    print(f"\n{'='*52}")
+    print(f"  Attribute Summary  ({total} sequences total)")
+    print(f"{'='*52}")
+    print(f"  {'Attribute':<25} {'Count':>6}  {'%':>6}")
+    print(f"  {'-'*42}")
+    for flag in ALL_FLAGS:
+        pct = 100.0 * counts[flag] / total if total else 0.0
+        print(f"  {_FLAG_FULL[flag] + ' (' + flag + ')':<25} {counts[flag]:>6}  {pct:>5.1f}%")
+    print(f"{'='*52}\n")
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    print(f"Loading {args.dataset} from {args.root} ...")
+    dataset = load_dataset(args)
+    print(f"  → {len(dataset)} sequences found.")
+
+    print("Computing sequence attributes ...")
+    tagged = tag_sequences(dataset)
+
+    if args.filter:
+        filtered = {
+            n: a for n, a in tagged.items()
+            if a.flags.to_dict().get(args.filter, False)
+        }
+        print(f"\nSequences with {_FLAG_FULL[args.filter]} ({args.filter}): "
+              f"{len(filtered)} / {len(tagged)}")
+        if not args.summary_only:
+            for name, attrs in sorted(filtered.items()):
+                print(f"  {name:<35} {attrs.flags}")
+    else:
+        print_summary_table(tagged)
+        if not args.summary_only:
+            print(f"{'Sequence':<35} {'Frames':>6}  {'Area':>8}  {'Flags'}")
+            print("-" * 75)
+            for name, attrs in sorted(tagged.items()):
+                flags_str = str(attrs.flags)
+                print(
+                    f"  {name:<33} {attrs.num_frames:>6}  "
+                    f"{attrs.mean_area_px:>8.0f}  {flags_str}"
+                )
+
+    if args.output:
+        out = {name: attrs.to_dict() for name, attrs in tagged.items()}
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w") as fh:
+            json.dump(out, fh, indent=2)
+        print(f"\nFull report saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_attribute_analysis.py
+++ b/tests/test_attribute_analysis.py
@@ -1,0 +1,350 @@
+"""Tests for eovot.analysis.attribute — AttributeAnalyzer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.analysis.attribute import (
+    STANDARD_ATTRIBUTES,
+    AttributeAnalysis,
+    AttributeAnalyzer,
+    AttributeResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def attr_map() -> dict:
+    return {
+        "seq_a": ["fast_motion", "occlusion"],
+        "seq_b": ["occlusion", "scale_variation"],
+        "seq_c": ["fast_motion", "motion_blur"],
+        "seq_d": ["illumination_variation"],
+    }
+
+
+@pytest.fixture
+def analyzer(attr_map) -> AttributeAnalyzer:
+    return AttributeAnalyzer(attribute_map=attr_map)
+
+
+@pytest.fixture
+def sequence_ious() -> dict:
+    rng = np.random.default_rng(42)
+    return {
+        "seq_a": rng.uniform(0.3, 0.8, 50),
+        "seq_b": rng.uniform(0.5, 0.9, 60),
+        "seq_c": rng.uniform(0.1, 0.6, 40),
+        "seq_d": rng.uniform(0.6, 1.0, 70),
+    }
+
+
+@pytest.fixture
+def sequence_distances() -> dict:
+    rng = np.random.default_rng(7)
+    return {
+        "seq_a": rng.uniform(0.0, 30.0, 50),
+        "seq_b": rng.uniform(0.0, 20.0, 60),
+        "seq_c": rng.uniform(5.0, 40.0, 40),
+        "seq_d": rng.uniform(0.0, 15.0, 70),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestStandardAttributes:
+    def test_contains_core_challenges(self):
+        for attr in ("fast_motion", "occlusion", "scale_variation", "motion_blur"):
+            assert attr in STANDARD_ATTRIBUTES
+
+    def test_minimum_count(self):
+        assert len(STANDARD_ATTRIBUTES) >= 10
+
+    def test_all_lowercase(self):
+        for attr in STANDARD_ATTRIBUTES:
+            assert attr == attr.lower()
+
+
+# ---------------------------------------------------------------------------
+# AttributeAnalyzer construction and registration
+# ---------------------------------------------------------------------------
+
+
+class TestAttributeAnalyzerConstruction:
+    def test_default_construction(self):
+        az = AttributeAnalyzer()
+        assert az._attribute_map == {}
+
+    def test_init_with_map(self, attr_map):
+        az = AttributeAnalyzer(attribute_map=attr_map)
+        assert "seq_a" in az._attribute_map
+        assert "fast_motion" in az._attribute_map["seq_a"]
+
+    def test_attributes_normalised_to_lowercase(self):
+        az = AttributeAnalyzer(attribute_map={"seq_x": ["Fast_Motion", "OCCLUSION"]})
+        assert az._attribute_map["seq_x"] == ["fast_motion", "occlusion"]
+
+    def test_register_sequence(self, sequence_ious):
+        az = AttributeAnalyzer()
+        az.register_sequence("seq_a", ["fast_motion", "occlusion"])
+        result = az.analyze("T", sequence_ious)
+        assert "fast_motion" in result.attribute_results
+
+    def test_register_normalises_case(self):
+        az = AttributeAnalyzer()
+        az.register_sequence("seq_x", ["FastMotion", "OCCLUSION"])
+        assert az._attribute_map["seq_x"] == ["fastmotion", "occlusion"]
+
+    def test_load_otb_attributes(self, tmp_path, sequence_ious):
+        f = tmp_path / "attrs.txt"
+        f.write_text(
+            "# comment\n"
+            "seq_a, fast_motion, occlusion\n"
+            "seq_b, scale_variation\n"
+            "\n"
+            "seq_c, motion_blur\n"
+        )
+        az = AttributeAnalyzer()
+        az.load_otb_attributes(str(f))
+        assert "fast_motion" in az._attribute_map["seq_a"]
+        assert "scale_variation" in az._attribute_map["seq_b"]
+        result = az.analyze("T", sequence_ious)
+        assert "fast_motion" in result.attribute_results
+
+    def test_load_otb_attributes_file_not_found(self):
+        az = AttributeAnalyzer()
+        with pytest.raises(FileNotFoundError):
+            az.load_otb_attributes("/nonexistent/path/attrs.txt")
+
+    def test_load_otb_attributes_skips_short_lines(self, tmp_path, sequence_ious):
+        f = tmp_path / "attrs.txt"
+        # A line with only the sequence name (no attributes) should be skipped.
+        f.write_text("seq_a\nseq_b, occlusion\n")
+        az = AttributeAnalyzer()
+        az.load_otb_attributes(str(f))
+        assert "seq_a" not in az._attribute_map
+        assert "seq_b" in az._attribute_map
+
+
+# ---------------------------------------------------------------------------
+# Core analysis
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyze:
+    def test_returns_attribute_analysis(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        assert isinstance(result, AttributeAnalysis)
+        assert result.tracker_name == "MOSSE"
+
+    def test_expected_attributes_present(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        for attr in ("fast_motion", "occlusion", "scale_variation", "illumination_variation"):
+            assert attr in result.attribute_results
+
+    def test_attribute_sequence_counts(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        # fast_motion: seq_a + seq_c
+        assert result.attribute_results["fast_motion"].num_sequences == 2
+        # occlusion: seq_a + seq_b
+        assert result.attribute_results["occlusion"].num_sequences == 2
+        # illumination_variation: seq_d only
+        assert result.attribute_results["illumination_variation"].num_sequences == 1
+
+    def test_mean_iou_in_range(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        for ar in result.attribute_results.values():
+            assert 0.0 <= ar.mean_iou <= 1.0
+
+    def test_overall_matches_global_mean(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        expected = float(np.concatenate(list(sequence_ious.values())).mean())
+        assert result.overall.mean_iou == pytest.approx(expected, abs=1e-6)
+
+    def test_success_auc_in_range(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        for ar in result.attribute_results.values():
+            assert 0.0 <= ar.success_auc <= 1.0
+
+    def test_precision_auc_zero_without_distances(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious, sequence_distances=None)
+        for ar in result.attribute_results.values():
+            assert ar.precision_auc == pytest.approx(0.0)
+
+    def test_precision_auc_nonzero_with_distances(self, analyzer, sequence_ious, sequence_distances):
+        result = analyzer.analyze("MOSSE", sequence_ious, sequence_distances=sequence_distances)
+        # At least some attributes should have non-trivial precision AUC
+        aucs = [ar.precision_auc for ar in result.attribute_results.values()]
+        assert max(aucs) > 0.0
+
+    def test_sequences_not_in_attribute_map_skipped(self, sequence_ious):
+        az = AttributeAnalyzer(attribute_map={"seq_a": ["occlusion"]})
+        result = az.analyze("T", sequence_ious)
+        # Only seq_a contributes to attribute data
+        assert "occlusion" in result.attribute_results
+        assert result.attribute_results["occlusion"].num_sequences == 1
+        assert result.attribute_results["occlusion"].sequence_names == ["seq_a"]
+
+    def test_missing_sequences_excluded_from_overall(self):
+        partial_ious = {"seq_a": np.array([0.5, 0.6, 0.7])}
+        az = AttributeAnalyzer(attribute_map={"seq_a": ["fast_motion"]})
+        result = az.analyze("T", partial_ious)
+        expected = float(np.array([0.5, 0.6, 0.7]).mean())
+        assert result.overall.mean_iou == pytest.approx(expected, abs=1e-6)
+
+    def test_empty_distances_dict(self, analyzer, sequence_ious):
+        result = analyzer.analyze("T", sequence_ious, sequence_distances={})
+        for ar in result.attribute_results.values():
+            assert ar.precision_auc == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# AttributeAnalysis helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAttributeAnalysisHelpers:
+    def test_sorted_by_difficulty(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        sorted_attrs = result.sorted_by_difficulty
+        ious = [r.mean_iou for r in sorted_attrs]
+        assert ious == sorted(ious), "sorted_by_difficulty should be ascending"
+
+    def test_hardest_attribute_is_first(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        hardest = result.hardest_attribute
+        assert hardest is not None
+        all_ious = [r.mean_iou for r in result.attribute_results.values()]
+        assert hardest.mean_iou == pytest.approx(min(all_ious), abs=1e-8)
+
+    def test_easiest_attribute_is_last(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        easiest = result.easiest_attribute
+        assert easiest is not None
+        all_ious = [r.mean_iou for r in result.attribute_results.values()]
+        assert easiest.mean_iou == pytest.approx(max(all_ious), abs=1e-8)
+
+    def test_no_attributes_returns_none_hardest(self, sequence_ious):
+        az = AttributeAnalyzer()  # empty map
+        result = az.analyze("T", sequence_ious)
+        assert result.hardest_attribute is None
+        assert result.easiest_attribute is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-tracker comparison
+# ---------------------------------------------------------------------------
+
+
+class TestCompare:
+    @pytest.fixture
+    def two_analyses(self, analyzer, sequence_ious):
+        rng = np.random.default_rng(99)
+        other_ious = {k: rng.uniform(0.2, 0.7, len(v)) for k, v in sequence_ious.items()}
+        a1 = analyzer.analyze("MOSSE", sequence_ious)
+        a2 = analyzer.analyze("KCF", other_ious)
+        return a1, a2
+
+    def test_compare_returns_nested_dict(self, two_analyses):
+        a1, a2 = two_analyses
+        analyzer = AttributeAnalyzer(
+            attribute_map={
+                "seq_a": ["fast_motion", "occlusion"],
+                "seq_b": ["occlusion", "scale_variation"],
+                "seq_c": ["fast_motion", "motion_blur"],
+                "seq_d": ["illumination_variation"],
+            }
+        )
+        table = analyzer.compare([a1, a2])
+        assert "fast_motion" in table
+        assert "MOSSE" in table["fast_motion"]
+        assert "KCF" in table["fast_motion"]
+
+    def test_compare_values_in_range(self, analyzer, two_analyses):
+        a1, a2 = two_analyses
+        table = analyzer.compare([a1, a2])
+        for attr_vals in table.values():
+            for val in attr_vals.values():
+                assert 0.0 <= val <= 1.0
+
+    def test_format_comparison_table_markdown(self, analyzer, sequence_ious):
+        result = analyzer.analyze("MOSSE", sequence_ious)
+        md = analyzer.format_comparison_table([result])
+        assert "| Attribute |" in md
+        assert "MOSSE" in md
+        assert "**Overall**" in md
+
+    def test_format_comparison_table_missing_entry(self, sequence_ious):
+        az1 = AttributeAnalyzer(attribute_map={"seq_a": ["fast_motion"]})
+        az2 = AttributeAnalyzer(attribute_map={"seq_b": ["scale_variation"]})
+        rng = np.random.default_rng(0)
+        iou_a = {"seq_a": rng.uniform(0.3, 0.8, 30)}
+        iou_b = {"seq_b": rng.uniform(0.4, 0.9, 40)}
+        a1 = az1.analyze("T1", iou_a)
+        a2 = az2.analyze("T2", iou_b)
+        # Combine both analyses; T1 has no scale_variation, T2 has no fast_motion
+        md = az1.format_comparison_table([a1, a2])
+        assert " — |" in md  # missing entry placeholder
+
+    def test_difficulty_ranking_sorted_ascending(self, analyzer, two_analyses):
+        a1, a2 = two_analyses
+        ranking = analyzer.difficulty_ranking([a1, a2])
+        values = [v for _, v in ranking]
+        assert values == sorted(values), "Difficulty ranking should be ascending"
+
+    def test_difficulty_ranking_contains_all_attrs(self, analyzer, two_analyses):
+        a1, a2 = two_analyses
+        ranking = analyzer.difficulty_ranking([a1, a2])
+        all_attrs = {attr for r in (a1, a2) for attr in r.attribute_results}
+        ranked_attrs = {attr for attr, _ in ranking}
+        assert ranked_attrs == all_attrs
+
+
+# ---------------------------------------------------------------------------
+# from_benchmark_result integration
+# ---------------------------------------------------------------------------
+
+
+class TestFromBenchmarkResult:
+    """Tests for the BenchmarkResult integration path."""
+
+    class _FakeSequenceResult:
+        def __init__(self, name, ious, dists=None):
+            self.sequence_name = name
+            self.ious = ious
+            self.center_distances = dists
+
+    class _FakeBenchmarkResult:
+        def __init__(self, tracker_name, seq_results):
+            self.tracker_name = tracker_name
+            self.sequence_results = seq_results
+
+    def test_from_benchmark_result_basic(self, analyzer, sequence_ious, sequence_distances):
+        sr_list = [
+            self._FakeSequenceResult(
+                name, sequence_ious[name], sequence_distances.get(name)
+            )
+            for name in sequence_ious
+        ]
+        result_obj = self._FakeBenchmarkResult("KCF", sr_list)
+        analysis = analyzer.from_benchmark_result(result_obj)
+        assert analysis.tracker_name == "KCF"
+        assert "fast_motion" in analysis.attribute_results
+
+    def test_from_benchmark_result_without_distances(self, analyzer, sequence_ious):
+        sr_list = [
+            self._FakeSequenceResult(name, sequence_ious[name], None)
+            for name in sequence_ious
+        ]
+        result_obj = self._FakeBenchmarkResult("MOSSE", sr_list)
+        analysis = analyzer.from_benchmark_result(result_obj)
+        for ar in analysis.attribute_results.values():
+            assert ar.precision_auc == pytest.approx(0.0)

--- a/tests/test_sequence_attributes.py
+++ b/tests/test_sequence_attributes.py
@@ -1,0 +1,384 @@
+"""Tests for eovot.analysis — sequence attribute computation and reporting."""
+
+from __future__ import annotations
+
+from typing import Iterator, List, Tuple
+
+import numpy as np
+import pytest
+
+from eovot.analysis.sequence_attributes import (
+    AttributeFlags,
+    SequenceAttributes,
+    compute_sequence_attributes,
+    tag_sequences,
+)
+from eovot.analysis.attribute_report import (
+    AttributeReport,
+    generate_attribute_report,
+    TrackerAttributeSlice,
+)
+from eovot.datasets.base import BaseDataset, Sequence
+from eovot.benchmark.engine import BenchmarkEngine, BenchmarkResult, SequenceResult
+from eovot.profiling.profiler import Profiler, ProfilingResult
+from eovot.trackers.base import BaseTracker
+
+BBox = Tuple[float, float, float, float]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NUM_FRAMES = 30
+FIXED_BOX: BBox = (10.0, 10.0, 50.0, 50.0)
+
+
+def make_gt(boxes: List[BBox]) -> np.ndarray:
+    return np.array(boxes, dtype=np.float64)
+
+
+def static_gt(n: int, box: BBox = (10.0, 10.0, 50.0, 50.0)) -> np.ndarray:
+    return np.tile(np.array(box), (n, 1)).astype(np.float64)
+
+
+class SyntheticSequence(Sequence):
+    def __init__(self, name: str, gt: np.ndarray) -> None:
+        super().__init__(
+            name=name,
+            frame_paths=[f"frame_{i:04d}.jpg" for i in range(len(gt))],
+            ground_truth=gt,
+        )
+
+    def __iter__(self) -> Iterator[np.ndarray]:
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+        for _ in range(len(self.ground_truth)):
+            yield frame
+
+
+class SyntheticDataset(BaseDataset):
+    def __init__(self, seqs: List[Sequence]) -> None:
+        self._seqs = seqs
+
+    def __len__(self) -> int:
+        return len(self._seqs)
+
+    def __getitem__(self, idx: int) -> Sequence:
+        return self._seqs[idx]
+
+
+class ConstantTracker(BaseTracker):
+    @property
+    def name(self) -> str:
+        return "ConstantTracker"
+
+    def initialize(self, frame: np.ndarray, bbox: BBox) -> None:
+        self._box = bbox
+
+    def update(self, frame: np.ndarray) -> BBox:
+        return self._box
+
+
+def _make_profiling_result(fps: float = 100.0) -> ProfilingResult:
+    return ProfilingResult(
+        tracker_name="Test",
+        frame_count=10,
+        fps=fps,
+        latency_mean_ms=1_000 / fps,
+        latency_std_ms=0.0,
+        latency_p95_ms=1_000 / fps,
+        peak_memory_mb=50.0,
+    )
+
+
+def _make_seq_result(name: str, ious: np.ndarray, fps: float = 100.0) -> SequenceResult:
+    return SequenceResult(
+        sequence_name=name,
+        ious=ious,
+        profiling=_make_profiling_result(fps),
+    )
+
+
+def _make_bench_result(tracker_name: str, seq_results: List[SequenceResult]) -> BenchmarkResult:
+    r = BenchmarkResult(tracker_name=tracker_name, dataset_name="Synthetic")
+    r.sequence_results = seq_results
+    return r
+
+
+# ---------------------------------------------------------------------------
+# AttributeFlags tests
+# ---------------------------------------------------------------------------
+
+class TestAttributeFlags:
+    def test_all_false_by_default(self):
+        f = AttributeFlags()
+        assert not f.scale_variation
+        assert not f.aspect_ratio_change
+        assert not f.fast_motion
+        assert not f.low_resolution
+        assert not f.partial_occlusion
+        assert not f.deformation
+
+    def test_active_flags_empty_when_none(self):
+        f = AttributeFlags()
+        assert f.active_flags() == []
+
+    def test_active_flags_returns_abbreviations(self):
+        f = AttributeFlags(scale_variation=True, fast_motion=True)
+        active = f.active_flags()
+        assert "SV" in active
+        assert "FM" in active
+        assert "ARC" not in active
+
+    def test_to_dict_has_all_keys(self):
+        f = AttributeFlags(low_resolution=True)
+        d = f.to_dict()
+        assert set(d.keys()) == {"SV", "ARC", "FM", "LR", "PO", "DEF"}
+        assert d["LR"] is True
+        assert d["SV"] is False
+
+    def test_str_shows_active_flags(self):
+        f = AttributeFlags(fast_motion=True)
+        assert "FM" in str(f)
+
+    def test_str_none_when_no_flags(self):
+        f = AttributeFlags()
+        assert "none" in str(f)
+
+
+# ---------------------------------------------------------------------------
+# compute_sequence_attributes tests
+# ---------------------------------------------------------------------------
+
+class TestComputeSequenceAttributes:
+    def test_invalid_shape_raises(self):
+        with pytest.raises(ValueError, match="shape"):
+            compute_sequence_attributes(np.zeros((10, 3)), "bad")
+
+    def test_empty_array_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            compute_sequence_attributes(np.zeros((0, 4)), "empty")
+
+    def test_static_sequence_no_flags(self):
+        gt = static_gt(30)
+        attrs = compute_sequence_attributes(gt, "static")
+        assert not attrs.flags.scale_variation
+        assert not attrs.flags.fast_motion
+        assert not attrs.flags.partial_occlusion
+
+    def test_scale_variation_detected(self):
+        # Box grows 4× in area → ratio=4 ≥ threshold (2)
+        boxes = [(10.0, 10.0, 20.0, 20.0)] * 10 + [(10.0, 10.0, 40.0, 40.0)] * 10
+        gt = make_gt(boxes)
+        attrs = compute_sequence_attributes(gt, "sv_seq")
+        assert attrs.flags.scale_variation
+
+    def test_no_scale_variation_when_stable(self):
+        gt = static_gt(20, (10.0, 10.0, 30.0, 30.0))
+        attrs = compute_sequence_attributes(gt, "stable")
+        assert not attrs.flags.scale_variation
+
+    def test_fast_motion_detected(self):
+        # Object moves 200px per frame on a 40×40 box → 200/40 = 5 >> 0.2
+        boxes = [(float(i * 200), 10.0, 40.0, 40.0) for i in range(20)]
+        gt = make_gt(boxes)
+        attrs = compute_sequence_attributes(gt, "fast")
+        assert attrs.flags.fast_motion
+
+    def test_slow_motion_not_flagged(self):
+        # Object moves 1px per frame on a 100×100 box → negligible
+        boxes = [(float(i), 10.0, 100.0, 100.0) for i in range(20)]
+        gt = make_gt(boxes)
+        attrs = compute_sequence_attributes(gt, "slow")
+        assert not attrs.flags.fast_motion
+
+    def test_low_resolution_detected(self):
+        # 10×10 box = 100 px² < 400 threshold
+        gt = static_gt(20, (10.0, 10.0, 10.0, 10.0))
+        attrs = compute_sequence_attributes(gt, "lr")
+        assert attrs.flags.low_resolution
+
+    def test_high_resolution_not_flagged(self):
+        # 100×100 box = 10000 px²
+        gt = static_gt(20, (10.0, 10.0, 100.0, 100.0))
+        attrs = compute_sequence_attributes(gt, "hr")
+        assert not attrs.flags.low_resolution
+
+    def test_aspect_ratio_change_detected(self):
+        # Switches from wide (4:1) to tall (1:4) aspect ratio
+        boxes = [(10.0, 10.0, 80.0, 20.0)] * 10 + [(10.0, 10.0, 20.0, 80.0)] * 10
+        gt = make_gt(boxes)
+        attrs = compute_sequence_attributes(gt, "arc")
+        assert attrs.flags.aspect_ratio_change
+
+    def test_partial_occlusion_detected(self):
+        # Large box then very small box — abrupt area drop
+        boxes = [(10.0, 10.0, 80.0, 80.0)] * 10 + [(10.0, 10.0, 10.0, 10.0)] * 10
+        gt = make_gt(boxes)
+        attrs = compute_sequence_attributes(gt, "po")
+        assert attrs.flags.partial_occlusion
+
+    def test_scale_ratio_reported(self):
+        boxes = [(0.0, 0.0, 10.0, 10.0)] + [(0.0, 0.0, 30.0, 30.0)] * 9
+        gt = make_gt(boxes)
+        attrs = compute_sequence_attributes(gt, "ratio")
+        assert attrs.scale_ratio == pytest.approx(9.0, rel=0.01)
+
+    def test_mean_area_computed(self):
+        gt = static_gt(10, (0.0, 0.0, 10.0, 10.0))  # area = 100
+        attrs = compute_sequence_attributes(gt, "area")
+        assert attrs.mean_area_px == pytest.approx(100.0)
+
+    def test_num_frames_matches(self):
+        gt = static_gt(42)
+        attrs = compute_sequence_attributes(gt, "count")
+        assert attrs.num_frames == 42
+
+    def test_to_dict_keys(self):
+        gt = static_gt(10)
+        attrs = compute_sequence_attributes(gt, "dict_test")
+        d = attrs.to_dict()
+        assert "sequence_name" in d
+        assert "num_frames" in d
+        assert "flags" in d
+        assert "active_flags" in d
+
+    def test_custom_threshold_override(self):
+        # Only flag SV when ratio >= 10 (very high threshold)
+        boxes = [(0.0, 0.0, 10.0, 10.0)] * 5 + [(0.0, 0.0, 30.0, 30.0)] * 5
+        gt = make_gt(boxes)
+        # ratio = 9 → should NOT trigger SV with threshold=10
+        attrs = compute_sequence_attributes(gt, "high_thresh", sv_threshold=10.0)
+        assert not attrs.flags.scale_variation
+        # But should trigger with default threshold (2.0)
+        attrs2 = compute_sequence_attributes(gt, "default_thresh")
+        assert attrs2.flags.scale_variation
+
+
+# ---------------------------------------------------------------------------
+# tag_sequences tests
+# ---------------------------------------------------------------------------
+
+class TestTagSequences:
+    def _make_dataset(self):
+        seqs = [
+            SyntheticSequence("static", static_gt(20)),
+            SyntheticSequence("fast", make_gt(
+                [(float(i * 200), 10.0, 40.0, 40.0) for i in range(20)]
+            )),
+        ]
+        return SyntheticDataset(seqs)
+
+    def test_returns_dict_keyed_by_name(self):
+        ds = self._make_dataset()
+        tagged = tag_sequences(ds)
+        assert set(tagged.keys()) == {"static", "fast"}
+
+    def test_each_value_is_sequence_attributes(self):
+        ds = self._make_dataset()
+        tagged = tag_sequences(ds)
+        for v in tagged.values():
+            assert isinstance(v, SequenceAttributes)
+
+    def test_fast_sequence_flagged(self):
+        ds = self._make_dataset()
+        tagged = tag_sequences(ds)
+        assert tagged["fast"].flags.fast_motion
+
+    def test_static_sequence_not_flagged_for_motion(self):
+        ds = self._make_dataset()
+        tagged = tag_sequences(ds)
+        assert not tagged["static"].flags.fast_motion
+
+
+# ---------------------------------------------------------------------------
+# AttributeReport tests
+# ---------------------------------------------------------------------------
+
+class TestGenerateAttributeReport:
+    def _build_inputs(self):
+        # Two sequences: 'fast' has FM, 'static' doesn't
+        tagged_fast = make_gt([(float(i * 200), 10.0, 40.0, 40.0) for i in range(20)])
+        tagged_static = static_gt(20)
+
+        seqs = [
+            SyntheticSequence("fast_seq", tagged_fast),
+            SyntheticSequence("static_seq", tagged_static),
+        ]
+        ds = SyntheticDataset(seqs)
+        seq_attrs = tag_sequences(ds)
+
+        # Fake benchmark results for two trackers
+        r_mosse = _make_bench_result("MOSSE", [
+            _make_seq_result("fast_seq", np.full(20, 0.5)),
+            _make_seq_result("static_seq", np.full(20, 0.9)),
+        ])
+        r_kcf = _make_bench_result("KCF", [
+            _make_seq_result("fast_seq", np.full(20, 0.6)),
+            _make_seq_result("static_seq", np.full(20, 0.85)),
+        ])
+        return {"MOSSE": r_mosse, "KCF": r_kcf}, seq_attrs
+
+    def test_report_has_correct_trackers(self):
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        assert set(report.tracker_names) == {"MOSSE", "KCF"}
+
+    def test_overall_slice_populated(self):
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        assert "MOSSE" in report.overall
+        assert report.overall["MOSSE"].num_sequences == 2
+
+    def test_attribute_slices_all_flags(self):
+        from eovot.analysis.attribute_report import _ALL_FLAGS
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        for flag in _ALL_FLAGS:
+            assert flag in report.attribute_slices
+
+    def test_fm_slice_has_fast_sequence(self):
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        fm_mosse = report.attribute_slices["FM"]["MOSSE"]
+        assert fm_mosse.num_sequences >= 1
+
+    def test_overall_mean_iou_correct(self):
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        # MOSSE: mean IoU over fast_seq (0.5) and static_seq (0.9) = 0.7
+        assert report.overall["MOSSE"].mean_iou == pytest.approx(0.7, rel=0.01)
+
+    def test_markdown_table_contains_trackers(self):
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        table = report.markdown_table()
+        assert "MOSSE" in table
+        assert "KCF" in table
+
+    def test_markdown_table_contains_attributes(self):
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        table = report.markdown_table()
+        assert "Fast Motion" in table
+        assert "Scale Variation" in table
+
+    def test_to_dict_serialisable(self):
+        import json
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        d = report.to_dict()
+        # Should be JSON-serialisable (no numpy types)
+        json_str = json.dumps(d)
+        assert len(json_str) > 0
+
+    def test_save_json(self, tmp_path):
+        import json
+        results, attrs = self._build_inputs()
+        report = generate_attribute_report(results, attrs)
+        out = tmp_path / "report.json"
+        report.save_json(str(out))
+        assert out.exists()
+        with open(out) as fh:
+            loaded = json.load(fh)
+        assert "trackers" in loaded
+        assert "per_attribute" in loaded


### PR DESCRIPTION
## Summary

This PR adds a complete **sequence attribute analysis** sub-package (`eovot/analysis/`) that enables per-attribute tracker performance breakdown — a standard part of every publication-quality VOT benchmark paper (OTB, LaSOT, GOT-10k, VOT challenge).

Two complementary systems are introduced:

### 1. Annotation-based `AttributeAnalyzer` (`eovot/analysis/attribute.py`)
Loads attribute tags from OTB-style CSV files or manual registration, then stratifies accuracy metrics (IoU, success AUC, precision AUC) by attribute across one or more trackers.

```python
from eovot.analysis import AttributeAnalyzer

analyzer = AttributeAnalyzer()
analyzer.load_otb_attributes("data/otb_attributes.txt")

# Integrate directly with BenchmarkResult
analysis = analyzer.from_benchmark_result(result)

# Multi-tracker Markdown comparison table
print(analyzer.format_comparison_table([analysis_mosse, analysis_kcf]))

# Rank attributes by difficulty
for attr, avg_iou in analyzer.difficulty_ranking([analysis_mosse, analysis_kcf]):
    print(f"{attr}: {avg_iou:.3f}")
```

### 2. GT-based auto-detection (`eovot/analysis/sequence_attributes.py`)
Computes difficulty flags (SV, ARC, FM, LR, PO, DEF) directly from ground-truth bounding boxes — no external annotation file needed.

```python
from eovot.analysis import tag_sequences, generate_attribute_report

tagged = tag_sequences(dataset)
report = generate_attribute_report({"MOSSE": result_mosse, "KCF": result_kcf}, tagged)
print(report.markdown_table())
report.save_json("results/attribute_breakdown.json")
```

### 3. CLI (`scripts/analyze_attributes.py`)
```bash
python scripts/analyze_attributes.py --dataset OTBDataset --root /data/OTB100
python scripts/analyze_attributes.py --dataset OTBDataset --root /data/OTB100 --filter FM
```

## What was added

| File | Description |
|------|-------------|
| `eovot/analysis/attribute.py` | `AttributeAnalyzer`, `AttributeAnalysis`, `AttributeResult`, `STANDARD_ATTRIBUTES` |
| `eovot/analysis/sequence_attributes.py` | `compute_sequence_attributes()`, `tag_sequences()`, `AttributeFlags`, `SequenceAttributes` |
| `eovot/analysis/attribute_report.py` | `generate_attribute_report()`, `AttributeReport`, `TrackerAttributeSlice` |
| `eovot/analysis/__init__.py` | Unified public API for both systems |
| `scripts/analyze_attributes.py` | CLI for dataset-level attribute tagging |
| `tests/test_attribute_analysis.py` | 34 unit tests for `AttributeAnalyzer` |
| `tests/test_sequence_attributes.py` | 35 unit tests for auto-detection and reporting |

**Total: 69 passing tests.**

## Why it matters

Without per-attribute analysis, it is impossible to answer: *"Does this tracker fail because of fast motion, occlusion, or scale variation?"* This PR closes that gap and brings EOVOT to the standard expected by VOT/OTB-style publications.

## No breaking changes

All existing APIs are unchanged. The new `eovot.analysis` sub-package is purely additive.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbBwH9dA6hDxRiZNxJXRL6)_