### PR TITLE
[feat] Edge Deployment Score (EDS) and Pareto-frontier analysis

### DIFF
--- a/configs/hardware_profiles.yaml
+++ b/configs/hardware_profiles.yaml
@@ -1,0 +1,75 @@
+# Hardware deployment profiles for EOVOT Edge Deployment Score (EDS).
+#
+# Each profile defines:
+#   description   — Human-readable device name and power mode
+#   target_fps    — Minimum FPS required for real-time deployment
+#   max_memory_mb — Maximum peak RSS memory allowed (MB)
+#   tdp_watts     — CPU/SoC Thermal Design Power for energy estimation
+#   weights       — EDS axis weights (must sum to 1.0)
+#     accuracy    — Mean IoU (higher is better)
+#     fps         — Throughput (higher is better)
+#     memory      — Peak RSS (lower is better, normalised inversely)
+#     energy      — Energy per frame mJ (lower is better, normalised inversely)
+#
+# Usage with rank_for_edge.py:
+#   python scripts/rank_for_edge.py --results-dir results/ --profile raspberry_pi_4
+
+profiles:
+
+  raspberry_pi_4:
+    description: "Raspberry Pi 4 (Cortex-A72 quad-core, up to 15 W TDP)"
+    target_fps: 25.0
+    max_memory_mb: 512.0
+    tdp_watts: 15.0
+    weights:
+      accuracy: 0.35
+      fps: 0.35
+      memory: 0.20
+      energy: 0.10
+
+  jetson_nano:
+    description: "NVIDIA Jetson Nano (Cortex-A57 + Maxwell GPU, 10 W mode)"
+    target_fps: 30.0
+    max_memory_mb: 1024.0
+    tdp_watts: 10.0
+    weights:
+      accuracy: 0.40
+      fps: 0.30
+      memory: 0.15
+      energy: 0.15
+
+  laptop_cpu:
+    description: "Mid-range laptop CPU (15–45 W TDP, no discrete GPU)"
+    target_fps: 60.0
+    max_memory_mb: 4096.0
+    tdp_watts: 45.0
+    weights:
+      accuracy: 0.50
+      fps: 0.25
+      memory: 0.15
+      energy: 0.10
+
+  desktop_gpu:
+    description: "Desktop GPU workstation (high compute, 250 W TDP)"
+    target_fps: 120.0
+    max_memory_mb: 8192.0
+    tdp_watts: 250.0
+    weights:
+      accuracy: 0.70
+      fps: 0.15
+      memory: 0.10
+      energy: 0.05
+
+# --- Custom profile template ---
+# Uncomment and fill in to define your own hardware target.
+#
+# my_device:
+#   description: "My custom edge device"
+#   target_fps: 20.0
+#   max_memory_mb: 256.0
+#   tdp_watts: 5.0
+#   weights:
+#     accuracy: 0.40
+#     fps: 0.30
+#     memory: 0.20
+#     energy: 0.10

--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -1,10 +1,27 @@
 """Metrics sub-package — accuracy and efficiency evaluation."""
 
 from .accuracy import (
-    iou,
-    center_distance,
     AccuracyMetrics,
     MetricsEngine,
+    center_distance,
+    iou,
+)
+from .edge_score import (
+    HARDWARE_PROFILES,
+    EdgeDeploymentScorer,
+    EdgeScore,
+    ParetoPoint,
+    TrackerMetrics,
 )
 
-__all__ = ["iou", "center_distance", "AccuracyMetrics", "MetricsEngine"]
+__all__ = [
+    "iou",
+    "center_distance",
+    "AccuracyMetrics",
+    "MetricsEngine",
+    "EdgeDeploymentScorer",
+    "EdgeScore",
+    "ParetoPoint",
+    "TrackerMetrics",
+    "HARDWARE_PROFILES",
+]

--- a/eovot/metrics/edge_score.py
+++ b/eovot/metrics/edge_score.py
@@ -1,0 +1,459 @@
+"""Edge Deployment Score (EDS) — composite deployability metric for VOT trackers.
+
+The EDS ranks trackers for resource-constrained edge hardware by combining:
+  - Accuracy   (mean IoU) — higher is better
+  - Throughput (FPS)      — higher is better
+  - Memory     (peak MB)  — lower is better
+  - Energy     (mJ/frame) — lower is better
+
+Each axis is min-max normalised across the compared tracker set, then a
+weighted sum produces the scalar EDS ∈ [0, 1].  Pre-defined hardware profiles
+(Raspberry Pi 4, Jetson Nano, laptop CPU, desktop GPU) ship with tuned weights
+and hard deployment constraints (minimum FPS, maximum memory).
+
+A Pareto-frontier analysis identifies trackers that are not dominated on any
+two objectives simultaneously (default: accuracy vs. speed).
+
+Typical usage::
+
+    from eovot.metrics.edge_score import EdgeDeploymentScorer, TrackerMetrics
+
+    trackers = [
+        TrackerMetrics("MOSSE", mean_iou=0.42, fps=450.0, peak_memory_mb=45.0),
+        TrackerMetrics("KCF",   mean_iou=0.51, fps=180.0, peak_memory_mb=52.0),
+        TrackerMetrics("CSRT",  mean_iou=0.65, fps=40.0,  peak_memory_mb=68.0),
+    ]
+
+    scorer = EdgeDeploymentScorer.from_hardware_profile("raspberry_pi_4")
+    scores = scorer.score(trackers)
+    print(scorer.format_leaderboard(scores))
+
+    pareto = scorer.pareto_frontier(trackers)
+    optimal = [p.tracker_name for p in pareto if p.is_pareto_optimal]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Hardware profiles
+# ---------------------------------------------------------------------------
+
+HARDWARE_PROFILES: Dict[str, Dict] = {
+    "raspberry_pi_4": {
+        "description": "Raspberry Pi 4 (Cortex-A72 quad-core, up to 15 W TDP)",
+        "target_fps": 25.0,
+        "max_memory_mb": 512.0,
+        "tdp_watts": 15.0,
+        "weights": {"accuracy": 0.35, "fps": 0.35, "memory": 0.20, "energy": 0.10},
+    },
+    "jetson_nano": {
+        "description": "NVIDIA Jetson Nano (Cortex-A57 + Maxwell GPU, 10 W mode)",
+        "target_fps": 30.0,
+        "max_memory_mb": 1024.0,
+        "tdp_watts": 10.0,
+        "weights": {"accuracy": 0.40, "fps": 0.30, "memory": 0.15, "energy": 0.15},
+    },
+    "laptop_cpu": {
+        "description": "Mid-range laptop CPU (15–45 W TDP, no discrete GPU)",
+        "target_fps": 60.0,
+        "max_memory_mb": 4096.0,
+        "tdp_watts": 45.0,
+        "weights": {"accuracy": 0.50, "fps": 0.25, "memory": 0.15, "energy": 0.10},
+    },
+    "desktop_gpu": {
+        "description": "Desktop GPU workstation (high compute, 250 W TDP)",
+        "target_fps": 120.0,
+        "max_memory_mb": 8192.0,
+        "tdp_watts": 250.0,
+        "weights": {"accuracy": 0.70, "fps": 0.15, "memory": 0.10, "energy": 0.05},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrackerMetrics:
+    """Raw hardware metrics for one tracker obtained from a benchmark run.
+
+    Args:
+        name: Tracker identifier (e.g. ``"MOSSE"``).
+        mean_iou: Mean IoU across all evaluated frames.
+        fps: Mean frames-per-second throughput.
+        peak_memory_mb: Peak RSS memory in megabytes.
+        energy_per_frame_mj: Mean per-frame energy in milli-Joules.
+            Defaults to ``0.0`` when energy profiling was not enabled.
+    """
+
+    name: str
+    mean_iou: float
+    fps: float
+    peak_memory_mb: float
+    energy_per_frame_mj: float = 0.0
+
+    @classmethod
+    def from_benchmark_result(cls, result: object) -> "TrackerMetrics":
+        """Construct from a :class:`~eovot.benchmark.engine.BenchmarkResult`.
+
+        Args:
+            result: A :class:`~eovot.benchmark.engine.BenchmarkResult` instance.
+
+        Returns:
+            :class:`TrackerMetrics` populated from *result*'s aggregate
+            properties.
+        """
+        energy_mj = getattr(result, "mean_energy_per_frame_mj", None) or 0.0
+        return cls(
+            name=result.tracker_name,  # type: ignore[attr-defined]
+            mean_iou=result.mean_iou,  # type: ignore[attr-defined]
+            fps=result.mean_fps,  # type: ignore[attr-defined]
+            peak_memory_mb=result.peak_memory_mb,  # type: ignore[attr-defined]
+            energy_per_frame_mj=float(energy_mj),
+        )
+
+
+@dataclass
+class EdgeScore:
+    """Composite Edge Deployment Score for one tracker.
+
+    Attributes:
+        tracker_name: Tracker identifier.
+        raw: Original :class:`TrackerMetrics` before normalisation.
+        normalized: Per-axis normalised scores in ``[0, 1]``.
+        weights: Weights used for each axis.
+        score: Final weighted EDS in ``[0, 1]`` (higher = more deployable).
+        meets_fps_target: Whether *fps* ≥ ``target_fps`` constraint.
+        meets_memory_target: Whether *peak_memory_mb* ≤ ``max_memory_mb``.
+    """
+
+    tracker_name: str
+    raw: TrackerMetrics
+    normalized: Dict[str, float]
+    weights: Dict[str, float]
+    score: float
+    meets_fps_target: bool
+    meets_memory_target: bool
+
+    @property
+    def is_deployable(self) -> bool:
+        """``True`` if both FPS and memory hard constraints are met."""
+        return self.meets_fps_target and self.meets_memory_target
+
+    def to_dict(self) -> Dict:
+        """Serialise to a plain dict for JSON export."""
+        return {
+            "tracker": self.tracker_name,
+            "eds": round(self.score, 4),
+            "mean_iou": round(self.raw.mean_iou, 4),
+            "fps": round(self.raw.fps, 2),
+            "peak_memory_mb": round(self.raw.peak_memory_mb, 2),
+            "energy_per_frame_mj": round(self.raw.energy_per_frame_mj, 4),
+            "is_deployable": self.is_deployable,
+            "normalized": {k: round(v, 4) for k, v in self.normalized.items()},
+        }
+
+
+@dataclass
+class ParetoPoint:
+    """One point on the accuracy–speed Pareto frontier.
+
+    Attributes:
+        tracker_name: Tracker identifier.
+        mean_iou: Accuracy axis value.
+        fps: Speed axis value.
+        is_pareto_optimal: ``True`` if no other tracker strictly dominates
+            this point on *both* objectives.
+    """
+
+    tracker_name: str
+    mean_iou: float
+    fps: float
+    is_pareto_optimal: bool
+
+
+# ---------------------------------------------------------------------------
+# Scorer
+# ---------------------------------------------------------------------------
+
+
+class EdgeDeploymentScorer:
+    """Score and rank trackers for edge hardware deployment.
+
+    Normalises each metric axis min-max across the tracker cohort, then
+    computes a weighted sum to produce the Edge Deployment Score (EDS).
+    Hard constraints (``target_fps``, ``max_memory_mb``) flag trackers that
+    cannot meet deployment requirements regardless of their EDS.
+
+    Args:
+        weights: Dict with keys ``"accuracy"``, ``"fps"``, ``"memory"``,
+            ``"energy"`` that must sum to ``1.0``.
+            Defaults to equal 0.25 weighting on each axis.
+        target_fps: Minimum FPS required for deployment.
+        max_memory_mb: Maximum peak memory allowed (MB).
+
+    Raises:
+        ValueError: If *weights* keys are missing or do not sum to 1.0.
+    """
+
+    _REQUIRED_WEIGHT_KEYS = frozenset({"accuracy", "fps", "memory", "energy"})
+
+    def __init__(
+        self,
+        weights: Optional[Dict[str, float]] = None,
+        target_fps: float = 25.0,
+        max_memory_mb: float = 512.0,
+    ) -> None:
+        if weights is None:
+            weights = {k: 0.25 for k in self._REQUIRED_WEIGHT_KEYS}
+        self._validate_weights(weights)
+        self.weights = weights
+        self.target_fps = target_fps
+        self.max_memory_mb = max_memory_mb
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_hardware_profile(cls, profile_name: str) -> "EdgeDeploymentScorer":
+        """Instantiate a scorer tuned for a named hardware target.
+
+        Args:
+            profile_name: One of the keys in :data:`HARDWARE_PROFILES`
+                (e.g. ``"raspberry_pi_4"``).
+
+        Returns:
+            Pre-configured :class:`EdgeDeploymentScorer`.
+
+        Raises:
+            KeyError: If *profile_name* is not in :data:`HARDWARE_PROFILES`.
+        """
+        if profile_name not in HARDWARE_PROFILES:
+            available = list(HARDWARE_PROFILES)
+            raise KeyError(
+                f"Unknown hardware profile {profile_name!r}. "
+                f"Available: {available}"
+            )
+        profile = HARDWARE_PROFILES[profile_name]
+        return cls(
+            weights=dict(profile["weights"]),
+            target_fps=profile["target_fps"],
+            max_memory_mb=profile["max_memory_mb"],
+        )
+
+    # ------------------------------------------------------------------
+    # Core scoring
+    # ------------------------------------------------------------------
+
+    def score(self, trackers: List[TrackerMetrics]) -> List[EdgeScore]:
+        """Compute EDS for each tracker.
+
+        Args:
+            trackers: All trackers to compare.  Normalisation is relative
+                to this cohort, so all trackers intended for comparison
+                should be passed together.
+
+        Returns:
+            List of :class:`EdgeScore` sorted by ``score`` descending
+            (best-for-deployment first).
+        """
+        if not trackers:
+            return []
+
+        norm = self._normalize(trackers)
+
+        results: List[EdgeScore] = []
+        for i, tracker in enumerate(trackers):
+            eds = (
+                self.weights["accuracy"] * norm["accuracy"][i]
+                + self.weights["fps"] * norm["fps"][i]
+                + self.weights["memory"] * norm["memory"][i]
+                + self.weights["energy"] * norm["energy"][i]
+            )
+            results.append(
+                EdgeScore(
+                    tracker_name=tracker.name,
+                    raw=tracker,
+                    normalized={k: float(norm[k][i]) for k in norm},
+                    weights=dict(self.weights),
+                    score=float(eds),
+                    meets_fps_target=tracker.fps >= self.target_fps,
+                    meets_memory_target=tracker.peak_memory_mb <= self.max_memory_mb,
+                )
+            )
+
+        return sorted(results, key=lambda s: s.score, reverse=True)
+
+    def pareto_frontier(
+        self,
+        trackers: List[TrackerMetrics],
+        objective_x: str = "fps",
+        objective_y: str = "mean_iou",
+    ) -> List[ParetoPoint]:
+        """Identify Pareto-optimal trackers on a 2D objective plane.
+
+        A tracker is Pareto-optimal if no other tracker is strictly better
+        on **both** objectives simultaneously.
+
+        Args:
+            trackers: Tracker cohort.
+            objective_x: Attribute name for the x-axis (higher-is-better).
+                One of ``"fps"``, ``"mean_iou"``.
+            objective_y: Attribute name for the y-axis (higher-is-better).
+
+        Returns:
+            List of :class:`ParetoPoint` with ``is_pareto_optimal`` set.
+        """
+        if not trackers:
+            return []
+
+        x_vals = np.array([getattr(t, objective_x) for t in trackers], dtype=float)
+        y_vals = np.array([getattr(t, objective_y) for t in trackers], dtype=float)
+
+        points: List[ParetoPoint] = []
+        for i, t in enumerate(trackers):
+            dominated = any(
+                (x_vals[j] >= x_vals[i] and y_vals[j] >= y_vals[i])
+                and (x_vals[j] > x_vals[i] or y_vals[j] > y_vals[i])
+                for j in range(len(trackers))
+                if j != i
+            )
+            points.append(
+                ParetoPoint(
+                    tracker_name=t.name,
+                    mean_iou=t.mean_iou,
+                    fps=t.fps,
+                    is_pareto_optimal=not dominated,
+                )
+            )
+        return points
+
+    # ------------------------------------------------------------------
+    # Reporting
+    # ------------------------------------------------------------------
+
+    def format_leaderboard(self, scores: List[EdgeScore]) -> str:
+        """Render a Markdown leaderboard table sorted by EDS.
+
+        Args:
+            scores: Output of :meth:`score` (already sorted).
+
+        Returns:
+            Markdown-formatted table string.
+        """
+        header = (
+            "| Rank | Tracker | EDS | IoU | FPS | Memory (MB) | "
+            "Energy (mJ/fr) | Deployable |"
+        )
+        sep = "|------|---------|-----|-----|-----|-------------|---------------|------------|"
+        rows = [header, sep]
+        for rank, s in enumerate(scores, 1):
+            dep = "Yes" if s.is_deployable else "No"
+            rows.append(
+                f"| {rank} | {s.tracker_name} | {s.score:.3f} "
+                f"| {s.raw.mean_iou:.3f} | {s.raw.fps:.1f} "
+                f"| {s.raw.peak_memory_mb:.1f} "
+                f"| {s.raw.energy_per_frame_mj:.3f} | {dep} |"
+            )
+        return "\n".join(rows)
+
+    def suitability_report(
+        self,
+        scores: List[EdgeScore],
+        profile_name: Optional[str] = None,
+    ) -> str:
+        """Generate a plain-text deployment suitability report.
+
+        Args:
+            scores: Output of :meth:`score`.
+            profile_name: Optional hardware profile name for the header.
+
+        Returns:
+            Multi-line report string.
+        """
+        hw_line = (
+            f"Hardware Profile : {profile_name} — "
+            f"{HARDWARE_PROFILES[profile_name]['description']}"
+            if profile_name and profile_name in HARDWARE_PROFILES
+            else "Custom Hardware Profile"
+        )
+        deployable = [s for s in scores if s.is_deployable]
+        not_deployable = [s for s in scores if not s.is_deployable]
+
+        lines = [
+            "Edge Deployment Suitability Report",
+            "=" * 55,
+            hw_line,
+            f"  Target FPS      : >= {self.target_fps:.0f}",
+            f"  Max Memory      : <= {self.max_memory_mb:.0f} MB",
+            f"  Weights         : {self.weights}",
+            "",
+            f"Deployable Trackers ({len(deployable)}/{len(scores)}):",
+        ]
+        for s in deployable:
+            lines.append(
+                f"  [{s.score:.3f}] {s.tracker_name:<20s}  "
+                f"IoU={s.raw.mean_iou:.3f}  FPS={s.raw.fps:.1f}  "
+                f"Mem={s.raw.peak_memory_mb:.0f} MB"
+            )
+        if not_deployable:
+            lines += ["", "Not Meeting Constraints:"]
+            for s in not_deployable:
+                reasons = []
+                if not s.meets_fps_target:
+                    reasons.append(f"FPS={s.raw.fps:.1f} < {self.target_fps:.0f}")
+                if not s.meets_memory_target:
+                    reasons.append(
+                        f"Mem={s.raw.peak_memory_mb:.0f} MB > {self.max_memory_mb:.0f} MB"
+                    )
+                lines.append(
+                    f"  [{s.score:.3f}] {s.tracker_name:<20s}  ({', '.join(reasons)})"
+                )
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _validate_weights(cls, weights: Dict[str, float]) -> None:
+        missing = cls._REQUIRED_WEIGHT_KEYS - set(weights)
+        if missing:
+            raise ValueError(f"Missing weight keys: {sorted(missing)}")
+        total = sum(weights.values())
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(f"Weights must sum to 1.0, got {total:.6f}")
+
+    @staticmethod
+    def _normalize(trackers: List[TrackerMetrics]) -> Dict[str, List[float]]:
+        """Min-max normalise each axis.  Memory and energy are inverted."""
+
+        def minmax(vals: np.ndarray, invert: bool = False) -> np.ndarray:
+            lo, hi = vals.min(), vals.max()
+            if hi == lo:
+                # All trackers equal on this axis → give everyone 1.0
+                return np.ones_like(vals, dtype=float)
+            normed = (vals - lo) / (hi - lo)
+            return 1.0 - normed if invert else normed
+
+        accuracy = minmax(np.array([t.mean_iou for t in trackers]))
+        fps = minmax(np.array([t.fps for t in trackers]))
+        memory = minmax(np.array([t.peak_memory_mb for t in trackers]), invert=True)
+        energy = minmax(
+            np.array([t.energy_per_frame_mj for t in trackers]), invert=True
+        )
+
+        return {
+            "accuracy": accuracy.tolist(),
+            "fps": fps.tolist(),
+            "memory": memory.tolist(),
+            "energy": energy.tolist(),
+        }

--- a/scripts/rank_for_edge.py
+++ b/scripts/rank_for_edge.py
@@ -1,0 +1,230 @@
+"""CLI: Rank trackers by Edge Deployment Score (EDS) for a target hardware profile.
+
+Reads benchmark JSON result files (produced by run_benchmark.py or
+run_experiment.py) and ranks each tracker using the Edge Deployment Score —
+a weighted composite of accuracy, throughput, memory, and energy.
+
+Usage examples::
+
+    # Rank using Raspberry Pi 4 profile (reads all JSON files in results/)
+    python scripts/rank_for_edge.py --results-dir results/ --profile raspberry_pi_4
+
+    # Rank using custom weights and show Pareto-optimal trackers
+    python scripts/rank_for_edge.py \\
+        --results-dir results/ \\
+        --accuracy-weight 0.5 --fps-weight 0.3 \\
+        --memory-weight 0.1 --energy-weight 0.1 \\
+        --target-fps 30 --max-memory 512 \\
+        --pareto
+
+    # Save report to file
+    python scripts/rank_for_edge.py \\
+        --results-dir results/ \\
+        --profile jetson_nano \\
+        --output results/edge_leaderboard.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eovot.metrics.edge_score import (
+    HARDWARE_PROFILES,
+    EdgeDeploymentScorer,
+    TrackerMetrics,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Rank trackers by Edge Deployment Score.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--results-dir",
+        required=True,
+        metavar="DIR",
+        help="Directory containing tracker JSON result files.",
+    )
+    p.add_argument(
+        "--profile",
+        choices=list(HARDWARE_PROFILES),
+        default=None,
+        metavar="PROFILE",
+        help=(
+            "Hardware profile to use for weights and constraints. "
+            f"Choices: {list(HARDWARE_PROFILES)}."
+        ),
+    )
+    p.add_argument(
+        "--accuracy-weight",
+        type=float,
+        default=0.25,
+        help="Weight for accuracy (IoU) axis [0, 1]. Default: 0.25.",
+    )
+    p.add_argument(
+        "--fps-weight",
+        type=float,
+        default=0.25,
+        help="Weight for throughput (FPS) axis [0, 1]. Default: 0.25.",
+    )
+    p.add_argument(
+        "--memory-weight",
+        type=float,
+        default=0.25,
+        help="Weight for memory (lower is better) axis [0, 1]. Default: 0.25.",
+    )
+    p.add_argument(
+        "--energy-weight",
+        type=float,
+        default=0.25,
+        help="Weight for energy (lower is better) axis [0, 1]. Default: 0.25.",
+    )
+    p.add_argument(
+        "--target-fps",
+        type=float,
+        default=25.0,
+        help="Minimum FPS required for deployment. Default: 25.",
+    )
+    p.add_argument(
+        "--max-memory",
+        type=float,
+        default=512.0,
+        metavar="MB",
+        help="Maximum peak memory in MB. Default: 512.",
+    )
+    p.add_argument(
+        "--pareto",
+        action="store_true",
+        help="Print Pareto-optimal trackers (accuracy vs. speed).",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        metavar="FILE",
+        help="Save the Markdown leaderboard and suitability report to FILE.",
+    )
+    p.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="Print all available hardware profiles and exit.",
+    )
+    return p
+
+
+def load_tracker_metrics(results_dir: str) -> list[TrackerMetrics]:
+    """Load TrackerMetrics from all JSON result files in *results_dir*."""
+    dir_path = Path(results_dir)
+    if not dir_path.is_dir():
+        print(f"Error: results directory not found: {results_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    json_files = sorted(dir_path.glob("*.json"))
+    if not json_files:
+        print(f"No JSON result files found in {results_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    trackers: list[TrackerMetrics] = []
+    for jf in json_files:
+        try:
+            with open(jf) as fh:
+                data = json.load(fh)
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"Warning: skipping {jf.name}: {exc}", file=sys.stderr)
+            continue
+
+        summary = data.get("summary", data)
+        try:
+            tm = TrackerMetrics(
+                name=summary.get("tracker", jf.stem),
+                mean_iou=float(summary["mean_iou"]),
+                fps=float(summary["mean_fps"]),
+                peak_memory_mb=float(summary["peak_memory_mb"]),
+                energy_per_frame_mj=float(summary.get("mean_energy_per_frame_mj", 0.0)),
+            )
+            trackers.append(tm)
+        except (KeyError, TypeError) as exc:
+            print(f"Warning: skipping {jf.name}, missing field: {exc}", file=sys.stderr)
+
+    return trackers
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.list_profiles:
+        print("Available hardware profiles:")
+        for name, cfg in HARDWARE_PROFILES.items():
+            print(f"  {name:<20s}  {cfg['description']}")
+        return
+
+    # Build scorer
+    if args.profile:
+        scorer = EdgeDeploymentScorer.from_hardware_profile(args.profile)
+        print(f"\nUsing hardware profile: {args.profile}")
+        print(f"  {HARDWARE_PROFILES[args.profile]['description']}")
+    else:
+        total_w = args.accuracy_weight + args.fps_weight + args.memory_weight + args.energy_weight
+        if abs(total_w - 1.0) > 1e-6:
+            print(
+                f"Error: weights must sum to 1.0, got {total_w:.4f}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        scorer = EdgeDeploymentScorer(
+            weights={
+                "accuracy": args.accuracy_weight,
+                "fps": args.fps_weight,
+                "memory": args.memory_weight,
+                "energy": args.energy_weight,
+            },
+            target_fps=args.target_fps,
+            max_memory_mb=args.max_memory,
+        )
+        print("\nUsing custom weights:")
+        print(f"  accuracy={args.accuracy_weight}  fps={args.fps_weight}  "
+              f"memory={args.memory_weight}  energy={args.energy_weight}")
+
+    # Load tracker results
+    trackers = load_tracker_metrics(args.results_dir)
+    if not trackers:
+        print("No valid tracker results found.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\nLoaded {len(trackers)} tracker(s) from {args.results_dir}")
+
+    # Score
+    scores = scorer.score(trackers)
+
+    # Print leaderboard
+    print("\n" + scorer.format_leaderboard(scores))
+
+    # Print suitability report
+    print("\n" + scorer.suitability_report(scores, profile_name=args.profile))
+
+    # Pareto frontier
+    if args.pareto:
+        pareto_pts = scorer.pareto_frontier(trackers)
+        optimal = [p.tracker_name for p in pareto_pts if p.is_pareto_optimal]
+        print(f"\nPareto-optimal trackers (accuracy vs. speed): {optimal}")
+
+    # Save output
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        content = scorer.format_leaderboard(scores)
+        content += "\n\n"
+        content += scorer.suitability_report(scores, profile_name=args.profile)
+        out.write_text(content)
+        print(f"\nReport saved to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_edge_score.py
+++ b/tests/test_edge_score.py
@@ -1,0 +1,343 @@
+"""Tests for eovot.metrics.edge_score — EdgeDeploymentScorer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.metrics.edge_score import (
+    HARDWARE_PROFILES,
+    EdgeDeploymentScorer,
+    EdgeScore,
+    ParetoPoint,
+    TrackerMetrics,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def three_trackers() -> list:
+    """Fast-but-inaccurate, balanced, slow-but-accurate."""
+    return [
+        TrackerMetrics("MOSSE", mean_iou=0.42, fps=450.0, peak_memory_mb=45.0, energy_per_frame_mj=0.2),
+        TrackerMetrics("KCF",   mean_iou=0.51, fps=180.0, peak_memory_mb=52.0, energy_per_frame_mj=0.5),
+        TrackerMetrics("CSRT",  mean_iou=0.65, fps=40.0,  peak_memory_mb=68.0, energy_per_frame_mj=1.2),
+    ]
+
+
+@pytest.fixture
+def scorer_equal() -> EdgeDeploymentScorer:
+    return EdgeDeploymentScorer(
+        weights={"accuracy": 0.25, "fps": 0.25, "memory": 0.25, "energy": 0.25},
+        target_fps=25.0,
+        max_memory_mb=512.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TrackerMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestTrackerMetrics:
+    def test_default_energy_is_zero(self):
+        t = TrackerMetrics("T", mean_iou=0.5, fps=100.0, peak_memory_mb=50.0)
+        assert t.energy_per_frame_mj == 0.0
+
+    def test_from_benchmark_result(self):
+        class _FakeResult:
+            tracker_name = "MOSSE"
+            mean_iou = 0.42
+            mean_fps = 300.0
+            peak_memory_mb = 48.0
+            mean_energy_per_frame_mj = 0.8
+
+        tm = TrackerMetrics.from_benchmark_result(_FakeResult())
+        assert tm.name == "MOSSE"
+        assert tm.mean_iou == pytest.approx(0.42)
+        assert tm.fps == pytest.approx(300.0)
+        assert tm.peak_memory_mb == pytest.approx(48.0)
+        assert tm.energy_per_frame_mj == pytest.approx(0.8)
+
+    def test_from_benchmark_result_none_energy(self):
+        class _FakeResult:
+            tracker_name = "T"
+            mean_iou = 0.5
+            mean_fps = 100.0
+            peak_memory_mb = 60.0
+            mean_energy_per_frame_mj = None
+
+        tm = TrackerMetrics.from_benchmark_result(_FakeResult())
+        assert tm.energy_per_frame_mj == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# HARDWARE_PROFILES
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareProfiles:
+    def test_all_required_profiles_present(self):
+        for key in ("raspberry_pi_4", "jetson_nano", "laptop_cpu", "desktop_gpu"):
+            assert key in HARDWARE_PROFILES
+
+    def test_each_profile_has_required_keys(self):
+        required = {"description", "target_fps", "max_memory_mb", "tdp_watts", "weights"}
+        for profile in HARDWARE_PROFILES.values():
+            assert required <= set(profile)
+
+    def test_each_profile_weights_sum_to_one(self):
+        for name, profile in HARDWARE_PROFILES.items():
+            total = sum(profile["weights"].values())
+            assert abs(total - 1.0) < 1e-6, f"Profile {name} weights don't sum to 1"
+
+
+# ---------------------------------------------------------------------------
+# EdgeDeploymentScorer construction
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeDeploymentScorerConstruction:
+    def test_default_weights_equal(self):
+        scorer = EdgeDeploymentScorer()
+        for val in scorer.weights.values():
+            assert val == pytest.approx(0.25)
+
+    def test_custom_weights_stored(self):
+        w = {"accuracy": 0.5, "fps": 0.3, "memory": 0.1, "energy": 0.1}
+        scorer = EdgeDeploymentScorer(weights=w)
+        assert scorer.weights == w
+
+    def test_invalid_weights_missing_key(self):
+        with pytest.raises(ValueError, match="Missing weight keys"):
+            EdgeDeploymentScorer(weights={"accuracy": 0.5, "fps": 0.5})
+
+    def test_invalid_weights_wrong_sum(self):
+        with pytest.raises(ValueError, match="sum to 1"):
+            EdgeDeploymentScorer(
+                weights={"accuracy": 0.4, "fps": 0.4, "memory": 0.1, "energy": 0.5}
+            )
+
+    def test_from_hardware_profile_raspberry_pi(self):
+        scorer = EdgeDeploymentScorer.from_hardware_profile("raspberry_pi_4")
+        assert scorer.target_fps == pytest.approx(25.0)
+        assert scorer.max_memory_mb == pytest.approx(512.0)
+
+    def test_from_hardware_profile_jetson_nano(self):
+        scorer = EdgeDeploymentScorer.from_hardware_profile("jetson_nano")
+        assert scorer.target_fps == pytest.approx(30.0)
+
+    def test_from_hardware_profile_unknown_raises(self):
+        with pytest.raises(KeyError, match="Unknown hardware profile"):
+            EdgeDeploymentScorer.from_hardware_profile("doesnotexist")
+
+
+# ---------------------------------------------------------------------------
+# score()
+# ---------------------------------------------------------------------------
+
+
+class TestScore:
+    def test_returns_list_of_edge_scores(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        assert len(scores) == 3
+        assert all(isinstance(s, EdgeScore) for s in scores)
+
+    def test_sorted_descending(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        vals = [s.score for s in scores]
+        assert vals == sorted(vals, reverse=True)
+
+    def test_score_in_unit_interval(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        for s in scores:
+            assert 0.0 <= s.score <= 1.0
+
+    def test_empty_input_returns_empty(self, scorer_equal):
+        assert scorer_equal.score([]) == []
+
+    def test_single_tracker_gets_score_one(self, scorer_equal):
+        only = [TrackerMetrics("T", mean_iou=0.5, fps=100.0, peak_memory_mb=50.0)]
+        scores = scorer_equal.score(only)
+        # All normalised to 1.0 when only one tracker → EDS = 1.0
+        assert scores[0].score == pytest.approx(1.0)
+
+    def test_normalized_values_in_range(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        for s in scores:
+            for v in s.normalized.values():
+                assert 0.0 <= v <= 1.0
+
+    def test_meets_fps_target_flag(self, three_trackers):
+        scorer = EdgeDeploymentScorer(
+            weights={"accuracy": 0.25, "fps": 0.25, "memory": 0.25, "energy": 0.25},
+            target_fps=100.0,   # MOSSE 450 ok, KCF 180 ok, CSRT 40 NOT ok
+            max_memory_mb=9999.0,
+        )
+        scores = {s.tracker_name: s for s in scorer.score(three_trackers)}
+        assert scores["MOSSE"].meets_fps_target is True
+        assert scores["KCF"].meets_fps_target is True
+        assert scores["CSRT"].meets_fps_target is False
+
+    def test_meets_memory_target_flag(self, three_trackers):
+        scorer = EdgeDeploymentScorer(
+            weights={"accuracy": 0.25, "fps": 0.25, "memory": 0.25, "energy": 0.25},
+            target_fps=0.0,
+            max_memory_mb=50.0,  # MOSSE 45 ok, KCF 52 NOT ok, CSRT 68 NOT ok
+        )
+        scores = {s.tracker_name: s for s in scorer.score(three_trackers)}
+        assert scores["MOSSE"].meets_memory_target is True
+        assert scores["KCF"].meets_memory_target is False
+        assert scores["CSRT"].meets_memory_target is False
+
+    def test_is_deployable_requires_both_constraints(self, three_trackers):
+        scorer = EdgeDeploymentScorer(
+            weights={"accuracy": 0.25, "fps": 0.25, "memory": 0.25, "energy": 0.25},
+            target_fps=100.0,
+            max_memory_mb=50.0,
+        )
+        scores = {s.tracker_name: s for s in scorer.score(three_trackers)}
+        # MOSSE: fps=450 >= 100 AND mem=45 <= 50 → deployable
+        assert scores["MOSSE"].is_deployable is True
+        # KCF: fps=180 >= 100 but mem=52 > 50 → NOT deployable
+        assert scores["KCF"].is_deployable is False
+
+    def test_score_higher_accuracy_weight_favours_csrt(self, three_trackers):
+        accuracy_heavy = EdgeDeploymentScorer(
+            weights={"accuracy": 0.90, "fps": 0.05, "memory": 0.03, "energy": 0.02},
+        )
+        scores = accuracy_heavy.score(three_trackers)
+        # CSRT has highest IoU → should rank first
+        assert scores[0].tracker_name == "CSRT"
+
+    def test_score_higher_fps_weight_favours_mosse(self, three_trackers):
+        fps_heavy = EdgeDeploymentScorer(
+            weights={"accuracy": 0.05, "fps": 0.90, "memory": 0.03, "energy": 0.02},
+        )
+        scores = fps_heavy.score(three_trackers)
+        # MOSSE has highest FPS → should rank first
+        assert scores[0].tracker_name == "MOSSE"
+
+    def test_to_dict_keys(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        d = scores[0].to_dict()
+        for key in ("tracker", "eds", "mean_iou", "fps", "peak_memory_mb", "is_deployable"):
+            assert key in d
+
+
+# ---------------------------------------------------------------------------
+# pareto_frontier()
+# ---------------------------------------------------------------------------
+
+
+class TestParetoFrontier:
+    def test_returns_list_of_pareto_points(self, scorer_equal, three_trackers):
+        points = scorer_equal.pareto_frontier(three_trackers)
+        assert len(points) == 3
+        assert all(isinstance(p, ParetoPoint) for p in points)
+
+    def test_empty_input_returns_empty(self, scorer_equal):
+        assert scorer_equal.pareto_frontier([]) == []
+
+    def test_dominated_tracker_not_optimal(self, scorer_equal):
+        # B dominates A on both axes: more accurate AND faster
+        trackers = [
+            TrackerMetrics("A", mean_iou=0.3, fps=50.0, peak_memory_mb=50.0),
+            TrackerMetrics("B", mean_iou=0.6, fps=100.0, peak_memory_mb=50.0),
+            TrackerMetrics("C", mean_iou=0.8, fps=20.0, peak_memory_mb=50.0),
+        ]
+        pts = {p.tracker_name: p for p in scorer_equal.pareto_frontier(trackers)}
+        assert pts["A"].is_pareto_optimal is False
+        assert pts["B"].is_pareto_optimal is True
+        assert pts["C"].is_pareto_optimal is True
+
+    def test_single_tracker_always_pareto_optimal(self, scorer_equal):
+        trackers = [TrackerMetrics("X", mean_iou=0.5, fps=100.0, peak_memory_mb=60.0)]
+        pts = scorer_equal.pareto_frontier(trackers)
+        assert pts[0].is_pareto_optimal is True
+
+    def test_identical_trackers_both_optimal(self, scorer_equal):
+        trackers = [
+            TrackerMetrics("A", mean_iou=0.5, fps=100.0, peak_memory_mb=50.0),
+            TrackerMetrics("B", mean_iou=0.5, fps=100.0, peak_memory_mb=50.0),
+        ]
+        pts = scorer_equal.pareto_frontier(trackers)
+        assert all(p.is_pareto_optimal for p in pts)
+
+    def test_pareto_points_have_correct_attributes(self, scorer_equal, three_trackers):
+        pts = {p.tracker_name: p for p in scorer_equal.pareto_frontier(three_trackers)}
+        assert pts["MOSSE"].fps == pytest.approx(450.0)
+        assert pts["CSRT"].mean_iou == pytest.approx(0.65)
+
+
+# ---------------------------------------------------------------------------
+# format_leaderboard()
+# ---------------------------------------------------------------------------
+
+
+class TestFormatLeaderboard:
+    def test_contains_header(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        md = scorer_equal.format_leaderboard(scores)
+        assert "| Rank |" in md
+        assert "EDS" in md
+
+    def test_contains_all_tracker_names(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        md = scorer_equal.format_leaderboard(scores)
+        for name in ("MOSSE", "KCF", "CSRT"):
+            assert name in md
+
+    def test_deployable_column(self, three_trackers):
+        scorer = EdgeDeploymentScorer(
+            weights={"accuracy": 0.25, "fps": 0.25, "memory": 0.25, "energy": 0.25},
+            target_fps=50.0,
+            max_memory_mb=100.0,
+        )
+        scores = scorer.score(three_trackers)
+        md = scorer.format_leaderboard(scores)
+        assert "Yes" in md or "No" in md
+
+
+# ---------------------------------------------------------------------------
+# suitability_report()
+# ---------------------------------------------------------------------------
+
+
+class TestSuitabilityReport:
+    def test_report_contains_profile_name(self, three_trackers):
+        scorer = EdgeDeploymentScorer.from_hardware_profile("raspberry_pi_4")
+        scores = scorer.score(three_trackers)
+        report = scorer.suitability_report(scores, profile_name="raspberry_pi_4")
+        assert "raspberry_pi_4" in report
+
+    def test_report_contains_target_fps(self, scorer_equal, three_trackers):
+        scores = scorer_equal.score(three_trackers)
+        report = scorer_equal.suitability_report(scores)
+        assert "25" in report  # target_fps = 25.0
+
+    def test_report_lists_deployable_trackers(self, three_trackers):
+        scorer = EdgeDeploymentScorer(
+            weights={"accuracy": 0.25, "fps": 0.25, "memory": 0.25, "energy": 0.25},
+            target_fps=50.0,
+            max_memory_mb=100.0,
+        )
+        scores = scorer.score(three_trackers)
+        report = scorer.suitability_report(scores)
+        # MOSSE (450 FPS) and KCF (180 FPS) should be in deployable section
+        assert "MOSSE" in report
+
+    def test_report_lists_not_meeting_constraints(self, three_trackers):
+        scorer = EdgeDeploymentScorer(
+            weights={"accuracy": 0.25, "fps": 0.25, "memory": 0.25, "energy": 0.25},
+            target_fps=200.0,  # Only MOSSE (450 FPS) meets this
+            max_memory_mb=100.0,
+        )
+        scores = scorer.score(three_trackers)
+        report = scorer.suitability_report(scores)
+        assert "Not Meeting Constraints" in report
+        assert "CSRT" in report


### PR DESCRIPTION
## Summary

This PR introduces the **Edge Deployment Score (EDS)** — a hardware-aware composite metric that gives a principled, single-number answer to: *"Which tracker should I deploy on this device?"*

The EDS normalises accuracy (IoU), throughput (FPS), memory, and energy across the compared tracker cohort, then computes a configurable weighted sum. Hard constraints (minimum FPS, maximum memory) flag trackers that cannot meet deployment requirements regardless of their EDS.

## What was added

| File | Description |
|------|-------------|
| `eovot/metrics/edge_score.py` | `EdgeDeploymentScorer`, `TrackerMetrics`, `EdgeScore`, `ParetoPoint`, `HARDWARE_PROFILES` |
| `eovot/metrics/__init__.py` | Updated to expose all new public symbols |
| `configs/hardware_profiles.yaml` | Four pre-configured device profiles with documented weights, TDP, FPS targets, memory budgets |
| `scripts/rank_for_edge.py` | CLI to rank trackers from experiment JSON outputs |
| `tests/test_edge_score.py` | 38 unit tests |

## Usage

### Python API

```python
from eovot.metrics.edge_score import EdgeDeploymentScorer, TrackerMetrics

trackers = [
    TrackerMetrics("MOSSE", mean_iou=0.42, fps=450.0, peak_memory_mb=45.0),
    TrackerMetrics("KCF",   mean_iou=0.51, fps=180.0, peak_memory_mb=52.0),
    TrackerMetrics("CSRT",  mean_iou=0.65, fps=40.0,  peak_memory_mb=68.0),
]

# Use a pre-defined hardware profile
scorer = EdgeDeploymentScorer.from_hardware_profile("raspberry_pi_4")
scores = scorer.score(trackers)

print(scorer.format_leaderboard(scores))
print(scorer.suitability_report(scores, profile_name="raspberry_pi_4"))

# Pareto frontier (accuracy vs. speed)
pareto = scorer.pareto_frontier(trackers)
optimal = [p.tracker_name for p in pareto if p.is_pareto_optimal]
```

### From a BenchmarkResult

```python
# Bridge directly from benchmark output
tm = TrackerMetrics.from_benchmark_result(result)
```

### CLI

```bash
# Rank all trackers in results/ for Raspberry Pi 4
python scripts/rank_for_edge.py --results-dir results/ --profile raspberry_pi_4

# Custom weights + Pareto output
python scripts/rank_for_edge.py \
    --results-dir results/ \
    --accuracy-weight 0.5 --fps-weight 0.3 --memory-weight 0.1 --energy-weight 0.1 \
    --target-fps 30 --pareto --output results/edge_report.md

# List all available hardware profiles
python scripts/rank_for_edge.py --list-profiles
```

## Hardware Profiles

| Profile | Target FPS | Max Memory | Accuracy Weight | FPS Weight |
|---------|-----------|------------|-----------------|------------|
| `raspberry_pi_4` | 25 | 512 MB | 0.35 | 0.35 |
| `jetson_nano` | 30 | 1024 MB | 0.40 | 0.30 |
| `laptop_cpu` | 60 | 4096 MB | 0.50 | 0.25 |
| `desktop_gpu` | 120 | 8192 MB | 0.70 | 0.15 |

## Why it matters

Academic benchmarks rank trackers solely by accuracy. EOVOT's mission is edge-aware benchmarking. The EDS makes this concrete: a single reproducible score that reflects real deployment tradeoffs, with transparent per-axis breakdown and Pareto-frontier analysis for multi-objective comparison.

## No breaking changes

All existing APIs are unchanged. `eovot/metrics/__init__.py` is updated only with new exports.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbBwH9dA6hDxRiZNxJXRL6)_