### PR TITLE
[feat] Add edge-score composite metric for hardware-aware tracker ranking

### DIFF
--- a/configs/experiments/multi_tracker.yaml
+++ b/configs/experiments/multi_tracker.yaml
@@ -38,3 +38,26 @@ trackers:
 
   - name: MedianFlow
     params: {}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Edge-Score Configuration
+#
+# Controls the hardware-aware composite ranking produced alongside the
+# standard mIoU leaderboard.  Tune these values to match your target device.
+#
+#   target_fps      — FPS above which speed component is capped at 1.0.
+#                     30 fps = real-time video; 15 fps = IoT / low-power.
+#   memory_budget_mb — Maximum acceptable RSS memory in MiB.
+#                     256 MB → Raspberry Pi 4 (1 GB); 512 MB → Jetson Nano.
+#   energy_budget_mj — Per-frame energy budget in mJ. Only meaningful when
+#                     tdp_watts is set above. null disables the energy column.
+#   w_*             — Relative weights (automatically normalised to sum to 1).
+# ─────────────────────────────────────────────────────────────────────────────
+edge_score:
+  target_fps: 30.0
+  memory_budget_mb: 512.0
+  energy_budget_mj: null     # set to e.g. 5.0 when tdp_watts is configured
+  w_accuracy: 0.40
+  w_speed: 0.30
+  w_memory: 0.20
+  w_energy: 0.10

--- a/eovot/experiment/runner.py
+++ b/eovot/experiment/runner.py
@@ -37,6 +37,16 @@ Config schema::
       - name: KCF
         params:
           learning_rate: 0.125
+
+    # Optional: edge-score config for hardware-aware ranking
+    edge_score:
+      target_fps: 30.0
+      memory_budget_mb: 512.0
+      energy_budget_mj: null   # set to a float when tdp_watts is configured
+      w_accuracy: 0.40
+      w_speed: 0.30
+      w_memory: 0.20
+      w_energy: 0.10
 """
 
 from __future__ import annotations
@@ -47,6 +57,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ..benchmark.engine import BenchmarkEngine
+from ..metrics.efficiency import EdgeScoreConfig, edge_score_leaderboard_md
 from ..reporting.reporter import BenchmarkReporter
 from .snapshot import ReproducibilitySnapshot
 
@@ -98,6 +109,21 @@ class ExperimentRunner:
         seed = exp_cfg.get("seed", None)
         tdp_watts = exp_cfg.get("tdp_watts", None)
 
+        edge_cfg_raw = config.get("edge_score", {}) or {}
+        edge_score_config = EdgeScoreConfig(
+            target_fps=float(edge_cfg_raw.get("target_fps", 30.0)),
+            memory_budget_mb=float(edge_cfg_raw.get("memory_budget_mb", 512.0)),
+            energy_budget_mj=(
+                float(edge_cfg_raw["energy_budget_mj"])
+                if edge_cfg_raw.get("energy_budget_mj") is not None
+                else None
+            ),
+            w_accuracy=float(edge_cfg_raw.get("w_accuracy", 0.40)),
+            w_speed=float(edge_cfg_raw.get("w_speed", 0.30)),
+            w_memory=float(edge_cfg_raw.get("w_memory", 0.20)),
+            w_energy=float(edge_cfg_raw.get("w_energy", 0.10)),
+        )
+
         snapshot = ReproducibilitySnapshot.capture(seed=seed)
 
         exp_dir = self.output_dir / exp_name
@@ -141,7 +167,7 @@ class ExperimentRunner:
             reporter.save_all(result_dict, name=f"{tracker_name}-{dataset_name}")
             all_results.append(result_dict)
 
-        leaderboard = self._build_leaderboard(all_results)
+        leaderboard = self._build_leaderboard(all_results, edge_score_config)
         leaderboard_path = exp_dir / "leaderboard.md"
         leaderboard_path.write_text(leaderboard, encoding="utf-8")
 
@@ -170,15 +196,24 @@ class ExperimentRunner:
     # Leaderboard generation
     # ------------------------------------------------------------------
 
-    def _build_leaderboard(self, results: List[Dict]) -> str:
-        """Build a Markdown leaderboard table ranked by mIoU (descending).
+    def _build_leaderboard(
+        self,
+        results: List[Dict],
+        edge_config: Optional[EdgeScoreConfig] = None,
+    ) -> str:
+        """Build a Markdown leaderboard with mIoU ranking and edge-score section.
 
         Args:
             results: List of result dicts from
                 :meth:`~eovot.benchmark.engine.BenchmarkResult.to_dict`.
+            edge_config: :class:`~eovot.metrics.efficiency.EdgeScoreConfig`
+                for the hardware-aware ranking section.  Defaults to
+                ``EdgeScoreConfig()`` when ``None``.
 
         Returns:
             Multi-line Markdown string ready for writing to a ``.md`` file.
+            Contains two sections: accuracy-only ranking (mIoU) followed by
+            the composite edge-score ranking.
         """
         if not results:
             return "No results to display.\n"
@@ -201,6 +236,7 @@ class ExperimentRunner:
 
         lines = [
             "# EOVOT Experiment Leaderboard\n",
+            "## Accuracy Ranking (mIoU)\n",
             "| Rank | Tracker | Dataset | mIoU | FPS | Mem (MB) | Sequences |",
             "|------|---------|---------|-----:|----:|---------:|----------:|",
         ]
@@ -211,6 +247,16 @@ class ExperimentRunner:
                 f"| {row['mem_mb']:.1f} | {row['n_seq']} |"
             )
         lines.append("")
+
+        # Append the hardware-aware edge-score section.
+        lines.append(
+            edge_score_leaderboard_md(
+                results,
+                config=edge_config,
+                title="Edge-Score Ranking (accuracy + speed + memory)",
+            )
+        )
+
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/eovot/metrics/efficiency.py
+++ b/eovot/metrics/efficiency.py
@@ -1,0 +1,302 @@
+"""Edge-aware composite efficiency scoring for EOVOT tracker evaluation.
+
+Bridges the gap between pure accuracy rankings (mIoU-only) and practical
+edge deployment decisions by computing a weighted composite *edge score* that
+penalises resource-hungry trackers and rewards those achieving good accuracy
+within hardware constraints.
+
+Edge Score formula::
+
+    edge_score = (
+        w_accuracy * iou
+        + w_speed   * min(fps / target_fps, 1.0)
+        + w_memory  * max(0, 1 - memory_mb / memory_budget_mb)
+        + w_energy  * max(0, 1 - energy_mj / energy_budget_mj)   # optional
+    ) / (w_accuracy + w_speed + w_memory + w_energy)
+
+All component weights must be non-negative and are automatically normalised
+to sum to 1.  The energy weight is excluded from normalisation when energy
+data is unavailable.
+
+Typical usage::
+
+    from eovot.metrics.efficiency import EdgeScoreConfig, compute_edge_score
+
+    config = EdgeScoreConfig(
+        target_fps=30.0,
+        memory_budget_mb=512.0,
+        energy_budget_mj=5.0,
+        w_accuracy=0.40,
+        w_speed=0.30,
+        w_memory=0.20,
+        w_energy=0.10,
+    )
+    score = compute_edge_score(result_dict["summary"], config)
+    print(score)
+
+    # Rank multiple trackers
+    ranked = rank_by_edge_score(all_result_dicts, config)
+    md = edge_score_leaderboard_md(all_result_dicts, config)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class EdgeScoreConfig:
+    """Configuration for edge-score computation.
+
+    Attributes:
+        target_fps: FPS above which the speed component is capped at 1.0.
+            Represents the minimum acceptable real-time frame rate for the
+            target application (e.g. 30 fps for drone control, 15 fps for
+            IoT cameras).
+        memory_budget_mb: Maximum acceptable RSS memory (MiB).  A tracker
+            that stays at or below this value scores 1.0 on the memory
+            component; trackers exceeding it score 0.
+        energy_budget_mj: Per-frame energy budget in milli-Joules.  Set to
+            ``None`` to disable the energy component.  Meaningful only when
+            the benchmark was run with ``tdp_watts`` configured.
+        w_accuracy: Weight for the IoU accuracy component.
+        w_speed: Weight for the FPS throughput component.
+        w_memory: Weight for the memory efficiency component.
+        w_energy: Weight for the energy efficiency component.  Only active
+            when energy data are available and ``energy_budget_mj`` is set.
+    """
+
+    target_fps: float = 30.0
+    memory_budget_mb: float = 512.0
+    energy_budget_mj: Optional[float] = None
+
+    w_accuracy: float = 0.40
+    w_speed: float = 0.30
+    w_memory: float = 0.20
+    w_energy: float = 0.10
+
+
+@dataclass
+class EdgeScoreResult:
+    """Per-tracker edge-score with full component breakdown.
+
+    All component values are in ``[0, 1]``; higher is better.
+    The ``edge_score`` field is the weighted, normalised composite.
+
+    Attributes:
+        tracker: Tracker identifier string.
+        edge_score: Final composite score in ``[0, 1]`` (higher is better).
+        accuracy_component: Normalised IoU contribution.
+        speed_component: Normalised FPS contribution (capped at 1.0 when
+            FPS exceeds ``target_fps``).
+        memory_component: ``max(0, 1 - memory_mb / memory_budget_mb)``.
+        energy_component: ``max(0, 1 - energy_mj / energy_budget_mj)``,
+            or ``None`` when energy data or budget are unavailable.
+        mean_iou: Raw mean IoU value.
+        fps: Raw mean FPS value.
+        memory_mb: Raw peak memory in MiB.
+        energy_mj: Raw mean energy per frame in mJ, or ``None``.
+    """
+
+    tracker: str
+    edge_score: float
+    accuracy_component: float
+    speed_component: float
+    memory_component: float
+    energy_component: Optional[float]
+    mean_iou: float
+    fps: float
+    memory_mb: float
+    energy_mj: Optional[float]
+
+    def __str__(self) -> str:
+        e_str = (
+            f"  energy_comp={self.energy_component:.3f}"
+            if self.energy_component is not None
+            else ""
+        )
+        return (
+            f"EdgeScoreResult[{self.tracker}] "
+            f"edge_score={self.edge_score:.4f}  "
+            f"(acc={self.accuracy_component:.3f}  "
+            f"spd={self.speed_component:.3f}  "
+            f"mem={self.memory_component:.3f}"
+            f"{e_str})"
+        )
+
+
+def compute_edge_score(
+    summary: Dict[str, Any],
+    config: EdgeScoreConfig,
+) -> EdgeScoreResult:
+    """Compute an :class:`EdgeScoreResult` from a benchmark summary dict.
+
+    Args:
+        summary: The ``"summary"`` sub-dict returned by
+            :meth:`~eovot.benchmark.engine.BenchmarkResult.to_dict`.
+            Recognised keys: ``"tracker"``, ``"tracker_name"``,
+            ``"mean_iou"``, ``"mean_fps"``, ``"peak_memory_mb"``,
+            ``"mean_energy_per_frame_mj"``.
+        config: :class:`EdgeScoreConfig` controlling weights and device
+            budgets.
+
+    Returns:
+        :class:`EdgeScoreResult` with the composite score and each
+        normalised component.
+    """
+    tracker = summary.get("tracker") or summary.get("tracker_name", "?")
+    iou = float(summary.get("mean_iou", 0.0))
+    fps = float(summary.get("mean_fps", 0.0))
+    memory_mb = float(summary.get("peak_memory_mb", 0.0))
+    energy_mj_raw = summary.get("mean_energy_per_frame_mj")
+    energy_mj: Optional[float] = float(energy_mj_raw) if energy_mj_raw is not None else None
+
+    # Normalised components, each in [0, 1].
+    acc_comp = float(max(0.0, min(1.0, iou)))
+
+    if config.target_fps > 0:
+        spd_comp = float(min(fps / config.target_fps, 1.0))
+    else:
+        spd_comp = 0.0
+
+    if config.memory_budget_mb > 0:
+        mem_comp = float(max(0.0, 1.0 - memory_mb / config.memory_budget_mb))
+    else:
+        mem_comp = 0.0
+
+    use_energy = (
+        energy_mj is not None
+        and config.energy_budget_mj is not None
+        and config.energy_budget_mj > 0
+    )
+    if use_energy:
+        assert energy_mj is not None and config.energy_budget_mj is not None
+        e_comp: Optional[float] = float(
+            max(0.0, 1.0 - energy_mj / config.energy_budget_mj)
+        )
+    else:
+        e_comp = None
+
+    # Normalise weights so they sum to 1 (drop energy weight when unused).
+    w_acc = float(config.w_accuracy)
+    w_spd = float(config.w_speed)
+    w_mem = float(config.w_memory)
+    w_ene = float(config.w_energy) if use_energy else 0.0
+    total_w = w_acc + w_spd + w_mem + w_ene
+    if total_w <= 0.0:
+        total_w = 1.0
+
+    score = (
+        w_acc * acc_comp
+        + w_spd * spd_comp
+        + w_mem * mem_comp
+        + w_ene * (e_comp or 0.0)
+    ) / total_w
+
+    return EdgeScoreResult(
+        tracker=tracker,
+        edge_score=round(float(score), 6),
+        accuracy_component=round(acc_comp, 6),
+        speed_component=round(spd_comp, 6),
+        memory_component=round(mem_comp, 6),
+        energy_component=round(e_comp, 6) if e_comp is not None else None,
+        mean_iou=round(iou, 6),
+        fps=round(fps, 4),
+        memory_mb=round(memory_mb, 4),
+        energy_mj=round(energy_mj, 6) if energy_mj is not None else None,
+    )
+
+
+def rank_by_edge_score(
+    results: List[Dict[str, Any]],
+    config: Optional[EdgeScoreConfig] = None,
+) -> List[EdgeScoreResult]:
+    """Compute and rank edge scores for a list of benchmark result dicts.
+
+    Args:
+        results: List of result dicts, each containing a ``"summary"``
+            sub-dict as produced by
+            :meth:`~eovot.benchmark.engine.BenchmarkResult.to_dict`.
+            Bare summary dicts (without the ``"summary"`` wrapper) are also
+            accepted for convenience.
+        config: :class:`EdgeScoreConfig`.  Defaults to
+            ``EdgeScoreConfig()`` (equal-ish weights, 30 fps / 512 MB
+            budgets) when ``None``.
+
+    Returns:
+        List of :class:`EdgeScoreResult` sorted by ``edge_score``
+        descending (best tracker first).
+    """
+    if config is None:
+        config = EdgeScoreConfig()
+    summaries = [r.get("summary", r) for r in results]
+    scores = [compute_edge_score(s, config) for s in summaries]
+    scores.sort(key=lambda x: x.edge_score, reverse=True)
+    return scores
+
+
+def edge_score_leaderboard_md(
+    results: List[Dict[str, Any]],
+    config: Optional[EdgeScoreConfig] = None,
+    title: str = "EOVOT Edge-Score Leaderboard",
+) -> str:
+    """Generate a Markdown leaderboard table ranked by edge score.
+
+    Args:
+        results: List of result dicts (same format as
+            :func:`rank_by_edge_score`).
+        config: Scoring configuration.  Defaults to ``EdgeScoreConfig()``.
+        title: Markdown heading text for the leaderboard section.
+
+    Returns:
+        Multi-line Markdown string ready for appending to a ``.md`` file.
+    """
+    if config is None:
+        config = EdgeScoreConfig()
+
+    if not results:
+        return "No results to display.\n"
+
+    ranked = rank_by_edge_score(results, config)
+    has_energy = any(r.energy_component is not None for r in ranked)
+
+    header = ["Rank", "Tracker", "EdgeScore", "mIoU", "FPS", "Mem (MB)",
+               "Acc ▸", "Spd ▸", "Mem ▸"]
+    sep = [":---:", ":---", "---:", "---:", "---:", "---:",
+           "---:", "---:", "---:"]
+    if has_energy:
+        header += ["Nrg ▸", "E (mJ/fr)"]
+        sep += ["---:", "---:"]
+
+    budget_info = (
+        f"> Config — target_fps={config.target_fps} fps, "
+        f"memory_budget={config.memory_budget_mb} MB"
+    )
+    if config.energy_budget_mj is not None:
+        budget_info += f", energy_budget={config.energy_budget_mj} mJ/fr"
+    budget_info += "\n"
+
+    lines = [
+        f"\n## {title}\n",
+        budget_info,
+        "| " + " | ".join(header) + " |",
+        "| " + " | ".join(sep) + " |",
+    ]
+
+    for rank, r in enumerate(ranked, start=1):
+        row = (
+            f"| {rank} | {r.tracker} | **{r.edge_score:.4f}** "
+            f"| {r.mean_iou:.4f} | {r.fps:.1f} | {r.memory_mb:.1f} "
+            f"| {r.accuracy_component:.3f} | {r.speed_component:.3f} "
+            f"| {r.memory_component:.3f}"
+        )
+        if has_energy:
+            e_c = f"{r.energy_component:.3f}" if r.energy_component is not None else "N/A"
+            e_j = f"{r.energy_mj:.3f}" if r.energy_mj is not None else "N/A"
+            row += f" | {e_c} | {e_j}"
+        row += " |"
+        lines.append(row)
+
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/test_efficiency_metrics.py
+++ b/tests/test_efficiency_metrics.py
@@ -1,0 +1,252 @@
+"""Unit tests for the edge-score efficiency metrics module."""
+
+from __future__ import annotations
+
+import pytest
+
+from eovot.metrics.efficiency import (
+    EdgeScoreConfig,
+    EdgeScoreResult,
+    compute_edge_score,
+    edge_score_leaderboard_md,
+    rank_by_edge_score,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+SUMMARY_NO_ENERGY = {
+    "tracker": "MOSSE",
+    "mean_iou": 0.60,
+    "mean_fps": 300.0,
+    "peak_memory_mb": 200.0,
+}
+
+SUMMARY_WITH_ENERGY = {
+    "tracker": "KCF",
+    "mean_iou": 0.55,
+    "mean_fps": 150.0,
+    "peak_memory_mb": 220.0,
+    "mean_energy_per_frame_mj": 2.5,
+}
+
+RESULT_NO_ENERGY = {"summary": SUMMARY_NO_ENERGY}
+RESULT_WITH_ENERGY = {"summary": SUMMARY_WITH_ENERGY}
+
+
+# ---------------------------------------------------------------------------
+# compute_edge_score
+# ---------------------------------------------------------------------------
+
+class TestComputeEdgeScore:
+    def test_score_in_unit_interval(self):
+        config = EdgeScoreConfig()
+        r = compute_edge_score(SUMMARY_NO_ENERGY, config)
+        assert 0.0 <= r.edge_score <= 1.0
+
+    def test_returns_edge_score_result(self):
+        r = compute_edge_score(SUMMARY_NO_ENERGY, EdgeScoreConfig())
+        assert isinstance(r, EdgeScoreResult)
+
+    def test_perfect_tracker_scores_near_one(self):
+        """A tracker with IoU=1, FPS >> target, memory=0 should score near 1."""
+        summary = {
+            "tracker": "Perfect",
+            "mean_iou": 1.0,
+            "mean_fps": 10_000.0,
+            "peak_memory_mb": 0.0,
+        }
+        r = compute_edge_score(summary, EdgeScoreConfig(target_fps=30.0, memory_budget_mb=512.0))
+        assert r.edge_score > 0.95
+
+    def test_zero_tracker_scores_zero(self):
+        """A tracker with zero accuracy, zero speed, and exhausted budgets scores 0."""
+        summary = {
+            "tracker": "Zero",
+            "mean_iou": 0.0,
+            "mean_fps": 0.0,
+            "peak_memory_mb": 9999.0,  # far exceeds budget → memory_component = 0
+        }
+        r = compute_edge_score(summary, EdgeScoreConfig())
+        assert r.edge_score == pytest.approx(0.0, abs=1e-6)
+
+    def test_speed_component_capped_at_one(self):
+        """FPS component must be ≤ 1.0 even when FPS ≫ target."""
+        summary = {
+            "tracker": "Fast",
+            "mean_iou": 0.5,
+            "mean_fps": 999_999.0,
+            "peak_memory_mb": 100.0,
+        }
+        r = compute_edge_score(summary, EdgeScoreConfig(target_fps=30.0))
+        assert r.speed_component == pytest.approx(1.0)
+
+    def test_memory_over_budget_yields_zero_component(self):
+        """Memory component must clamp to 0 when memory exceeds budget."""
+        summary = {
+            "tracker": "Heavy",
+            "mean_iou": 0.5,
+            "mean_fps": 30.0,
+            "peak_memory_mb": 1024.0,
+        }
+        r = compute_edge_score(summary, EdgeScoreConfig(memory_budget_mb=512.0))
+        assert r.memory_component == pytest.approx(0.0)
+
+    def test_energy_component_present_when_budget_set(self):
+        config = EdgeScoreConfig(energy_budget_mj=5.0)
+        r = compute_edge_score(SUMMARY_WITH_ENERGY, config)
+        assert r.energy_component is not None
+        assert 0.0 <= r.energy_component <= 1.0
+
+    def test_energy_component_none_when_no_budget(self):
+        config = EdgeScoreConfig(energy_budget_mj=None)
+        r = compute_edge_score(SUMMARY_WITH_ENERGY, config)
+        assert r.energy_component is None
+
+    def test_energy_component_none_when_no_data(self):
+        """Energy component absent when summary has no energy measurement."""
+        config = EdgeScoreConfig(energy_budget_mj=5.0)
+        r = compute_edge_score(SUMMARY_NO_ENERGY, config)
+        assert r.energy_component is None
+
+    def test_tracker_name_fallback(self):
+        """'tracker_name' key should work as fallback when 'tracker' is absent."""
+        summary = {
+            "tracker_name": "MyTracker",
+            "mean_iou": 0.5,
+            "mean_fps": 30.0,
+            "peak_memory_mb": 100.0,
+        }
+        r = compute_edge_score(summary, EdgeScoreConfig())
+        assert r.tracker == "MyTracker"
+
+    def test_weight_scaling_invariance(self):
+        """Results must be identical regardless of absolute weight scale."""
+        summary = SUMMARY_NO_ENERGY.copy()
+        cfg1 = EdgeScoreConfig(w_accuracy=0.4, w_speed=0.3, w_memory=0.2, w_energy=0.1)
+        cfg2 = EdgeScoreConfig(w_accuracy=4.0, w_speed=3.0, w_memory=2.0, w_energy=1.0)
+        r1 = compute_edge_score(summary, cfg1)
+        r2 = compute_edge_score(summary, cfg2)
+        assert r1.edge_score == pytest.approx(r2.edge_score, abs=1e-6)
+
+    def test_components_non_negative(self):
+        r = compute_edge_score(SUMMARY_NO_ENERGY, EdgeScoreConfig())
+        assert r.accuracy_component >= 0.0
+        assert r.speed_component >= 0.0
+        assert r.memory_component >= 0.0
+
+    def test_iou_clamped_to_unit_interval(self):
+        """IoU values outside [0,1] should not produce out-of-range components."""
+        summary = {
+            "tracker": "X",
+            "mean_iou": 1.5,
+            "mean_fps": 30.0,
+            "peak_memory_mb": 100.0,
+        }
+        r = compute_edge_score(summary, EdgeScoreConfig())
+        assert r.accuracy_component <= 1.0
+
+    def test_str_representation(self):
+        r = compute_edge_score(SUMMARY_NO_ENERGY, EdgeScoreConfig())
+        s = str(r)
+        assert "EdgeScoreResult" in s
+        assert "MOSSE" in s
+
+    def test_energy_over_budget_yields_zero_component(self):
+        """Energy component clamps to 0 when usage exceeds budget."""
+        summary = {
+            "tracker": "Hungry",
+            "mean_iou": 0.5,
+            "mean_fps": 30.0,
+            "peak_memory_mb": 100.0,
+            "mean_energy_per_frame_mj": 100.0,
+        }
+        config = EdgeScoreConfig(energy_budget_mj=5.0)
+        r = compute_edge_score(summary, config)
+        assert r.energy_component == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# rank_by_edge_score
+# ---------------------------------------------------------------------------
+
+class TestRankByEdgeScore:
+    def test_sorted_descending(self):
+        results = [RESULT_NO_ENERGY, RESULT_WITH_ENERGY]
+        ranked = rank_by_edge_score(results)
+        scores = [r.edge_score for r in ranked]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_default_config_accepted(self):
+        ranked = rank_by_edge_score([RESULT_NO_ENERGY, RESULT_WITH_ENERGY])
+        assert len(ranked) == 2
+
+    def test_returns_edge_score_result_objects(self):
+        ranked = rank_by_edge_score([RESULT_NO_ENERGY])
+        assert all(isinstance(r, EdgeScoreResult) for r in ranked)
+
+    def test_empty_input_returns_empty_list(self):
+        assert rank_by_edge_score([]) == []
+
+    def test_bare_summary_dict_accepted(self):
+        """A raw summary dict (without 'summary' wrapper) should work."""
+        ranked = rank_by_edge_score([SUMMARY_NO_ENERGY])
+        assert len(ranked) == 1
+
+    def test_custom_config_changes_ranking(self):
+        """Speed-first config should favour MOSSE (higher FPS) over KCF."""
+        speed_first = EdgeScoreConfig(
+            target_fps=30.0,
+            w_accuracy=0.10,
+            w_speed=0.80,
+            w_memory=0.10,
+            w_energy=0.0,
+        )
+        ranked = rank_by_edge_score([RESULT_NO_ENERGY, RESULT_WITH_ENERGY], config=speed_first)
+        # MOSSE has 300 fps vs KCF's 150 fps — should rank first
+        assert ranked[0].tracker == "MOSSE"
+
+
+# ---------------------------------------------------------------------------
+# edge_score_leaderboard_md
+# ---------------------------------------------------------------------------
+
+class TestEdgeScoreLeaderboardMd:
+    def test_contains_tracker_names(self):
+        md = edge_score_leaderboard_md([RESULT_NO_ENERGY, RESULT_WITH_ENERGY])
+        assert "MOSSE" in md
+        assert "KCF" in md
+
+    def test_empty_returns_fallback_message(self):
+        md = edge_score_leaderboard_md([])
+        assert "No results" in md
+
+    def test_no_energy_data_omits_energy_column(self):
+        md = edge_score_leaderboard_md([RESULT_NO_ENERGY])
+        assert "E (mJ/fr)" not in md
+
+    def test_energy_data_shows_energy_column(self):
+        config = EdgeScoreConfig(energy_budget_mj=5.0)
+        md = edge_score_leaderboard_md([RESULT_WITH_ENERGY], config=config)
+        assert "E (mJ/fr)" in md
+
+    def test_config_budget_appears_in_output(self):
+        config = EdgeScoreConfig(target_fps=60.0, memory_budget_mb=256.0)
+        md = edge_score_leaderboard_md([RESULT_NO_ENERGY], config=config)
+        assert "60.0" in md
+        assert "256.0" in md
+
+    def test_markdown_table_format(self):
+        md = edge_score_leaderboard_md([RESULT_NO_ENERGY])
+        lines = md.strip().split("\n")
+        table_lines = [l for l in lines if l.startswith("|")]
+        assert len(table_lines) >= 3  # header + separator + ≥1 data row
+
+    def test_ranked_by_edge_score(self):
+        """Higher edge score should appear first in the Markdown table."""
+        md = edge_score_leaderboard_md([RESULT_NO_ENERGY, RESULT_WITH_ENERGY])
+        mosse_pos = md.find("MOSSE")
+        kcf_pos = md.find("KCF")
+        # Whichever comes first in text has the higher edge score
+        assert mosse_pos != -1 and kcf_pos != -1


### PR DESCRIPTION
## What was added

Introduces a **hardware-aware composite efficiency score** (`EdgeScore`) that ranks trackers not only by mIoU but by how well they fit real edge deployment constraints — speed, memory, and energy.

### New module: `eovot/metrics/efficiency.py`

| Symbol | Role |
|--------|------|
| `EdgeScoreConfig` | Configures device budgets (target FPS, memory MB, energy mJ/fr) and component weights |
| `EdgeScoreResult` | Per-tracker breakdown: composite score + each normalised component |
| `compute_edge_score(summary, config)` | Compute score for one tracker from its benchmark summary dict |
| `rank_by_edge_score(results, config)` | Sort a list of trackers by edge score |
| `edge_score_leaderboard_md(results, config)` | Produce a Markdown leaderboard table |

### Edge Score formula

```
edge_score = (
    w_accuracy × iou
  + w_speed    × min(fps / target_fps, 1.0)
  + w_memory   × max(0, 1 − memory_mb / memory_budget_mb)
  + w_energy   × max(0, 1 − energy_mj / energy_budget_mj)   # optional
) / (w_accuracy + w_speed + w_memory + w_energy)
```

All weights are auto-normalised to sum to 1. The energy component is excluded when energy data or budget are absent.

### Updated: `eovot/experiment/runner.py`

`ExperimentRunner._build_leaderboard` now produces **two sections**:
1. Standard accuracy ranking (mIoU, unchanged)
2. Edge-score ranking — hardware-aware composite

The `edge_score` config block is read from the YAML experiment config.

### Updated: `configs/experiments/multi_tracker.yaml`

Added a ready-to-tune `edge_score:` block with documented per-device guidance:

```yaml
edge_score:
  target_fps: 30.0          # 15 fps for IoT, 30 for real-time video
  memory_budget_mb: 512.0   # 256 for RPi 4, 512 for Jetson Nano
  energy_budget_mj: null    # set when tdp_watts is configured
  w_accuracy: 0.40
  w_speed: 0.30
  w_memory: 0.20
  w_energy: 0.10
```

### New tests: `tests/test_efficiency_metrics.py`

28 unit tests covering:
- Score bounds (always in [0, 1])
- Component clamping (FPS cap, memory/energy over-budget → 0)
- Weight scaling invariance
- Energy opt-in/opt-out
- Ranking order with custom configs
- Markdown output formatting

## Why it matters

Academic leaderboards rank solely by accuracy. Edge deployment requires balancing accuracy against latency, memory footprint, and power draw. This module lets researchers compare trackers against a concrete device profile (RPi 4, Jetson Nano, etc.) in a single reproducible number.

## Example usage

```python
from eovot.metrics.efficiency import EdgeScoreConfig, rank_by_edge_score

config = EdgeScoreConfig(
    target_fps=30.0,
    memory_budget_mb=512.0,
    energy_budget_mj=5.0,    # only when tdp_watts was set
    w_accuracy=0.40,
    w_speed=0.30,
    w_memory=0.20,
    w_energy=0.10,
)

ranked = rank_by_edge_score(all_results, config)
for r in ranked:
    print(r)
```

## No breaking changes

Existing leaderboard output is preserved as a new section header ("Accuracy Ranking"); the edge-score section is appended below it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XsYSKmC5rDhpc7hKCmsR8v)_