### PR TITLE
[feat] Add EfficiencyAnalyzer, Pareto frontier, and radar/scatter visualization

### DIFF
--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -7,6 +7,7 @@ from .accuracy import (
     MetricsEngine,
 )
 from .robustness import RobustnessAnalyzer, RobustnessResult
+from .efficiency import EfficiencyAnalyzer, EdgeFitnessScore
 
 __all__ = [
     "iou",
@@ -15,4 +16,6 @@ __all__ = [
     "MetricsEngine",
     "RobustnessAnalyzer",
     "RobustnessResult",
+    "EfficiencyAnalyzer",
+    "EdgeFitnessScore",
 ]

--- a/eovot/metrics/efficiency.py
+++ b/eovot/metrics/efficiency.py
@@ -1,0 +1,371 @@
+"""Edge efficiency analysis for EOVOT benchmark results.
+
+Provides tools for reasoning about the accuracy-efficiency trade-off that is
+central to edge deployment of visual object trackers:
+
+- **Pareto frontier**: trackers that are not dominated on any combination of
+  accuracy (mIoU) and throughput (FPS).
+- **Edge Fitness Score**: a single weighted scalar that combines all relevant
+  metrics into a deployability score for a target device profile.
+- **Hardware constraint filtering**: quickly identify which trackers can run
+  within a device's latency, memory, and energy budget.
+- **Leaderboard ranking**: rank trackers by fitness and format the result.
+
+All methods accept standard EOVOT result dicts produced by
+:meth:`~eovot.benchmark.engine.BenchmarkResult.to_dict`::
+
+    {
+        "summary": {
+            "tracker":           str,
+            "mean_iou":          float,
+            "mean_fps":          float,
+            "peak_memory_mb":    float,
+            "mean_latency_ms":   float,  # optional
+            "mean_energy_per_frame_mj": float,  # optional
+        },
+        "sequences": [...]
+    }
+
+Typical usage::
+
+    from eovot.metrics.efficiency import EfficiencyAnalyzer
+
+    analyzer = EfficiencyAnalyzer()
+
+    # Which trackers are Pareto-optimal on IoU vs. FPS?
+    frontier = analyzer.pareto_frontier(results)
+
+    # Rank by weighted edge fitness (higher = more deployable)
+    ranked = analyzer.rank_trackers(results)
+    for score in ranked:
+        print(score)
+
+    # Filter to trackers that fit within a Raspberry Pi 4 budget
+    feasible = analyzer.filter_by_constraints(
+        results,
+        max_latency_ms=33.0,   # ≤ 30 FPS minimum
+        max_memory_mb=512.0,
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+
+@dataclass
+class EdgeFitnessScore:
+    """Composite deployability score for a single tracker.
+
+    Attributes:
+        tracker_name:      Tracker identifier.
+        fitness:           Weighted composite score in ``[0, 1]``.  Higher is
+                           more deployable on the target edge device profile.
+        is_pareto_optimal: ``True`` when this tracker is on the Pareto frontier
+                           of accuracy vs. throughput among the compared set.
+        violates_constraints: ``True`` when the tracker exceeds at least one
+                              hardware constraint passed to
+                              :meth:`EfficiencyAnalyzer.filter_by_constraints`.
+        component_scores:  Normalised per-metric scores used in the weighted
+                           sum (keys match the weight dict).
+    """
+
+    tracker_name: str
+    fitness: float
+    is_pareto_optimal: bool = False
+    violates_constraints: bool = False
+    component_scores: Dict[str, float] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        pareto_tag = " [Pareto]" if self.is_pareto_optimal else ""
+        violates_tag = " [violates constraints]" if self.violates_constraints else ""
+        return (
+            f"EdgeFitnessScore[{self.tracker_name}] "
+            f"fitness={self.fitness:.4f}{pareto_tag}{violates_tag}"
+        )
+
+
+class EfficiencyAnalyzer:
+    """Analyse accuracy-efficiency trade-offs across a set of benchmark results.
+
+    Args:
+        accuracy_weight:  Weight for mIoU in the fitness score.
+        fps_weight:       Weight for throughput (FPS).
+        memory_weight:    Weight for memory efficiency (penalises high peak RAM).
+        energy_weight:    Weight for energy efficiency (penalises high mJ/frame).
+                          Only applied when energy data is present in results.
+
+    The four weights are re-normalised to sum to 1.0 internally, so you can
+    pass any positive values (e.g. ``accuracy_weight=2, fps_weight=1``).
+
+    Example::
+
+        analyzer = EfficiencyAnalyzer(accuracy_weight=0.5, fps_weight=0.3,
+                                      memory_weight=0.2)
+        scores = analyzer.rank_trackers(results)
+    """
+
+    def __init__(
+        self,
+        accuracy_weight: float = 0.40,
+        fps_weight: float = 0.30,
+        memory_weight: float = 0.20,
+        energy_weight: float = 0.10,
+    ) -> None:
+        if any(w < 0 for w in (accuracy_weight, fps_weight, memory_weight, energy_weight)):
+            raise ValueError("All weights must be non-negative.")
+        total = accuracy_weight + fps_weight + memory_weight + energy_weight
+        if total <= 0:
+            raise ValueError("At least one weight must be positive.")
+        self.accuracy_weight = accuracy_weight / total
+        self.fps_weight = fps_weight / total
+        self.memory_weight = memory_weight / total
+        self.energy_weight = energy_weight / total
+
+    # ------------------------------------------------------------------
+    # Pareto frontier
+    # ------------------------------------------------------------------
+
+    def pareto_frontier(self, results: List[Dict[str, Any]]) -> List[str]:
+        """Return tracker names that lie on the accuracy-FPS Pareto frontier.
+
+        A tracker is Pareto-optimal when no other tracker in the set achieves
+        *both* higher mIoU *and* higher FPS simultaneously.  These trackers
+        represent the best accuracy-efficiency operating points — moving away
+        from any Pareto-optimal tracker costs accuracy or speed.
+
+        Args:
+            results: List of EOVOT result dicts.
+
+        Returns:
+            List of tracker names on the frontier, sorted by FPS ascending.
+        """
+        summaries = [r.get("summary", {}) for r in results]
+        names = [s.get("tracker", f"tracker_{i}") for i, s in enumerate(summaries)]
+        ious = np.array([float(s.get("mean_iou", 0.0)) for s in summaries])
+        fps = np.array([float(s.get("mean_fps", 0.0)) for s in summaries])
+
+        n = len(names)
+        on_frontier = []
+        for i in range(n):
+            dominated = False
+            for j in range(n):
+                if i == j:
+                    continue
+                # j dominates i if j is at least as good on both axes AND
+                # strictly better on at least one.
+                if ious[j] >= ious[i] and fps[j] >= fps[i]:
+                    if ious[j] > ious[i] or fps[j] > fps[i]:
+                        dominated = True
+                        break
+            if not dominated:
+                on_frontier.append((fps[i], names[i]))
+
+        on_frontier.sort(key=lambda x: x[0])
+        return [name for _, name in on_frontier]
+
+    # ------------------------------------------------------------------
+    # Edge fitness score
+    # ------------------------------------------------------------------
+
+    def compute_fitness(
+        self,
+        result: Dict[str, Any],
+        all_results: List[Dict[str, Any]],
+    ) -> EdgeFitnessScore:
+        """Compute the normalised edge fitness score for a single tracker.
+
+        Each metric is min-max normalised over ``all_results`` so that the
+        scores are always in ``[0, 1]`` and directly comparable.  Higher is
+        better for all components:
+
+        - ``accuracy``: mIoU normalised to ``[0, 1]``.
+        - ``throughput``: FPS normalised to ``[0, 1]``.
+        - ``memory_eff``: ``1 - (peak_mb / max_peak_mb)`` — penalises large RAM.
+        - ``energy_eff``: ``1 - (mj / max_mj)`` — penalises high energy draw;
+          omitted (weight redistributed) when energy data is unavailable.
+
+        Args:
+            result:      The result dict whose fitness to compute.
+            all_results: Full set of results used for normalisation.
+
+        Returns:
+            :class:`EdgeFitnessScore` with fitness and per-component scores.
+        """
+        summaries = [r.get("summary", {}) for r in all_results]
+
+        ious_all = np.array([float(s.get("mean_iou", 0.0)) for s in summaries])
+        fps_all = np.array([float(s.get("mean_fps", 0.0)) for s in summaries])
+        mem_all = np.array([float(s.get("peak_memory_mb", 0.0)) for s in summaries])
+
+        has_energy = any(s.get("mean_energy_per_frame_mj") is not None for s in summaries)
+        if has_energy:
+            energy_all = np.array(
+                [float(s.get("mean_energy_per_frame_mj", 0.0)) for s in summaries]
+            )
+        else:
+            energy_all = None
+
+        s = result.get("summary", {})
+        tracker_name = s.get("tracker", "unknown")
+
+        acc_score = _minmax_norm(float(s.get("mean_iou", 0.0)), ious_all)
+        fps_score = _minmax_norm(float(s.get("mean_fps", 0.0)), fps_all)
+        # Memory efficiency: lower memory → higher score
+        mem_score = 1.0 - _minmax_norm(float(s.get("peak_memory_mb", 0.0)), mem_all)
+
+        components: Dict[str, float] = {
+            "accuracy": acc_score,
+            "throughput": fps_score,
+            "memory_efficiency": mem_score,
+        }
+
+        if has_energy and energy_all is not None:
+            e_val = float(s.get("mean_energy_per_frame_mj", 0.0))
+            e_score = 1.0 - _minmax_norm(e_val, energy_all)
+            components["energy_efficiency"] = e_score
+            # Include all four weights
+            fitness = (
+                self.accuracy_weight * acc_score
+                + self.fps_weight * fps_score
+                + self.memory_weight * mem_score
+                + self.energy_weight * e_score
+            )
+        else:
+            # Re-distribute the energy weight to accuracy and FPS proportionally
+            total_w = self.accuracy_weight + self.fps_weight + self.memory_weight
+            w_acc = self.accuracy_weight / total_w if total_w > 0 else 1 / 3
+            w_fps = self.fps_weight / total_w if total_w > 0 else 1 / 3
+            w_mem = self.memory_weight / total_w if total_w > 0 else 1 / 3
+            fitness = w_acc * acc_score + w_fps * fps_score + w_mem * mem_score
+
+        pareto_names = self.pareto_frontier(all_results)
+        is_pareto = tracker_name in pareto_names
+
+        return EdgeFitnessScore(
+            tracker_name=tracker_name,
+            fitness=round(float(fitness), 4),
+            is_pareto_optimal=is_pareto,
+            violates_constraints=False,
+            component_scores={k: round(v, 4) for k, v in components.items()},
+        )
+
+    def rank_trackers(self, results: List[Dict[str, Any]]) -> List[EdgeFitnessScore]:
+        """Rank all trackers by edge fitness (highest first).
+
+        Args:
+            results: List of EOVOT result dicts.
+
+        Returns:
+            List of :class:`EdgeFitnessScore` objects sorted by
+            :attr:`~EdgeFitnessScore.fitness` descending.
+        """
+        scores = [self.compute_fitness(r, results) for r in results]
+        scores.sort(key=lambda s: s.fitness, reverse=True)
+        return scores
+
+    # ------------------------------------------------------------------
+    # Hardware constraint filtering
+    # ------------------------------------------------------------------
+
+    def filter_by_constraints(
+        self,
+        results: List[Dict[str, Any]],
+        max_latency_ms: Optional[float] = None,
+        max_memory_mb: Optional[float] = None,
+        min_fps: Optional[float] = None,
+        max_energy_mj: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return only the results that satisfy all specified hardware constraints.
+
+        Constraints are ANDed together; any ``None`` constraint is ignored.
+        Typical device profiles:
+
+        - Raspberry Pi 4: ``max_latency_ms=33, max_memory_mb=512``
+        - Jetson Nano:    ``max_latency_ms=20, max_memory_mb=2048``
+        - Desktop CPU:    ``min_fps=60``
+
+        Args:
+            results:        List of EOVOT result dicts.
+            max_latency_ms: Maximum acceptable mean latency per frame.
+            max_memory_mb:  Maximum acceptable peak memory usage.
+            min_fps:        Minimum acceptable throughput.
+            max_energy_mj:  Maximum acceptable mean energy per frame (mJ).
+
+        Returns:
+            Subset of ``results`` satisfying all constraints, preserving order.
+        """
+        feasible = []
+        for r in results:
+            s = r.get("summary", {})
+            if max_latency_ms is not None:
+                latency = float(s.get("mean_latency_ms", 0.0))
+                if latency > max_latency_ms:
+                    continue
+            if max_memory_mb is not None:
+                mem = float(s.get("peak_memory_mb", 0.0))
+                if mem > max_memory_mb:
+                    continue
+            if min_fps is not None:
+                fps = float(s.get("mean_fps", 0.0))
+                if fps < min_fps:
+                    continue
+            if max_energy_mj is not None:
+                energy = s.get("mean_energy_per_frame_mj")
+                if energy is not None and float(energy) > max_energy_mj:
+                    continue
+            feasible.append(r)
+        return feasible
+
+    def score_with_constraints(
+        self,
+        results: List[Dict[str, Any]],
+        max_latency_ms: Optional[float] = None,
+        max_memory_mb: Optional[float] = None,
+        min_fps: Optional[float] = None,
+        max_energy_mj: Optional[float] = None,
+    ) -> List[EdgeFitnessScore]:
+        """Rank all trackers, flagging those that violate hardware constraints.
+
+        Unlike :meth:`filter_by_constraints`, this method scores *all* trackers
+        but marks violating ones via
+        :attr:`~EdgeFitnessScore.violates_constraints`.  Useful for comparing
+        performance across a heterogeneous device fleet.
+
+        Args:
+            results: List of EOVOT result dicts.
+            max_latency_ms, max_memory_mb, min_fps, max_energy_mj:
+                Same semantics as :meth:`filter_by_constraints`.
+
+        Returns:
+            All :class:`EdgeFitnessScore` objects sorted by fitness; violating
+            trackers carry ``violates_constraints=True``.
+        """
+        feasible_set = {
+            r.get("summary", {}).get("tracker", "")
+            for r in self.filter_by_constraints(
+                results, max_latency_ms, max_memory_mb, min_fps, max_energy_mj
+            )
+        }
+        scores = self.rank_trackers(results)
+        for sc in scores:
+            sc.violates_constraints = sc.tracker_name not in feasible_set
+        return scores
+
+
+# ------------------------------------------------------------------
+# Private helpers
+# ------------------------------------------------------------------
+
+def _minmax_norm(value: float, arr: np.ndarray) -> float:
+    """Min-max normalise *value* into ``[0, 1]`` using the range of *arr*.
+
+    Returns 0.5 when all values in *arr* are identical (avoids division by zero).
+    """
+    lo, hi = float(arr.min()), float(arr.max())
+    if hi <= lo:
+        return 0.5
+    return float((value - lo) / (hi - lo))

--- a/eovot/trackers/__init__.py
+++ b/eovot/trackers/__init__.py
@@ -3,6 +3,7 @@ from .mosse import MOSSETracker
 from .kcf import KCFTracker
 from .csrt import CSRTTracker
 from .median_flow import MedianFlowTracker
+from .mil import MILTracker
 
 __all__ = [
     "BaseTracker",
@@ -11,4 +12,5 @@ __all__ = [
     "KCFTracker",
     "CSRTTracker",
     "MedianFlowTracker",
+    "MILTracker",
 ]

--- a/eovot/visualization/plots.py
+++ b/eovot/visualization/plots.py
@@ -279,3 +279,226 @@ def plot_tracker_comparison(
         print(f"[plot] Tracker comparison saved → {output_path}")
     else:
         plt.show()
+
+
+def plot_efficiency_scatter(
+    results: List[Dict[str, Any]],
+    pareto_names: Optional[List[str]] = None,
+    output_path: Optional[str] = None,
+    title: str = "Accuracy vs. Throughput",
+    size_metric: Optional[str] = "peak_memory_mb",
+) -> None:
+    """Scatter plot of mIoU (accuracy) vs. FPS (throughput) across trackers.
+
+    Pareto-optimal trackers are highlighted with a star marker; the Pareto
+    frontier is drawn as a step line.  Optionally, marker area is scaled by
+    ``size_metric`` (default: peak memory) to convey a third dimension.
+
+    This is the core edge-deployment decision chart: trackers in the
+    upper-right region are both accurate and fast; those on the frontier
+    represent the best achievable accuracy at each throughput level.
+
+    Args:
+        results:      List of EOVOT result dicts (one per tracker).
+        pareto_names: Pre-computed Pareto-frontier tracker names.  When
+                      ``None``, the frontier is computed automatically using
+                      :class:`~eovot.metrics.efficiency.EfficiencyAnalyzer`.
+        output_path:  Save path.  Interactive display when ``None``.
+        title:        Figure title string.
+        size_metric:  Summary key used to scale marker area.  Pass ``None``
+                      to use a uniform marker size.
+
+    Example::
+
+        from eovot.visualization.plots import plot_efficiency_scatter
+        plot_efficiency_scatter(results, output_path="efficiency.png")
+    """
+    plt = _get_matplotlib()
+    import matplotlib.patches as mpatches
+
+    if pareto_names is None:
+        from ..metrics.efficiency import EfficiencyAnalyzer
+        pareto_names = EfficiencyAnalyzer().pareto_frontier(results)
+
+    summaries = [r.get("summary", {}) for r in results]
+    names = [s.get("tracker", f"T{i}") for i, s in enumerate(summaries)]
+    ious = [float(s.get("mean_iou", 0.0)) for s in summaries]
+    fps_vals = [float(s.get("mean_fps", 0.0)) for s in summaries]
+
+    # Marker sizes scaled by size_metric (area in points²).
+    if size_metric is not None:
+        raw_sizes = np.array([float(s.get(size_metric, 1.0)) for s in summaries])
+        lo, hi = raw_sizes.min(), raw_sizes.max()
+        if hi > lo:
+            norm_sizes = (raw_sizes - lo) / (hi - lo)
+        else:
+            norm_sizes = np.ones(len(raw_sizes)) * 0.5
+        marker_areas = 80 + norm_sizes * 400  # scale to [80, 480] pt²
+    else:
+        marker_areas = np.full(len(names), 150.0)
+
+    fig, ax = plt.subplots(figsize=(9, 6))
+
+    pareto_set = set(pareto_names)
+    non_pareto_plotted = False
+    pareto_plotted = False
+
+    for i, (name, iou_val, fps_val, area) in enumerate(
+        zip(names, ious, fps_vals, marker_areas)
+    ):
+        if name in pareto_set:
+            ax.scatter(
+                fps_val, iou_val,
+                s=area, marker="*", zorder=5,
+                label=f"{name} (Pareto)" if not pareto_plotted else None,
+                edgecolors="black", linewidths=0.7,
+            )
+            pareto_plotted = True
+        else:
+            ax.scatter(
+                fps_val, iou_val,
+                s=area, marker="o", alpha=0.8, zorder=4,
+                label=None if non_pareto_plotted else "Other trackers",
+                edgecolors="black", linewidths=0.5,
+            )
+            non_pareto_plotted = True
+        ax.annotate(
+            name, (fps_val, iou_val),
+            textcoords="offset points", xytext=(6, 4),
+            fontsize=9,
+        )
+
+    # Draw the Pareto frontier as a step function from high FPS to high IoU.
+    if len(pareto_names) > 1:
+        pareto_pts = sorted(
+            [
+                (float(summaries[names.index(n)].get("mean_fps", 0.0)),
+                 float(summaries[names.index(n)].get("mean_iou", 0.0)))
+                for n in pareto_names
+                if n in names
+            ],
+            key=lambda p: p[0],
+        )
+        px, py = zip(*pareto_pts)
+        ax.step(px, py, where="post", linestyle="--", linewidth=1.5,
+                color="gray", alpha=0.7, label="Pareto frontier", zorder=3)
+
+    if size_metric is not None:
+        note = f"Marker area ∝ {size_metric.replace('_', ' ')}"
+        ax.annotate(note, xy=(0.02, 0.02), xycoords="axes fraction",
+                    fontsize=8, color="gray")
+
+    ax.set_xlabel("Throughput (FPS)", fontsize=12)
+    ax.set_ylabel("Accuracy (mIoU)", fontsize=12)
+    ax.set_title(title, fontsize=14)
+    ax.legend(fontsize=10, loc="lower right")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"[plot] Efficiency scatter saved → {output_path}")
+    else:
+        plt.show()
+
+
+def plot_radar_chart(
+    results: List[Dict[str, Any]],
+    metrics: Optional[List[str]] = None,
+    output_path: Optional[str] = None,
+    title: str = "Tracker Profile (Radar)",
+) -> None:
+    """Multi-metric radar (spider) chart for holistic tracker comparison.
+
+    Each axis represents one metric, normalised to ``[0, 1]`` across the
+    compared trackers.  A larger filled area indicates a more balanced tracker.
+    For efficiency metrics (memory, latency, energy) the values are inverted
+    so that a larger polygon always means better performance.
+
+    Args:
+        results: List of EOVOT result dicts (one per tracker).
+        metrics: List of summary dict keys to plot.  Defaults to
+            ``["mean_iou", "mean_fps", "peak_memory_mb", "mean_latency_ms"]``.
+            Keys ending in ``_mb`` or ``_ms`` or ``_j`` are treated as
+            *lower-is-better* and inverted automatically.
+        output_path: Save path.  Interactive display when ``None``.
+        title: Figure title string.
+
+    Example::
+
+        from eovot.visualization.plots import plot_radar_chart
+        plot_radar_chart(results, output_path="radar.png")
+    """
+    plt = _get_matplotlib()
+    import matplotlib.patches as mpatches
+
+    if metrics is None:
+        metrics = ["mean_iou", "mean_fps", "peak_memory_mb", "mean_latency_ms"]
+
+    # Keys where lower values are better — invert the normalised score.
+    lower_is_better = {"peak_memory_mb", "mean_latency_ms", "mean_energy_per_frame_mj",
+                       "total_energy_j"}
+
+    summaries = [r.get("summary", {}) for r in results]
+    names = [s.get("tracker", f"T{i}") for i, s in enumerate(summaries)]
+
+    # Collect raw values and normalise per metric.
+    raw: Dict[str, List[float]] = {}
+    for m in metrics:
+        raw[m] = [float(s.get(m, 0.0)) for s in summaries]
+
+    norm: Dict[str, np.ndarray] = {}
+    for m, vals in raw.items():
+        arr = np.array(vals, dtype=np.float64)
+        lo, hi = arr.min(), arr.max()
+        if hi > lo:
+            n_arr = (arr - lo) / (hi - lo)
+        else:
+            n_arr = np.ones(len(arr)) * 0.5
+        if m in lower_is_better:
+            n_arr = 1.0 - n_arr  # invert: smaller memory/latency → higher score
+        norm[m] = n_arr
+
+    n_metrics = len(metrics)
+    angles = np.linspace(0, 2 * np.pi, n_metrics, endpoint=False).tolist()
+    angles += angles[:1]  # close the polygon
+
+    fig, ax = plt.subplots(figsize=(7, 7), subplot_kw={"polar": True})
+    color_cycle = plt.rcParams.get("axes.prop_cycle", None)
+    colors = (
+        color_cycle.by_key()["color"]
+        if color_cycle is not None
+        else ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd"]
+    )
+
+    for i, (name, summary) in enumerate(zip(names, summaries)):
+        values = [float(norm[m][i]) for m in metrics]
+        values += values[:1]  # close the polygon
+        color = colors[i % len(colors)]
+        ax.plot(angles, values, linewidth=2, linestyle="solid", color=color, label=name)
+        ax.fill(angles, values, alpha=0.12, color=color)
+
+    # Axis labels: replace underscores and add (↓) for lower-is-better.
+    axis_labels = []
+    for m in metrics:
+        label = m.replace("_", " ")
+        if m in lower_is_better:
+            label += "\n(↓ better, inverted)"
+        axis_labels.append(label)
+
+    ax.set_xticks(angles[:-1])
+    ax.set_xticklabels(axis_labels, fontsize=9)
+    ax.set_ylim(0.0, 1.0)
+    ax.set_yticks([0.25, 0.5, 0.75, 1.0])
+    ax.set_yticklabels(["0.25", "0.5", "0.75", "1.0"], fontsize=7, color="grey")
+    ax.set_title(title, fontsize=14, pad=20)
+    ax.legend(loc="upper right", bbox_to_anchor=(1.3, 1.1), fontsize=10)
+    fig.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"[plot] Radar chart saved → {output_path}")
+    else:
+        plt.show()

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1,0 +1,329 @@
+"""Unit tests for eovot.metrics.efficiency.EfficiencyAnalyzer."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from eovot.metrics.efficiency import EdgeFitnessScore, EfficiencyAnalyzer, _minmax_norm
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic result dicts
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    tracker: str,
+    mean_iou: float,
+    mean_fps: float,
+    peak_memory_mb: float = 100.0,
+    mean_latency_ms: float = 5.0,
+    mean_energy_mj: float | None = None,
+) -> Dict[str, Any]:
+    s: Dict[str, Any] = {
+        "tracker": tracker,
+        "mean_iou": mean_iou,
+        "mean_fps": mean_fps,
+        "peak_memory_mb": peak_memory_mb,
+        "mean_latency_ms": mean_latency_ms,
+    }
+    if mean_energy_mj is not None:
+        s["mean_energy_per_frame_mj"] = mean_energy_mj
+    return {"summary": s, "sequences": []}
+
+
+# Representative 4-tracker comparison used across several tests.
+RESULTS_4 = [
+    _make_result("MOSSE",      mean_iou=0.40, mean_fps=500.0, peak_memory_mb=50.0),
+    _make_result("KCF",        mean_iou=0.52, mean_fps=250.0, peak_memory_mb=80.0),
+    _make_result("CSRT",       mean_iou=0.65, mean_fps=60.0,  peak_memory_mb=150.0),
+    _make_result("MedianFlow", mean_iou=0.35, mean_fps=120.0, peak_memory_mb=60.0),
+]
+
+
+# ---------------------------------------------------------------------------
+# _minmax_norm helper
+# ---------------------------------------------------------------------------
+
+class TestMinmaxNorm:
+    def test_min_value_maps_to_zero(self):
+        import numpy as np
+        arr = np.array([1.0, 2.0, 3.0])
+        assert _minmax_norm(1.0, arr) == pytest.approx(0.0)
+
+    def test_max_value_maps_to_one(self):
+        import numpy as np
+        arr = np.array([1.0, 2.0, 3.0])
+        assert _minmax_norm(3.0, arr) == pytest.approx(1.0)
+
+    def test_midpoint(self):
+        import numpy as np
+        arr = np.array([0.0, 1.0])
+        assert _minmax_norm(0.5, arr) == pytest.approx(0.5)
+
+    def test_constant_array_returns_half(self):
+        import numpy as np
+        arr = np.array([5.0, 5.0, 5.0])
+        assert _minmax_norm(5.0, arr) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# EfficiencyAnalyzer initialisation
+# ---------------------------------------------------------------------------
+
+class TestEfficiencyAnalyzerInit:
+    def test_weights_normalised_to_one(self):
+        analyzer = EfficiencyAnalyzer(
+            accuracy_weight=2.0, fps_weight=1.0, memory_weight=1.0, energy_weight=0.0
+        )
+        total = (
+            analyzer.accuracy_weight
+            + analyzer.fps_weight
+            + analyzer.memory_weight
+            + analyzer.energy_weight
+        )
+        assert total == pytest.approx(1.0)
+
+    def test_negative_weight_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            EfficiencyAnalyzer(accuracy_weight=-1.0)
+
+    def test_all_zero_weights_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            EfficiencyAnalyzer(
+                accuracy_weight=0.0, fps_weight=0.0,
+                memory_weight=0.0, energy_weight=0.0
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pareto frontier
+# ---------------------------------------------------------------------------
+
+class TestParetoFrontier:
+    def setup_method(self):
+        self.analyzer = EfficiencyAnalyzer()
+
+    def test_clear_domination(self):
+        # A strictly dominates B on both axes.
+        results = [
+            _make_result("A", mean_iou=0.8, mean_fps=200.0),
+            _make_result("B", mean_iou=0.5, mean_fps=100.0),
+        ]
+        frontier = self.analyzer.pareto_frontier(results)
+        assert "A" in frontier
+        assert "B" not in frontier
+
+    def test_trade_off_both_on_frontier(self):
+        # Fast-but-inaccurate and slow-but-accurate trackers are both Pareto-optimal.
+        results = [
+            _make_result("Fast",     mean_iou=0.40, mean_fps=500.0),
+            _make_result("Accurate", mean_iou=0.70, mean_fps=50.0),
+        ]
+        frontier = self.analyzer.pareto_frontier(results)
+        assert "Fast" in frontier
+        assert "Accurate" in frontier
+
+    def test_equal_trackers_both_on_frontier(self):
+        results = [
+            _make_result("T1", mean_iou=0.5, mean_fps=100.0),
+            _make_result("T2", mean_iou=0.5, mean_fps=100.0),
+        ]
+        frontier = self.analyzer.pareto_frontier(results)
+        assert "T1" in frontier
+        assert "T2" in frontier
+
+    def test_single_tracker_is_on_frontier(self):
+        results = [_make_result("Solo", mean_iou=0.6, mean_fps=200.0)]
+        frontier = self.analyzer.pareto_frontier(results)
+        assert frontier == ["Solo"]
+
+    def test_frontier_sorted_by_fps(self):
+        results = [
+            _make_result("Fast",     mean_iou=0.40, mean_fps=500.0),
+            _make_result("Accurate", mean_iou=0.70, mean_fps=50.0),
+        ]
+        frontier = self.analyzer.pareto_frontier(results)
+        fps_vals = [
+            results[["Fast", "Accurate"].index(n)].get("summary", {}).get("mean_fps", 0)
+            for n in frontier
+        ]
+        assert fps_vals == sorted(fps_vals)
+
+    def test_dominated_tracker_excluded(self):
+        results = [
+            _make_result("Best",  mean_iou=0.80, mean_fps=300.0),
+            _make_result("Weak",  mean_iou=0.50, mean_fps=100.0),  # dominated by Best
+            _make_result("Niche", mean_iou=0.30, mean_fps=800.0),  # fast, low IoU
+        ]
+        frontier = self.analyzer.pareto_frontier(results)
+        assert "Weak" not in frontier
+        assert "Best" in frontier
+        assert "Niche" in frontier
+
+
+# ---------------------------------------------------------------------------
+# Fitness score computation
+# ---------------------------------------------------------------------------
+
+class TestComputeFitness:
+    def setup_method(self):
+        self.analyzer = EfficiencyAnalyzer()
+
+    def test_returns_edge_fitness_score(self):
+        score = self.analyzer.compute_fitness(RESULTS_4[0], RESULTS_4)
+        assert isinstance(score, EdgeFitnessScore)
+
+    def test_fitness_in_unit_interval(self):
+        for r in RESULTS_4:
+            score = self.analyzer.compute_fitness(r, RESULTS_4)
+            assert 0.0 <= score.fitness <= 1.0
+
+    def test_tracker_name_propagated(self):
+        score = self.analyzer.compute_fitness(RESULTS_4[0], RESULTS_4)
+        assert score.tracker_name == "MOSSE"
+
+    def test_pareto_flag_set_correctly(self):
+        # MOSSE is fast and CSRT is accurate — both are Pareto-optimal in RESULTS_4.
+        mosse_score = self.analyzer.compute_fitness(RESULTS_4[0], RESULTS_4)  # MOSSE
+        csrt_score = self.analyzer.compute_fitness(RESULTS_4[2], RESULTS_4)   # CSRT
+        assert mosse_score.is_pareto_optimal
+        assert csrt_score.is_pareto_optimal
+
+    def test_component_scores_present(self):
+        score = self.analyzer.compute_fitness(RESULTS_4[0], RESULTS_4)
+        assert "accuracy" in score.component_scores
+        assert "throughput" in score.component_scores
+        assert "memory_efficiency" in score.component_scores
+
+    def test_best_on_all_axes_has_highest_fitness(self):
+        # Construct a tracker that wins on all axes.
+        best = _make_result("BestEver", mean_iou=1.0, mean_fps=1000.0, peak_memory_mb=1.0)
+        results = RESULTS_4 + [best]
+        best_score = self.analyzer.compute_fitness(best, results)
+        for r in RESULTS_4:
+            other_score = self.analyzer.compute_fitness(r, results)
+            assert best_score.fitness >= other_score.fitness
+
+    def test_energy_component_when_present(self):
+        results = [
+            _make_result("A", mean_iou=0.5, mean_fps=100.0, mean_energy_mj=1.0),
+            _make_result("B", mean_iou=0.6, mean_fps=200.0, mean_energy_mj=2.0),
+        ]
+        score = self.analyzer.compute_fitness(results[0], results)
+        assert "energy_efficiency" in score.component_scores
+
+    def test_no_energy_component_when_absent(self):
+        score = self.analyzer.compute_fitness(RESULTS_4[0], RESULTS_4)
+        assert "energy_efficiency" not in score.component_scores
+
+
+# ---------------------------------------------------------------------------
+# rank_trackers
+# ---------------------------------------------------------------------------
+
+class TestRankTrackers:
+    def setup_method(self):
+        self.analyzer = EfficiencyAnalyzer()
+
+    def test_returns_list_of_scores(self):
+        ranked = self.analyzer.rank_trackers(RESULTS_4)
+        assert len(ranked) == len(RESULTS_4)
+        assert all(isinstance(s, EdgeFitnessScore) for s in ranked)
+
+    def test_sorted_descending_by_fitness(self):
+        ranked = self.analyzer.rank_trackers(RESULTS_4)
+        fitnesses = [s.fitness for s in ranked]
+        assert fitnesses == sorted(fitnesses, reverse=True)
+
+    def test_single_tracker(self):
+        ranked = self.analyzer.rank_trackers([RESULTS_4[0]])
+        assert len(ranked) == 1
+        assert ranked[0].fitness == pytest.approx(0.5)  # all single-element ranges → 0.5
+
+
+# ---------------------------------------------------------------------------
+# Hardware constraint filtering
+# ---------------------------------------------------------------------------
+
+class TestFilterByConstraints:
+    def setup_method(self):
+        self.analyzer = EfficiencyAnalyzer()
+
+    def test_no_constraints_returns_all(self):
+        feasible = self.analyzer.filter_by_constraints(RESULTS_4)
+        assert len(feasible) == len(RESULTS_4)
+
+    def test_min_fps_filters_slow_trackers(self):
+        # Only MOSSE (500 FPS) and KCF (250 FPS) exceed 200 FPS.
+        feasible = self.analyzer.filter_by_constraints(RESULTS_4, min_fps=200.0)
+        names = [r["summary"]["tracker"] for r in feasible]
+        assert "MOSSE" in names
+        assert "KCF" in names
+        assert "CSRT" not in names
+        assert "MedianFlow" not in names
+
+    def test_max_memory_filters_heavy_trackers(self):
+        # CSRT uses 150 MB → excluded at 100 MB limit.
+        feasible = self.analyzer.filter_by_constraints(RESULTS_4, max_memory_mb=100.0)
+        names = [r["summary"]["tracker"] for r in feasible]
+        assert "CSRT" not in names
+
+    def test_max_latency_constraint(self):
+        results = [
+            _make_result("Fast",  mean_iou=0.5, mean_fps=200.0, mean_latency_ms=5.0),
+            _make_result("Slow",  mean_iou=0.7, mean_fps=20.0,  mean_latency_ms=50.0),
+        ]
+        feasible = self.analyzer.filter_by_constraints(results, max_latency_ms=10.0)
+        names = [r["summary"]["tracker"] for r in feasible]
+        assert "Fast" in names
+        assert "Slow" not in names
+
+    def test_energy_constraint(self):
+        results = [
+            _make_result("Green",  mean_iou=0.5, mean_fps=100.0, mean_energy_mj=0.5),
+            _make_result("Hungry", mean_iou=0.6, mean_fps=100.0, mean_energy_mj=5.0),
+        ]
+        feasible = self.analyzer.filter_by_constraints(results, max_energy_mj=1.0)
+        names = [r["summary"]["tracker"] for r in feasible]
+        assert "Green" in names
+        assert "Hungry" not in names
+
+    def test_combined_constraints(self):
+        feasible = self.analyzer.filter_by_constraints(
+            RESULTS_4, min_fps=100.0, max_memory_mb=100.0
+        )
+        names = [r["summary"]["tracker"] for r in feasible]
+        # MOSSE: 500 FPS, 50 MB → pass
+        # KCF:   250 FPS, 80 MB → pass
+        # CSRT:  60 FPS (fails min_fps) → excluded
+        # MedianFlow: 120 FPS, 60 MB → pass
+        assert "MOSSE" in names
+        assert "KCF" in names
+        assert "CSRT" not in names
+        assert "MedianFlow" in names
+
+    def test_impossible_constraints_return_empty(self):
+        feasible = self.analyzer.filter_by_constraints(RESULTS_4, min_fps=10_000.0)
+        assert feasible == []
+
+
+# ---------------------------------------------------------------------------
+# score_with_constraints
+# ---------------------------------------------------------------------------
+
+class TestScoreWithConstraints:
+    def setup_method(self):
+        self.analyzer = EfficiencyAnalyzer()
+
+    def test_violates_flag_set_for_slow_trackers(self):
+        scored = self.analyzer.score_with_constraints(RESULTS_4, min_fps=200.0)
+        violations = {s.tracker_name: s.violates_constraints for s in scored}
+        assert not violations["MOSSE"]
+        assert not violations["KCF"]
+        assert violations["CSRT"]
+
+    def test_all_pass_no_constraints(self):
+        scored = self.analyzer.score_with_constraints(RESULTS_4)
+        assert all(not s.violates_constraints for s in scored)


### PR DESCRIPTION
## What was added

### `EfficiencyAnalyzer` — `eovot/metrics/efficiency.py`

The core question for edge deployment is not *"which tracker is most accurate?"* but *"which tracker gives the best accuracy within my device's budget?"* This PR introduces the analysis layer that answers that question.

#### Pareto Frontier (`pareto_frontier`)
Identifies trackers that are not dominated by any other on the accuracy (mIoU) vs. throughput (FPS) plane. A tracker is Pareto-optimal if no competitor achieves both higher IoU **and** higher FPS simultaneously. The Pareto set represents the best accuracy-efficiency operating points — any move off the frontier costs accuracy or speed.

```python
from eovot.metrics.efficiency import EfficiencyAnalyzer

analyzer = EfficiencyAnalyzer()
frontier = analyzer.pareto_frontier(results)
# → ["MOSSE", "KCF", "CSRT"]  (fast-but-rough to slow-but-accurate)
```

#### Edge Fitness Score (`compute_fitness` / `rank_trackers`)
A single weighted scalar combining accuracy, throughput, memory efficiency, and energy efficiency (when available). Each metric is min-max normalised across the comparison set so scores are always in `[0, 1]`. Weights are configurable and auto-normalised.

```python
# Default weights: accuracy=0.40, fps=0.30, memory=0.20, energy=0.10
scores = analyzer.rank_trackers(results)
for sc in scores:
    print(sc)
# EdgeFitnessScore[KCF] fitness=0.7231 [Pareto]
# EdgeFitnessScore[MOSSE] fitness=0.6814 [Pareto]
# ...
```

#### Hardware Constraint Filtering (`filter_by_constraints` / `score_with_constraints`)
Quickly identify which trackers fit within a device's hard budget:

```python
# Raspberry Pi 4 profile
feasible = analyzer.filter_by_constraints(
    results,
    max_latency_ms=33.0,   # ≥ 30 FPS
    max_memory_mb=512.0,
)

# Or score all but flag those that violate constraints
scored = analyzer.score_with_constraints(results, min_fps=60.0)
```

---

### New visualizations — `eovot/visualization/plots.py`

#### `plot_efficiency_scatter(results, output_path)`
IoU on the Y-axis, FPS on the X-axis. Pareto-optimal trackers use star markers; the frontier is drawn as a dashed step line. Marker area optionally scales with a third metric (default: peak memory) to display four dimensions simultaneously.

#### `plot_radar_chart(results, metrics, output_path)`
Polar spider chart normalising all selected summary metrics to `[0, 1]`. Lower-is-better metrics (latency, memory, energy) are inverted automatically so a larger polygon always means better overall performance. Directly usable in papers for holistic tracker comparison.

---

### `MILTracker` export fix — `eovot/trackers/__init__.py`
`MILTracker` existed in `eovot/trackers/mil.py` and was registered in `ExperimentRunner`, but was missing from the package's public `__init__.py`. Users importing from `eovot.trackers` could not access it without knowing the internal module path.

---

## Why it matters
- Edge deployment is a multi-objective problem: accuracy, latency, memory, energy all matter simultaneously. Without Pareto analysis and fitness scoring, benchmark tables only answer half the question.
- The scatter and radar plots are the standard figures in deployment-oriented VOT papers (e.g., LightTrack, E.T.Track, MobileTrack).
- `filter_by_constraints` provides a one-line answer to *"what can run on this device?"* — essential for robotics and embedded applications.

## Example usage

```python
import json
from eovot.metrics.efficiency import EfficiencyAnalyzer
from eovot.visualization.plots import plot_efficiency_scatter, plot_radar_chart

with open("results/MOSSE-OTB100.json") as f:  mosse = json.load(f)
with open("results/KCF-OTB100.json")   as f:  kcf   = json.load(f)
with open("results/CSRT-OTB100.json")  as f:  csrt  = json.load(f)

results = [mosse, kcf, csrt]
analyzer = EfficiencyAnalyzer()

# Ranked leaderboard
for score in analyzer.rank_trackers(results):
    print(score)

# Figures
plot_efficiency_scatter(results, output_path="efficiency.png")
plot_radar_chart(results, output_path="radar.png")

# What runs on a Raspberry Pi 4?
pi4 = analyzer.filter_by_constraints(results, max_latency_ms=33, max_memory_mb=512)
print([r["summary"]["tracker"] for r in pi4])
```

## Tests
`tests/test_efficiency.py` — 33 tests covering `_minmax_norm`, `EfficiencyAnalyzer` initialisation, Pareto frontier logic (domination, trade-off, ties, sorting), fitness computation (range, pareto flag, component scores, energy present/absent), `rank_trackers`, constraint filtering (all combinations), and `score_with_constraints`. All 33 pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_019Fue7Weyi2PbyRDAwRzyqT)_