### PR TITLE
[feat] Hardware-Aware Device Profiles for Edge Deployment Evaluation

### DIFF
--- a/configs/hardware/intel_nuc.yaml
+++ b/configs/hardware/intel_nuc.yaml
@@ -1,0 +1,13 @@
+# Hardware profile: Intel NUC with Core i5 processor
+# Modelled after Intel NUC11PAHi5
+name: "Intel NUC (Core i5)"
+cpu_tdp_watts: 28.0
+ram_mb: 16384
+cpu_cores: 4
+cpu_freq_ghz: 3.6
+has_gpu: false
+gpu_tdp_watts: 0.0
+target_fps: 60.0
+max_latency_ms: 16.7
+max_memory_mb: 2048.0
+description: "Intel Core i5 NUC. Mid-range edge compute platform."

--- a/configs/hardware/jetson_nano.yaml
+++ b/configs/hardware/jetson_nano.yaml
@@ -1,0 +1,13 @@
+# Hardware profile: NVIDIA Jetson Nano Developer Kit
+# Source: https://developer.nvidia.com/embedded/jetson-nano
+name: "NVIDIA Jetson Nano"
+cpu_tdp_watts: 10.0
+ram_mb: 4096
+cpu_cores: 4
+cpu_freq_ghz: 1.43
+has_gpu: true
+gpu_tdp_watts: 5.0
+target_fps: 30.0
+max_latency_ms: 33.3
+max_memory_mb: 1024.0
+description: "ARM Cortex-A57 + 128 Maxwell CUDA cores. Entry-level embedded GPU."

--- a/configs/hardware/raspberry_pi4.yaml
+++ b/configs/hardware/raspberry_pi4.yaml
@@ -1,0 +1,13 @@
+# Hardware profile: Raspberry Pi 4 (4 GB variant)
+# Source: https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/
+name: "Raspberry Pi 4 (4 GB)"
+cpu_tdp_watts: 6.0
+ram_mb: 4096
+cpu_cores: 4
+cpu_freq_ghz: 1.5
+has_gpu: false
+gpu_tdp_watts: 0.0
+target_fps: 15.0
+max_latency_ms: 66.7
+max_memory_mb: 512.0
+description: "ARM Cortex-A72, quad-core 1.5 GHz. Most common IoT / edge device."

--- a/configs/hardware/smartphone.yaml
+++ b/configs/hardware/smartphone.yaml
@@ -1,0 +1,13 @@
+# Hardware profile: Representative mid-range smartphone ARM SoC
+# Modelled after Qualcomm Snapdragon 7 Gen 1 class devices
+name: "Smartphone ARM SoC"
+cpu_tdp_watts: 4.0
+ram_mb: 4096
+cpu_cores: 8
+cpu_freq_ghz: 2.4
+has_gpu: false
+gpu_tdp_watts: 0.0
+target_fps: 24.0
+max_latency_ms: 41.7
+max_memory_mb: 256.0
+description: "Modern smartphone SoC (e.g. Snapdragon 7 Gen 1). Mobile deployment target."

--- a/eovot/profiling/__init__.py
+++ b/eovot/profiling/__init__.py
@@ -1,6 +1,34 @@
-"""Profiling sub-package — hardware-aware latency, memory, and energy measurement."""
+"""Profiling sub-package — hardware-aware latency, memory, energy, and deployment evaluation."""
 
 from .profiler import Profiler, ProfilingResult
 from .energy import EnergyProfiler, EnergyResult
+from .hardware_profiles import (
+    HardwareProfile,
+    BUILTIN_PROFILES,
+    RASPBERRY_PI_4,
+    JETSON_NANO,
+    INTEL_NUC,
+    DESKTOP_CPU,
+    SMARTPHONE,
+    get_profile,
+    load_profile_from_yaml,
+)
+from .deployment_report import evaluate_deployment, compare_trackers_on_hardware
 
-__all__ = ["Profiler", "ProfilingResult", "EnergyProfiler", "EnergyResult"]
+__all__ = [
+    "Profiler",
+    "ProfilingResult",
+    "EnergyProfiler",
+    "EnergyResult",
+    "HardwareProfile",
+    "BUILTIN_PROFILES",
+    "RASPBERRY_PI_4",
+    "JETSON_NANO",
+    "INTEL_NUC",
+    "DESKTOP_CPU",
+    "SMARTPHONE",
+    "get_profile",
+    "load_profile_from_yaml",
+    "evaluate_deployment",
+    "compare_trackers_on_hardware",
+]

--- a/eovot/profiling/deployment_report.py
+++ b/eovot/profiling/deployment_report.py
@@ -1,0 +1,115 @@
+"""Deployment feasibility analysis across hardware profiles.
+
+Provides two public helpers:
+
+- :func:`evaluate_deployment` — check a **single tracker's** benchmark
+  results against one or more hardware profiles and return a per-device
+  feasibility DataFrame.
+
+- :func:`compare_trackers_on_hardware` — compare **multiple trackers** across
+  all hardware profiles and return a tracker × device deployment-score matrix.
+
+Usage::
+
+    from eovot.profiling.deployment_report import evaluate_deployment
+    from eovot.profiling.hardware_profiles import get_profile
+
+    report = evaluate_deployment(
+        tracker_results={"fps": 22.5, "mean_latency_ms": 44.2, "peak_memory_mb": 185.0},
+        profiles=[get_profile("raspberry_pi4"), get_profile("jetson_nano")],
+    )
+    print(report.to_string(index=False))
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .hardware_profiles import BUILTIN_PROFILES, HardwareProfile
+
+
+def evaluate_deployment(
+    tracker_results: Dict,
+    profiles: Optional[List[HardwareProfile]] = None,
+) -> pd.DataFrame:
+    """Evaluate one tracker's benchmark results against hardware profiles.
+
+    Args:
+        tracker_results: Dict with at least the keys:
+            - ``'fps'`` (float)
+            - ``'mean_latency_ms'`` (float)
+            - ``'peak_memory_mb'`` (float)
+        profiles: Hardware profiles to evaluate against.  Defaults to all
+            five built-in profiles.
+
+    Returns:
+        DataFrame with columns:
+        ``['profile', 'suitable', 'deployment_score',
+          'fps_ok', 'latency_ok', 'memory_ok',
+          'target_fps', 'max_latency_ms', 'max_memory_mb']``
+        sorted by ``deployment_score`` (descending).
+    """
+    if profiles is None:
+        profiles = list(BUILTIN_PROFILES.values())
+
+    fps = float(tracker_results.get("fps", 0.0))
+    latency = float(tracker_results.get("mean_latency_ms", float("inf")))
+    memory = float(tracker_results.get("peak_memory_mb", float("inf")))
+
+    rows = []
+    for profile in profiles:
+        rows.append(
+            {
+                "profile": profile.name,
+                "suitable": profile.is_tracker_suitable(fps, latency, memory),
+                "deployment_score": profile.deployment_score(fps, latency, memory),
+                "fps_ok": fps >= profile.target_fps,
+                "latency_ok": latency <= profile.max_latency_ms,
+                "memory_ok": memory <= profile.max_memory_mb,
+                "target_fps": profile.target_fps,
+                "max_latency_ms": profile.max_latency_ms,
+                "max_memory_mb": profile.max_memory_mb,
+            }
+        )
+
+    df = pd.DataFrame(rows)
+    return df.sort_values("deployment_score", ascending=False).reset_index(drop=True)
+
+
+def compare_trackers_on_hardware(
+    benchmark_results: Dict[str, Dict],
+    profiles: Optional[List[HardwareProfile]] = None,
+) -> pd.DataFrame:
+    """Compare multiple trackers via deployment scores across hardware profiles.
+
+    Args:
+        benchmark_results: Mapping ``{tracker_name: result_dict}`` where each
+            result_dict has keys ``'fps'``, ``'mean_latency_ms'``, and
+            ``'peak_memory_mb'``.
+        profiles: Hardware profiles to evaluate against.  Defaults to all
+            five built-in profiles.
+
+    Returns:
+        DataFrame indexed by tracker name, one column per hardware profile,
+        values are deployment scores in [0, 1].  A cell value of 1.0 means the
+        tracker fully satisfies all constraints for that device.
+    """
+    if profiles is None:
+        profiles = list(BUILTIN_PROFILES.values())
+
+    rows: Dict[str, Dict[str, float]] = {}
+    for tracker_name, results in benchmark_results.items():
+        fps = float(results.get("fps", 0.0))
+        latency = float(results.get("mean_latency_ms", float("inf")))
+        memory = float(results.get("peak_memory_mb", float("inf")))
+
+        rows[tracker_name] = {
+            profile.name: profile.deployment_score(fps, latency, memory)
+            for profile in profiles
+        }
+
+    df = pd.DataFrame(rows).T
+    df.index.name = "tracker"
+    return df

--- a/eovot/profiling/hardware_profiles.py
+++ b/eovot/profiling/hardware_profiles.py
@@ -1,0 +1,227 @@
+"""Hardware device profiles for edge deployment evaluation.
+
+Defines :class:`HardwareProfile` — a dataclass encoding a target device's
+deployment constraints (TDP, RAM, acceptable FPS/latency/memory) — along
+with five built-in profiles covering the most common edge deployment targets.
+
+Usage::
+
+    from eovot.profiling.hardware_profiles import get_profile
+
+    pi = get_profile("raspberry_pi4")
+    ok = pi.is_tracker_suitable(fps=18.3, latency_ms=54.6, memory_mb=210.0)
+    score = pi.deployment_score(fps=18.3, latency_ms=54.6, memory_mb=210.0)
+
+Custom profiles can be loaded from YAML::
+
+    profile = load_profile_from_yaml("configs/hardware/my_device.yaml")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+
+@dataclass
+class HardwareProfile:
+    """Deployment constraints for a target edge device.
+
+    Attributes:
+        name:              Human-readable device name.
+        cpu_tdp_watts:     CPU Thermal Design Power (W) from the datasheet.
+        ram_mb:            Total device RAM in megabytes.
+        cpu_cores:         Number of physical CPU cores.
+        cpu_freq_ghz:      Base CPU clock frequency (GHz).
+        has_gpu:           Whether the device has a usable GPU.
+        gpu_tdp_watts:     GPU TDP (W); 0 when ``has_gpu`` is False.
+        target_fps:        Minimum acceptable tracker FPS on this device.
+        max_latency_ms:    Maximum acceptable per-frame latency (ms).
+        max_memory_mb:     Maximum acceptable tracker memory footprint (MB).
+        description:       Free-text device description.
+    """
+
+    name: str
+    cpu_tdp_watts: float
+    ram_mb: int
+    cpu_cores: int
+    cpu_freq_ghz: float
+    has_gpu: bool = False
+    gpu_tdp_watts: float = 0.0
+    target_fps: float = 30.0
+    max_latency_ms: float = 33.3
+    max_memory_mb: float = 256.0
+    description: str = ""
+
+    def is_tracker_suitable(self, fps: float, latency_ms: float, memory_mb: float) -> bool:
+        """Return True iff the tracker meets all three deployment constraints.
+
+        Args:
+            fps:        Measured tracker FPS.
+            latency_ms: Measured mean per-frame latency (ms).
+            memory_mb:  Measured peak memory usage (MB).
+        """
+        return (
+            fps >= self.target_fps
+            and latency_ms <= self.max_latency_ms
+            and memory_mb <= self.max_memory_mb
+        )
+
+    def deployment_score(self, fps: float, latency_ms: float, memory_mb: float) -> float:
+        """Compute a [0, 1] deployment feasibility score for this hardware.
+
+        Each dimension is scored independently and clipped to [0, 1]:
+        - FPS score:     min(fps / target_fps, 1.0)
+        - Latency score: min(max_latency_ms / latency_ms, 1.0)
+        - Memory score:  min(max_memory_mb / memory_mb, 1.0)
+
+        Returns the unweighted mean of the three sub-scores.
+
+        Args:
+            fps:        Measured tracker FPS.
+            latency_ms: Measured mean per-frame latency (ms).
+            memory_mb:  Measured peak memory usage (MB).
+
+        Returns:
+            Float in [0, 1]; 1.0 means the tracker fully satisfies all
+            constraints, values below 1.0 indicate which dimension fails.
+        """
+        fps_score = min(fps / self.target_fps, 1.0) if self.target_fps > 0 else 1.0
+        lat_score = min(self.max_latency_ms / latency_ms, 1.0) if latency_ms > 0 else 1.0
+        mem_score = min(self.max_memory_mb / memory_mb, 1.0) if memory_mb > 0 else 1.0
+        return round((fps_score + lat_score + mem_score) / 3.0, 6)
+
+
+# ---------------------------------------------------------------------------
+# Built-in hardware profiles
+# ---------------------------------------------------------------------------
+
+RASPBERRY_PI_4 = HardwareProfile(
+    name="Raspberry Pi 4 (4 GB)",
+    cpu_tdp_watts=6.0,
+    ram_mb=4096,
+    cpu_cores=4,
+    cpu_freq_ghz=1.5,
+    has_gpu=False,
+    gpu_tdp_watts=0.0,
+    target_fps=15.0,
+    max_latency_ms=66.7,
+    max_memory_mb=512.0,
+    description="ARM Cortex-A72, quad-core 1.5 GHz. Most common IoT / edge device.",
+)
+
+JETSON_NANO = HardwareProfile(
+    name="NVIDIA Jetson Nano",
+    cpu_tdp_watts=10.0,
+    ram_mb=4096,
+    cpu_cores=4,
+    cpu_freq_ghz=1.43,
+    has_gpu=True,
+    gpu_tdp_watts=5.0,
+    target_fps=30.0,
+    max_latency_ms=33.3,
+    max_memory_mb=1024.0,
+    description="ARM Cortex-A57 + 128 Maxwell CUDA cores. Entry-level embedded GPU.",
+)
+
+INTEL_NUC = HardwareProfile(
+    name="Intel NUC (Core i5)",
+    cpu_tdp_watts=28.0,
+    ram_mb=16384,
+    cpu_cores=4,
+    cpu_freq_ghz=3.6,
+    has_gpu=False,
+    gpu_tdp_watts=0.0,
+    target_fps=60.0,
+    max_latency_ms=16.7,
+    max_memory_mb=2048.0,
+    description="Intel Core i5 NUC. Mid-range edge compute platform.",
+)
+
+DESKTOP_CPU = HardwareProfile(
+    name="Desktop CPU (x86 baseline)",
+    cpu_tdp_watts=65.0,
+    ram_mb=32768,
+    cpu_cores=8,
+    cpu_freq_ghz=4.0,
+    has_gpu=False,
+    gpu_tdp_watts=0.0,
+    target_fps=100.0,
+    max_latency_ms=10.0,
+    max_memory_mb=8192.0,
+    description="Standard desktop workstation. Used as upper-bound benchmark baseline.",
+)
+
+SMARTPHONE = HardwareProfile(
+    name="Smartphone ARM SoC",
+    cpu_tdp_watts=4.0,
+    ram_mb=4096,
+    cpu_cores=8,
+    cpu_freq_ghz=2.4,
+    has_gpu=False,
+    gpu_tdp_watts=0.0,
+    target_fps=24.0,
+    max_latency_ms=41.7,
+    max_memory_mb=256.0,
+    description="Modern smartphone SoC (e.g. Snapdragon 8 Gen 2). Mobile deployment target.",
+)
+
+
+BUILTIN_PROFILES: Dict[str, HardwareProfile] = {
+    "raspberry_pi4": RASPBERRY_PI_4,
+    "jetson_nano": JETSON_NANO,
+    "intel_nuc": INTEL_NUC,
+    "desktop_cpu": DESKTOP_CPU,
+    "smartphone": SMARTPHONE,
+}
+
+
+def get_profile(name: str) -> HardwareProfile:
+    """Retrieve a built-in hardware profile by key.
+
+    Args:
+        name: One of ``'raspberry_pi4'``, ``'jetson_nano'``, ``'intel_nuc'``,
+              ``'desktop_cpu'``, ``'smartphone'``.
+
+    Returns:
+        The corresponding :class:`HardwareProfile`.
+
+    Raises:
+        KeyError: If *name* is not found in the built-in registry.
+    """
+    if name not in BUILTIN_PROFILES:
+        raise KeyError(
+            f"Unknown hardware profile '{name}'. "
+            f"Available profiles: {sorted(BUILTIN_PROFILES)}"
+        )
+    return BUILTIN_PROFILES[name]
+
+
+def load_profile_from_yaml(path: str) -> HardwareProfile:
+    """Load a :class:`HardwareProfile` from a YAML file.
+
+    The YAML must contain keys matching the :class:`HardwareProfile` field
+    names.  Unknown keys are silently ignored so that future fields can be
+    added without breaking existing YAML files.
+
+    Args:
+        path: Filesystem path to the YAML file.
+
+    Returns:
+        A :class:`HardwareProfile` populated from the YAML data.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+        KeyError: If a required field is missing from the YAML.
+    """
+    fpath = Path(path)
+    if not fpath.exists():
+        raise FileNotFoundError(f"Hardware profile YAML not found: {fpath}")
+    with open(fpath, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    valid_fields = HardwareProfile.__dataclass_fields__
+    filtered = {k: v for k, v in data.items() if k in valid_fields}
+    return HardwareProfile(**filtered)

--- a/tests/test_hardware_profiles.py
+++ b/tests/test_hardware_profiles.py
@@ -1,0 +1,217 @@
+"""Unit tests for hardware profiles and deployment feasibility analysis."""
+
+import math
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from eovot.profiling.hardware_profiles import (
+    BUILTIN_PROFILES,
+    HardwareProfile,
+    get_profile,
+    load_profile_from_yaml,
+)
+from eovot.profiling.deployment_report import (
+    compare_trackers_on_hardware,
+    evaluate_deployment,
+)
+
+
+# ---------------------------------------------------------------------------
+# HardwareProfile — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareProfile:
+    def test_builtin_profiles_are_complete(self):
+        expected = {"raspberry_pi4", "jetson_nano", "intel_nuc", "desktop_cpu", "smartphone"}
+        assert set(BUILTIN_PROFILES.keys()) == expected
+
+    def test_get_profile_returns_correct_instance(self):
+        pi = get_profile("raspberry_pi4")
+        assert isinstance(pi, HardwareProfile)
+        assert pi.cpu_cores == 4
+        assert pi.target_fps == 15.0
+
+    def test_get_profile_raises_for_unknown_key(self):
+        with pytest.raises(KeyError, match="Unknown hardware profile"):
+            get_profile("nonexistent_device")
+
+    def test_is_tracker_suitable_true(self):
+        pi = get_profile("raspberry_pi4")
+        # fps=20 > 15, latency=50 < 66.7, memory=200 < 512
+        assert pi.is_tracker_suitable(fps=20.0, latency_ms=50.0, memory_mb=200.0) is True
+
+    def test_is_tracker_suitable_false_fps(self):
+        pi = get_profile("raspberry_pi4")
+        assert pi.is_tracker_suitable(fps=10.0, latency_ms=50.0, memory_mb=200.0) is False
+
+    def test_is_tracker_suitable_false_latency(self):
+        pi = get_profile("raspberry_pi4")
+        assert pi.is_tracker_suitable(fps=20.0, latency_ms=100.0, memory_mb=200.0) is False
+
+    def test_is_tracker_suitable_false_memory(self):
+        pi = get_profile("raspberry_pi4")
+        assert pi.is_tracker_suitable(fps=20.0, latency_ms=50.0, memory_mb=600.0) is False
+
+    def test_deployment_score_perfect(self):
+        pi = get_profile("raspberry_pi4")
+        # All constraints are exactly met or exceeded
+        score = pi.deployment_score(fps=pi.target_fps, latency_ms=pi.max_latency_ms, memory_mb=pi.max_memory_mb)
+        assert math.isclose(score, 1.0, abs_tol=1e-5)
+
+    def test_deployment_score_zero_fps(self):
+        pi = get_profile("raspberry_pi4")
+        score = pi.deployment_score(fps=0.0, latency_ms=50.0, memory_mb=200.0)
+        assert score == pytest.approx(0.0, abs=1e-5)
+
+    def test_deployment_score_clamped_above_one(self):
+        pi = get_profile("raspberry_pi4")
+        # fps far exceeds target, etc — score must still be <= 1
+        score = pi.deployment_score(fps=10_000.0, latency_ms=0.001, memory_mb=1.0)
+        assert score <= 1.0 + 1e-9
+
+    def test_deployment_score_partial(self):
+        pi = get_profile("raspberry_pi4")
+        # fps exactly meets target (score=1), latency and memory exceed limits (score < 1)
+        score = pi.deployment_score(
+            fps=pi.target_fps,
+            latency_ms=pi.max_latency_ms * 2,  # 2x over limit
+            memory_mb=pi.max_memory_mb * 2,
+        )
+        # fps_score=1, lat_score=0.5, mem_score=0.5 -> mean=0.666...
+        assert 0.0 < score < 1.0
+
+    def test_jetson_nano_has_gpu(self):
+        jetson = get_profile("jetson_nano")
+        assert jetson.has_gpu is True
+        assert jetson.gpu_tdp_watts > 0.0
+
+    def test_all_profiles_have_positive_target_fps(self):
+        for key, profile in BUILTIN_PROFILES.items():
+            assert profile.target_fps > 0, f"{key} has non-positive target_fps"
+
+
+# ---------------------------------------------------------------------------
+# load_profile_from_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestLoadProfileFromYaml:
+    def test_load_valid_yaml(self, tmp_path):
+        data = {
+            "name": "Test Device",
+            "cpu_tdp_watts": 8.0,
+            "ram_mb": 2048,
+            "cpu_cores": 4,
+            "cpu_freq_ghz": 1.8,
+        }
+        yaml_file = tmp_path / "test_device.yaml"
+        yaml_file.write_text(yaml.dump(data), encoding="utf-8")
+
+        profile = load_profile_from_yaml(str(yaml_file))
+        assert profile.name == "Test Device"
+        assert profile.cpu_tdp_watts == 8.0
+        assert profile.ram_mb == 2048
+
+    def test_load_yaml_ignores_unknown_keys(self, tmp_path):
+        data = {
+            "name": "Future Device",
+            "cpu_tdp_watts": 5.0,
+            "ram_mb": 1024,
+            "cpu_cores": 2,
+            "cpu_freq_ghz": 1.0,
+            "unknown_future_field": "ignored",
+        }
+        yaml_file = tmp_path / "future.yaml"
+        yaml_file.write_text(yaml.dump(data), encoding="utf-8")
+        # Should not raise
+        profile = load_profile_from_yaml(str(yaml_file))
+        assert profile.name == "Future Device"
+
+    def test_load_yaml_raises_for_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            load_profile_from_yaml("/nonexistent/path/device.yaml")
+
+
+# ---------------------------------------------------------------------------
+# evaluate_deployment
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateDeployment:
+    """Tests for the single-tracker deployment feasibility report."""
+
+    FAST_TRACKER = {"fps": 200.0, "mean_latency_ms": 5.0, "peak_memory_mb": 40.0}
+    SLOW_TRACKER = {"fps": 5.0, "mean_latency_ms": 200.0, "peak_memory_mb": 800.0}
+
+    def test_returns_dataframe_with_expected_columns(self):
+        import pandas as pd
+        df = evaluate_deployment(self.FAST_TRACKER)
+        assert isinstance(df, pd.DataFrame)
+        for col in ("profile", "suitable", "deployment_score", "fps_ok", "latency_ok", "memory_ok"):
+            assert col in df.columns
+
+    def test_fast_tracker_suitable_on_all_profiles(self):
+        df = evaluate_deployment(self.FAST_TRACKER)
+        assert df["suitable"].all(), "Fast tracker should be suitable on every profile"
+
+    def test_slow_tracker_not_suitable_on_any_profile(self):
+        df = evaluate_deployment(self.SLOW_TRACKER)
+        assert not df["suitable"].any(), "Slow tracker should not be suitable on any profile"
+
+    def test_sorted_by_deployment_score_descending(self):
+        df = evaluate_deployment(self.FAST_TRACKER)
+        scores = df["deployment_score"].tolist()
+        assert scores == sorted(scores, reverse=True)
+
+    def test_custom_profiles_list(self):
+        from eovot.profiling.hardware_profiles import RASPBERRY_PI_4, JETSON_NANO
+        df = evaluate_deployment(self.FAST_TRACKER, profiles=[RASPBERRY_PI_4, JETSON_NANO])
+        assert len(df) == 2
+
+    def test_defaults_to_all_builtin_profiles(self):
+        df = evaluate_deployment(self.FAST_TRACKER)
+        assert len(df) == len(BUILTIN_PROFILES)
+
+
+# ---------------------------------------------------------------------------
+# compare_trackers_on_hardware
+# ---------------------------------------------------------------------------
+
+
+class TestCompareTrackersOnHardware:
+    TRACKER_RESULTS = {
+        "MOSSE": {"fps": 520.0, "mean_latency_ms": 1.9, "peak_memory_mb": 42.0},
+        "KCF": {"fps": 280.0, "mean_latency_ms": 3.6, "peak_memory_mb": 68.0},
+        "CSRT": {"fps": 45.0, "mean_latency_ms": 22.2, "peak_memory_mb": 130.0},
+    }
+
+    def test_returns_dataframe_with_trackers_as_index(self):
+        import pandas as pd
+        df = compare_trackers_on_hardware(self.TRACKER_RESULTS)
+        assert isinstance(df, pd.DataFrame)
+        assert set(df.index) == {"MOSSE", "KCF", "CSRT"}
+
+    def test_columns_match_profile_names(self):
+        from eovot.profiling.hardware_profiles import RASPBERRY_PI_4, JETSON_NANO
+        df = compare_trackers_on_hardware(
+            self.TRACKER_RESULTS,
+            profiles=[RASPBERRY_PI_4, JETSON_NANO],
+        )
+        assert RASPBERRY_PI_4.name in df.columns
+        assert JETSON_NANO.name in df.columns
+
+    def test_mosse_scores_higher_than_csrt_on_all_profiles(self):
+        df = compare_trackers_on_hardware(self.TRACKER_RESULTS)
+        for col in df.columns:
+            assert df.loc["MOSSE", col] >= df.loc["CSRT", col], (
+                f"MOSSE should score >= CSRT on {col}"
+            )
+
+    def test_scores_in_unit_interval(self):
+        df = compare_trackers_on_hardware(self.TRACKER_RESULTS)
+        assert (df.values >= 0.0).all()
+        assert (df.values <= 1.0 + 1e-9).all()


### PR DESCRIPTION
## What was added

Closes #74

EOVOT's profiling engine already measures latency, FPS, and memory — but had no concept of a **target deployment device**. This PR introduces hardware profiles that encode a device's constraints and check whether a tracker is actually deployable on it.

### New files

| File | Purpose |
|------|---------|
| `eovot/profiling/hardware_profiles.py` | `HardwareProfile` dataclass + 5 built-in profiles |
| `eovot/profiling/deployment_report.py` | `evaluate_deployment()` and `compare_trackers_on_hardware()` |
| `configs/hardware/raspberry_pi4.yaml` | Raspberry Pi 4 profile (YAML-loadable) |
| `configs/hardware/jetson_nano.yaml` | NVIDIA Jetson Nano profile |
| `configs/hardware/smartphone.yaml` | Smartphone ARM SoC profile |
| `configs/hardware/intel_nuc.yaml` | Intel NUC Core i5 profile |
| `tests/test_hardware_profiles.py` | 22 unit tests covering all new code paths |

### Built-in profiles

| Key | Device | TDP | Target FPS | Max Memory |
|-----|--------|-----|-----------|------------|
| `raspberry_pi4` | Raspberry Pi 4 (4 GB) | 6 W | 15 FPS | 512 MB |
| `jetson_nano` | NVIDIA Jetson Nano | 10 W | 30 FPS | 1024 MB |
| `intel_nuc` | Intel NUC i5 | 28 W | 60 FPS | 2048 MB |
| `desktop_cpu` | Desktop CPU baseline | 65 W | 100 FPS | 8192 MB |
| `smartphone` | Smartphone ARM SoC | 4 W | 24 FPS | 256 MB |

## Why it matters

This answers the core edge-deployment question: **"Which trackers can run on a Raspberry Pi 4?"**  
Without device profiles, all benchmark results are hardware-agnostic and researchers must manually cross-reference device datasheets.

## Example usage

```python
from eovot.profiling import get_profile, evaluate_deployment, compare_trackers_on_hardware

# Check one tracker against all devices
report = evaluate_deployment(
    {"fps": 22.5, "mean_latency_ms": 44.2, "peak_memory_mb": 185.0}
)
print(report[["profile", "suitable", "deployment_score"]])

# Compare multiple trackers across all devices
matrix = compare_trackers_on_hardware({
    "MOSSE":      {"fps": 520.0, "mean_latency_ms": 1.9,  "peak_memory_mb": 42.0},
    "KCF":        {"fps": 280.0, "mean_latency_ms": 3.6,  "peak_memory_mb": 68.0},
    "CSRT":       {"fps": 45.0,  "mean_latency_ms": 22.2, "peak_memory_mb": 130.0},
})
print(matrix)  # tracker × device deployment-score matrix

# Load a custom device from YAML
from eovot.profiling import load_profile_from_yaml
custom = load_profile_from_yaml("configs/hardware/raspberry_pi4.yaml")
score = custom.deployment_score(fps=18.0, latency_ms=55.0, memory_mb=200.0)
```

## No breaking changes

All additions are purely additive. Existing `Profiler`, `EnergyProfiler`, and `BenchmarkEngine` APIs are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_019sLBTpCL1qyEp3rQH5ro2Y)_