### PR TITLE
[feat] Statistical significance testing and Pareto frontier analysis

### DIFF
--- a/eovot/__init__.py
+++ b/eovot/__init__.py
@@ -2,6 +2,14 @@
 
 __version__ = "0.1.0"
 
-from eovot import benchmark, datasets, metrics, profiling, reporting, trackers
+from eovot import analysis, benchmark, datasets, metrics, profiling, reporting, trackers
 
-__all__ = ["benchmark", "datasets", "metrics", "profiling", "reporting", "trackers"]
+__all__ = [
+    "analysis",
+    "benchmark",
+    "datasets",
+    "metrics",
+    "profiling",
+    "reporting",
+    "trackers",
+]

--- a/eovot/analysis/__init__.py
+++ b/eovot/analysis/__init__.py
@@ -1,0 +1,28 @@
+"""Statistical analysis sub-package for EOVOT.
+
+Provides publication-quality significance testing and Pareto frontier
+analysis for comparing tracker results.
+
+Typical usage::
+
+    from eovot.analysis.statistics import TrackerStatistics
+    from eovot.analysis.pareto import ParetoAnalyzer
+
+    stats = TrackerStatistics()
+    comparisons = stats.pairwise_comparison([mosse_result, kcf_result])
+    print(stats.significance_table(comparisons))
+
+    analyzer = ParetoAnalyzer()
+    points = analyzer.analyze({"MOSSE": mosse_result, "KCF": kcf_result})
+    print(analyzer.to_markdown(points))
+"""
+
+from .statistics import ComparisonResult, TrackerStatistics
+from .pareto import ParetoAnalyzer, ParetoPoint
+
+__all__ = [
+    "TrackerStatistics",
+    "ComparisonResult",
+    "ParetoAnalyzer",
+    "ParetoPoint",
+]

--- a/eovot/analysis/pareto.py
+++ b/eovot/analysis/pareto.py
@@ -1,0 +1,182 @@
+"""Pareto frontier analysis for tracker accuracy–efficiency tradeoff.
+
+Identifies which trackers are Pareto-optimal — no other tracker is
+simultaneously more accurate *and* faster — and provides a composite
+score based on the normalised geometric mean of both axes.
+
+Typical usage::
+
+    from eovot.analysis.pareto import ParetoAnalyzer
+
+    analyzer = ParetoAnalyzer()
+    points = analyzer.analyze(
+        {"MOSSE": mosse_result, "KCF": kcf_result, "CSRT": csrt_result}
+    )
+    print(analyzer.to_markdown(points))
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+
+@dataclass
+class ParetoPoint:
+    """A tracker mapped to its accuracy and efficiency values.
+
+    Attributes:
+        tracker:    Tracker identifier.
+        accuracy:   Accuracy metric value (higher is better).
+        efficiency: Efficiency metric value (higher is better, e.g. FPS).
+        is_pareto:  ``True`` when no other tracker dominates this one on
+                    *both* axes simultaneously.
+        score:      Composite score in ``[0, 1]`` — geometric mean of the
+                    values normalised by the best tracker on each axis.
+    """
+
+    tracker: str
+    accuracy: float
+    efficiency: float
+    is_pareto: bool
+    score: float = field(default=0.0)
+
+
+class ParetoAnalyzer:
+    """Identify and describe the Pareto frontier of accuracy vs efficiency.
+
+    Given a collection of tracker result dicts the analyser determines
+    which trackers are Pareto-optimal and assigns a composite score.  The
+    accuracy–efficiency frontier is useful for selecting the right tracker
+    for a given deployment constraint (e.g. "best accuracy under 30 ms/fr").
+
+    Example::
+
+        from eovot.analysis.pareto import ParetoAnalyzer
+
+        analyzer = ParetoAnalyzer()
+        results = {
+            "MOSSE": mosse_result_dict,
+            "KCF":   kcf_result_dict,
+            "CSRT":  csrt_result_dict,
+        }
+        points = analyzer.analyze(results)
+        print(analyzer.to_markdown(points))
+    """
+
+    def analyze(
+        self,
+        results: Dict[str, Dict],
+        accuracy_metric: str = "mean_iou",
+        efficiency_metric: str = "mean_fps",
+    ) -> List[ParetoPoint]:
+        """Compute Pareto-optimality for a collection of tracker results.
+
+        Args:
+            results:           Mapping of tracker name → result dict from
+                               ``BenchmarkResult.to_dict()``.
+            accuracy_metric:   Key inside ``"summary"`` for the accuracy axis.
+                               Default: ``"mean_iou"``.
+            efficiency_metric: Key inside ``"summary"`` for the efficiency
+                               axis.  Default: ``"mean_fps"``.
+
+        Returns:
+            List of :class:`ParetoPoint` sorted by accuracy (descending).
+        """
+        if not results:
+            return []
+
+        points: List[ParetoPoint] = []
+        for name, result in results.items():
+            summary = result.get("summary", result)
+            acc = float(summary.get(accuracy_metric, 0.0))
+            eff = float(summary.get(efficiency_metric, 0.0))
+            points.append(ParetoPoint(name, acc, eff, is_pareto=False))
+
+        # Domination: q dominates p if q >= p on both axes with strict > on one.
+        dominated: set = set()
+        for i, p in enumerate(points):
+            for j, q in enumerate(points):
+                if i == j:
+                    continue
+                if q.accuracy >= p.accuracy and q.efficiency >= p.efficiency:
+                    if q.accuracy > p.accuracy or q.efficiency > p.efficiency:
+                        dominated.add(i)
+                        break
+
+        max_acc = max(p.accuracy for p in points) or 1.0
+        max_eff = max(p.efficiency for p in points) or 1.0
+
+        for i, p in enumerate(points):
+            p.is_pareto = i not in dominated
+            norm_acc = p.accuracy / max_acc
+            norm_eff = p.efficiency / max_eff
+            p.score = round(math.sqrt(norm_acc * norm_eff), 4)
+
+        return sorted(points, key=lambda p: p.accuracy, reverse=True)
+
+    def pareto_scores(self, results: Dict[str, Dict]) -> Dict[str, float]:
+        """Composite Pareto score for each tracker in ``[0, 1]``.
+
+        The score is the geometric mean of accuracy and efficiency
+        normalised by the best tracker on each axis.  Higher is better.
+
+        Args:
+            results: Mapping of tracker name → result dict.
+
+        Returns:
+            Dict mapping tracker name → score.
+        """
+        return {p.tracker: p.score for p in self.analyze(results)}
+
+    def efficiency_frontier(
+        self,
+        results: Dict[str, Dict],
+        accuracy_metric: str = "mean_iou",
+        efficiency_metric: str = "mean_fps",
+    ) -> List[Tuple[float, float, str]]:
+        """Return the Pareto frontier as ``(efficiency, accuracy, name)`` triples.
+
+        Sorted by efficiency (ascending) for easy plotting of the
+        accuracy–efficiency curve.
+
+        Args:
+            results:           Mapping of tracker name → result dict.
+            accuracy_metric:   Accuracy axis key.
+            efficiency_metric: Efficiency axis key.
+
+        Returns:
+            List of ``(efficiency, accuracy, tracker_name)`` triples for
+            Pareto-optimal points only.
+        """
+        points = self.analyze(results, accuracy_metric, efficiency_metric)
+        frontier = [
+            (p.efficiency, p.accuracy, p.tracker)
+            for p in points
+            if p.is_pareto
+        ]
+        return sorted(frontier, key=lambda t: t[0])
+
+    def to_markdown(self, points: List[ParetoPoint]) -> str:
+        """Render the Pareto analysis as a Markdown table.
+
+        Args:
+            points: Output of :meth:`analyze`.
+
+        Returns:
+            Multi-line Markdown string.
+        """
+        lines = [
+            "| Rank | Tracker | Accuracy | Efficiency (FPS) | Score | Pareto |",
+            "|-----:|---------|----------|-----------------:|------:|:------:|",
+        ]
+        for rank, p in enumerate(points, start=1):
+            flag = "✓" if p.is_pareto else ""
+            lines.append(
+                f"| {rank} | {p.tracker} | {p.accuracy:.4f} "
+                f"| {p.efficiency:.1f} | {p.score:.4f} | {flag} |"
+            )
+        return "\n".join(lines)

--- a/eovot/analysis/statistics.py
+++ b/eovot/analysis/statistics.py
@@ -1,0 +1,352 @@
+"""Statistical significance testing for tracker comparison.
+
+Implements a distribution-free pairwise significance test
+(Mann-Whitney U) with bootstrap confidence intervals and Cohen's d
+effect size.  No external dependencies beyond the Python standard
+library and NumPy are required.
+
+Typical usage::
+
+    from eovot.analysis.statistics import TrackerStatistics
+
+    stats = TrackerStatistics(alpha=0.05, n_bootstrap=2000)
+    result = stats.compare(mosse_result_dict, kcf_result_dict)
+    print(f"p={result.p_value:.4f}  significant={result.significant}")
+
+    comparisons = stats.pairwise_comparison([r1, r2, r3])
+    print(stats.significance_table(comparisons))
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+# Map user-facing metric names to keys in per-sequence result dicts.
+_METRIC_KEY: Dict[str, str] = {
+    "iou": "mean_iou",
+    "fps": "fps",
+    "latency_ms": "mean_latency_ms",
+    "memory_mb": "peak_memory_mb",
+    "energy_j": "energy_j",
+}
+
+
+@dataclass
+class ComparisonResult:
+    """Outcome of a pairwise statistical test between two trackers.
+
+    Attributes:
+        tracker_a:    Name of the first tracker.
+        tracker_b:    Name of the second tracker.
+        metric:       Metric that was compared (e.g. ``"iou"``).
+        u_statistic:  Mann-Whitney U statistic.
+        p_value:      Two-sided p-value from the normal approximation.
+        effect_size:  Cohen's d (positive means tracker_a > tracker_b).
+        mean_a:       Mean per-sequence score for tracker A.
+        mean_b:       Mean per-sequence score for tracker B.
+        ci_lower:     Lower bound of the 95% bootstrap CI for mean_a.
+        ci_upper:     Upper bound of the 95% bootstrap CI for mean_a.
+        significant:  ``True`` when ``p_value < alpha``.
+    """
+
+    tracker_a: str
+    tracker_b: str
+    metric: str
+    u_statistic: float
+    p_value: float
+    effect_size: float
+    mean_a: float
+    mean_b: float
+    ci_lower: float
+    ci_upper: float
+    significant: bool
+
+    @property
+    def winner(self) -> Optional[str]:
+        """Tracker with the higher mean, or ``None`` when not significant."""
+        if not self.significant:
+            return None
+        return self.tracker_a if self.mean_a > self.mean_b else self.tracker_b
+
+
+class TrackerStatistics:
+    """Publication-quality statistical comparison between tracker results.
+
+    Uses the Mann-Whitney U test (non-parametric, distribution-free) with
+    a normal approximation for the p-value.  Bootstrap resampling provides
+    confidence intervals on the mean score, and Cohen's d quantifies the
+    practical effect size.
+
+    All methods accept the dict format produced by
+    ``BenchmarkResult.to_dict()``::
+
+        {
+            "summary": {"tracker": "MOSSE", "mean_iou": 0.52, ...},
+            "sequences": [
+                {"sequence_name": "Basketball", "mean_iou": 0.48, "fps": 320.0, ...},
+                ...
+            ]
+        }
+
+    Args:
+        alpha:       Significance level.  Default: ``0.05``.
+        n_bootstrap: Number of bootstrap resamples for CI estimation.
+                     Default: ``2000``.
+        seed:        Random seed for reproducible bootstrap sampling.
+                     Default: ``0``.
+
+    Example::
+
+        stats = TrackerStatistics()
+        result = stats.compare(mosse_result, kcf_result, metric="iou")
+        print(stats.significance_table([result]))
+    """
+
+    def __init__(
+        self,
+        alpha: float = 0.05,
+        n_bootstrap: int = 2000,
+        seed: int = 0,
+    ) -> None:
+        self.alpha = alpha
+        self.n_bootstrap = n_bootstrap
+        self._rng = np.random.default_rng(seed)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compare(
+        self,
+        result_a: Dict,
+        result_b: Dict,
+        metric: str = "iou",
+    ) -> ComparisonResult:
+        """Pairwise Mann-Whitney U test between two tracker result dicts.
+
+        Args:
+            result_a: ``BenchmarkResult.to_dict()`` output for tracker A.
+            result_b: ``BenchmarkResult.to_dict()`` output for tracker B.
+            metric:   Per-sequence metric to compare.  Supported values:
+                      ``"iou"`` (default), ``"fps"``, ``"latency_ms"``,
+                      ``"memory_mb"``, ``"energy_j"``.
+
+        Returns:
+            :class:`ComparisonResult` with test statistic, p-value, effect
+            size, and bootstrap CI.
+
+        Raises:
+            ValueError: If the requested metric is absent from the results.
+        """
+        name_a = result_a.get("summary", {}).get("tracker", "A")
+        name_b = result_b.get("summary", {}).get("tracker", "B")
+        scores_a = self._extract_scores(result_a, metric)
+        scores_b = self._extract_scores(result_b, metric)
+
+        u_stat, p_value = self._mannwhitneyu(scores_a, scores_b)
+        effect = self._cohens_d(scores_a, scores_b)
+        ci_lo, ci_hi = self._bootstrap_ci(scores_a)
+
+        return ComparisonResult(
+            tracker_a=name_a,
+            tracker_b=name_b,
+            metric=metric,
+            u_statistic=float(u_stat),
+            p_value=float(p_value),
+            effect_size=float(effect),
+            mean_a=float(scores_a.mean()),
+            mean_b=float(scores_b.mean()),
+            ci_lower=float(ci_lo),
+            ci_upper=float(ci_hi),
+            significant=bool(p_value < self.alpha),
+        )
+
+    def pairwise_comparison(
+        self,
+        results: List[Dict],
+        metric: str = "iou",
+    ) -> List[ComparisonResult]:
+        """All-pairs pairwise comparison for a list of tracker result dicts.
+
+        Args:
+            results: List of dicts from ``BenchmarkResult.to_dict()``.
+            metric:  Metric to compare.  Default: ``"iou"``.
+
+        Returns:
+            List of :class:`ComparisonResult`, one per unique ordered pair.
+        """
+        comparisons: List[ComparisonResult] = []
+        for i, ra in enumerate(results):
+            for rb in results[i + 1 :]:
+                comparisons.append(self.compare(ra, rb, metric))
+        return comparisons
+
+    def significance_table(self, comparisons: List[ComparisonResult]) -> str:
+        """Render a Markdown significance table.
+
+        Args:
+            comparisons: Output of :meth:`pairwise_comparison` or a manual
+                list of :meth:`compare` calls.
+
+        Returns:
+            Multi-line Markdown string suitable for GitHub or a ``.md`` file.
+        """
+        header = (
+            "| Tracker A | Tracker B | Metric | U-stat | p-value "
+            "| Cohen's d | Significant |"
+        )
+        sep = (
+            "|-----------|-----------|--------|-------:|--------:"
+            "|----------:|:-----------:|"
+        )
+        lines = [header, sep]
+        for c in comparisons:
+            sig = "Yes" if c.significant else "No"
+            lines.append(
+                f"| {c.tracker_a} | {c.tracker_b} | {c.metric} "
+                f"| {c.u_statistic:.1f} | {c.p_value:.4f} "
+                f"| {c.effect_size:.3f} | {sig} |"
+            )
+        return "\n".join(lines)
+
+    def latex_table(self, comparisons: List[ComparisonResult]) -> str:
+        """Render a LaTeX booktabs significance table.
+
+        Requires ``\\usepackage{booktabs}`` in the document preamble.
+
+        Args:
+            comparisons: Output of :meth:`pairwise_comparison`.
+
+        Returns:
+            Multi-line LaTeX string ready to paste into a paper.
+        """
+        rows = []
+        for c in comparisons:
+            sig = r"\checkmark" if c.significant else "--"
+            rows.append(
+                f"  {c.tracker_a} & {c.tracker_b} & {c.metric} "
+                f"& {c.u_statistic:.1f} & {c.p_value:.4f} "
+                f"& {c.effect_size:.3f} & {sig} \\\\"
+            )
+        header = (
+            "\\begin{table}[ht]\n"
+            "\\centering\n"
+            "\\begin{tabular}{llcrrrr}\n"
+            "\\toprule\n"
+            "Tracker A & Tracker B & Metric & U & p-value & Cohen's d & Sig.\\\\\n"
+            "\\midrule\n"
+        )
+        footer = "\\bottomrule\n\\end{tabular}\n\\end{table}"
+        return header + "\n".join(rows) + "\n" + footer
+
+    def auc_confidence_interval(
+        self,
+        result: Dict,
+        ci: float = 0.95,
+    ) -> Tuple[float, float]:
+        """Bootstrap confidence interval for the mean IoU across sequences.
+
+        Args:
+            result: Dict from ``BenchmarkResult.to_dict()``.
+            ci:     Confidence level.  Default: ``0.95``.
+
+        Returns:
+            ``(lower, upper)`` bounds on mean IoU.
+        """
+        scores = self._extract_scores(result, "iou")
+        return self._bootstrap_ci(scores, ci=ci)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_scores(result: Dict, metric: str) -> np.ndarray:
+        """Pull per-sequence scalar values from a result dict."""
+        key = _METRIC_KEY.get(metric, metric)
+        sequences = result.get("sequences", [])
+        values = [float(s[key]) for s in sequences if key in s]
+        if not values:
+            available = list(sequences[0]) if sequences else []
+            raise ValueError(
+                f"No per-sequence data for metric '{metric}' (key '{key}'). "
+                f"Available keys: {available}"
+            )
+        return np.array(values, dtype=np.float64)
+
+    @staticmethod
+    def _rankdata(x: np.ndarray) -> np.ndarray:
+        """Rank array elements using the average method for ties."""
+        n = len(x)
+        order = np.argsort(x, kind="mergesort")
+        ranks = np.empty(n, dtype=np.float64)
+        i = 0
+        while i < n:
+            j = i
+            while j < n - 1 and x[order[j]] == x[order[j + 1]]:
+                j += 1
+            avg = (i + j + 2) / 2.0  # 1-indexed average rank
+            for k in range(i, j + 1):
+                ranks[order[k]] = avg
+            i = j + 1
+        return ranks
+
+    @staticmethod
+    def _normal_sf(z: float) -> float:
+        """Upper-tail survival function of the standard normal."""
+        return 0.5 * math.erfc(z / math.sqrt(2))
+
+    def _mannwhitneyu(
+        self, a: np.ndarray, b: np.ndarray
+    ) -> Tuple[float, float]:
+        """Two-sided Mann-Whitney U test using the normal approximation.
+
+        Suitable for n > 20; for very small samples the approximation is
+        less precise, but avoids any look-up table dependency.
+        """
+        n1, n2 = len(a), len(b)
+        if n1 == 0 or n2 == 0:
+            raise ValueError("Both score arrays must be non-empty.")
+        combined = np.concatenate([a, b])
+        ranks = self._rankdata(combined)
+        r1 = ranks[:n1].sum()
+        u1 = r1 - n1 * (n1 + 1) / 2.0
+        u2 = n1 * n2 - u1
+        u = min(u1, u2)
+        mu = n1 * n2 / 2.0
+        sigma = math.sqrt(n1 * n2 * (n1 + n2 + 1) / 12.0)
+        z = (u - mu) / sigma if sigma > 0 else 0.0
+        p = 2.0 * self._normal_sf(abs(z))
+        return float(u), float(min(p, 1.0))
+
+    @staticmethod
+    def _cohens_d(a: np.ndarray, b: np.ndarray) -> float:
+        """Pooled-variance Cohen's d effect size."""
+        if len(a) < 2 or len(b) < 2:
+            return 0.0
+        pooled_var = (np.var(a, ddof=1) + np.var(b, ddof=1)) / 2.0
+        return float((np.mean(a) - np.mean(b)) / math.sqrt(pooled_var + 1e-12))
+
+    def _bootstrap_ci(
+        self,
+        scores: np.ndarray,
+        ci: float = 0.95,
+    ) -> Tuple[float, float]:
+        """Bootstrap CI for the mean of ``scores``."""
+        n = len(scores)
+        boot_means = np.fromiter(
+            (
+                self._rng.choice(scores, size=n, replace=True).mean()
+                for _ in range(self.n_bootstrap)
+            ),
+            dtype=np.float64,
+            count=self.n_bootstrap,
+        )
+        lo = (1.0 - ci) / 2.0
+        hi = 1.0 - lo
+        return float(np.quantile(boot_means, lo)), float(np.quantile(boot_means, hi))

--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""analyze_results.py — post-hoc statistical analysis of EOVOT benchmark results.
+
+Performs pairwise significance tests (Mann-Whitney U), bootstrap
+confidence intervals, and Pareto frontier analysis across saved JSON
+result files produced by the EOVOT benchmark engine.
+
+Usage::
+
+    # Pairwise significance test on IoU
+    python scripts/analyze_results.py results/mosse.json results/kcf.json
+
+    # Compare multiple trackers on FPS, output LaTeX table
+    python scripts/analyze_results.py results/*.json --metric fps --latex
+
+    # Pareto frontier: accuracy vs FPS
+    python scripts/analyze_results.py results/*.json --pareto
+
+    # Bootstrap 95% CI for each tracker's mean IoU
+    python scripts/analyze_results.py results/*.json --ci
+
+    # Write output to a file
+    python scripts/analyze_results.py results/*.json --output analysis.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+
+def _load(path: str) -> Dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _tracker_name(result: Dict, fallback: str) -> str:
+    return result.get("summary", {}).get("tracker", fallback)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Statistical analysis of EOVOT benchmark results.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "results",
+        nargs="+",
+        metavar="RESULT_JSON",
+        help="One or more JSON result files produced by the benchmark engine.",
+    )
+    parser.add_argument(
+        "--metric",
+        default="iou",
+        choices=["iou", "fps", "latency_ms", "memory_mb", "energy_j"],
+        help="Per-sequence metric to compare in the significance test (default: iou).",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.05,
+        help="Significance level for the Mann-Whitney U test (default: 0.05).",
+    )
+    parser.add_argument(
+        "--n-bootstrap",
+        type=int,
+        default=2000,
+        help="Number of bootstrap resamples for CI estimation (default: 2000).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for reproducible bootstrap sampling (default: 0).",
+    )
+    parser.add_argument(
+        "--latex",
+        action="store_true",
+        help="Emit a LaTeX booktabs table instead of Markdown.",
+    )
+    parser.add_argument(
+        "--pareto",
+        action="store_true",
+        help="Show Pareto frontier analysis (accuracy vs FPS).",
+    )
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="Print 95%% bootstrap CI for each tracker's mean IoU.",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        default=None,
+        help="Write analysis to FILE instead of stdout.",
+    )
+    args = parser.parse_args()
+
+    if len(args.results) < 2 and not (args.pareto or args.ci):
+        parser.error(
+            "At least 2 result files are required for pairwise comparison. "
+            "Use --pareto or --ci for single-file analyses."
+        )
+
+    result_dicts = [_load(p) for p in args.results]
+    labels = [_tracker_name(rd, Path(p).stem) for rd, p in zip(result_dicts, args.results)]
+
+    from eovot.analysis.statistics import TrackerStatistics
+    from eovot.analysis.pareto import ParetoAnalyzer
+
+    output_lines: List[str] = []
+
+    # ------------------------------------------------------------------
+    # Pareto frontier
+    # ------------------------------------------------------------------
+    if args.pareto:
+        tracker_map = {label: rd for label, rd in zip(labels, result_dicts)}
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(tracker_map)
+        output_lines.append("## Pareto Frontier Analysis\n")
+        output_lines.append(analyzer.to_markdown(points))
+        output_lines.append("")
+
+    # ------------------------------------------------------------------
+    # Bootstrap confidence intervals
+    # ------------------------------------------------------------------
+    if args.ci:
+        stats = TrackerStatistics(
+            alpha=args.alpha, n_bootstrap=args.n_bootstrap, seed=args.seed
+        )
+        output_lines.append("## Bootstrap 95% Confidence Interval — Mean IoU\n")
+        output_lines.append("| Tracker | Mean IoU | CI Lower | CI Upper |")
+        output_lines.append("|---------|----------|---------:|---------:|")
+        for label, rd in zip(labels, result_dicts):
+            mean_iou = rd.get("summary", {}).get("mean_iou", float("nan"))
+            try:
+                lo, hi = stats.auc_confidence_interval(rd)
+            except ValueError as exc:
+                output_lines.append(f"| {label} | error: {exc} | — | — |")
+                continue
+            output_lines.append(
+                f"| {label} | {mean_iou:.4f} | {lo:.4f} | {hi:.4f} |"
+            )
+        output_lines.append("")
+
+    # ------------------------------------------------------------------
+    # Pairwise significance test
+    # ------------------------------------------------------------------
+    if len(args.results) >= 2:
+        stats = TrackerStatistics(
+            alpha=args.alpha, n_bootstrap=args.n_bootstrap, seed=args.seed
+        )
+        try:
+            comparisons = stats.pairwise_comparison(result_dicts, metric=args.metric)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        output_lines.append(
+            f"## Pairwise Significance Test  (metric={args.metric}, α={args.alpha})\n"
+        )
+        if args.latex:
+            output_lines.append(stats.latex_table(comparisons))
+        else:
+            output_lines.append(stats.significance_table(comparisons))
+        output_lines.append("")
+
+        # Brief summary
+        sig_count = sum(1 for c in comparisons if c.significant)
+        output_lines.append(
+            f"_{sig_count} of {len(comparisons)} pair(s) are statistically significant "
+            f"at α={args.alpha}._"
+        )
+
+    text = "\n".join(output_lines)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.write_text(text + "\n", encoding="utf-8")
+        print(f"Analysis written to {out_path}")
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -1,0 +1,205 @@
+"""Tests for eovot.analysis.pareto."""
+
+import pytest
+
+from eovot.analysis.pareto import ParetoAnalyzer, ParetoPoint
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(tracker: str, mean_iou: float, mean_fps: float) -> dict:
+    return {
+        "summary": {
+            "tracker": tracker,
+            "mean_iou": mean_iou,
+            "mean_fps": mean_fps,
+        },
+        "sequences": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def three_tracker_results():
+    """CSRT: high accuracy / high FPS; MOSSE: low accuracy / very high FPS;
+    KCF: medium accuracy / low FPS (dominated by CSRT on both axes)."""
+    return {
+        "CSRT": _make_result("CSRT", 0.80, 200.0),   # dominates KCF
+        "MOSSE": _make_result("MOSSE", 0.50, 500.0),  # higher FPS than all
+        "KCF": _make_result("KCF", 0.65, 150.0),      # dominated by CSRT
+    }
+
+
+# ---------------------------------------------------------------------------
+# ParetoAnalyzer.analyze()
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyze:
+    def test_returns_all_trackers(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        names = {p.tracker for p in points}
+        assert names == {"CSRT", "MOSSE", "KCF"}
+
+    def test_extreme_accuracy_tracker_is_pareto(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        pareto_names = {p.tracker for p in points if p.is_pareto}
+        assert "CSRT" in pareto_names
+
+    def test_extreme_efficiency_tracker_is_pareto(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        pareto_names = {p.tracker for p in points if p.is_pareto}
+        assert "MOSSE" in pareto_names
+
+    def test_dominated_tracker_not_pareto(self, three_tracker_results):
+        """KCF is dominated by CSRT on both accuracy (0.80>0.65) and FPS (200>150)."""
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        kcf = next(p for p in points if p.tracker == "KCF")
+        assert not kcf.is_pareto
+
+    def test_sorted_by_accuracy_descending(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        accs = [p.accuracy for p in points]
+        assert accs == sorted(accs, reverse=True)
+
+    def test_scores_in_unit_range(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        for p in points:
+            assert 0.0 <= p.score <= 1.0
+
+    def test_empty_results_returns_empty(self):
+        analyzer = ParetoAnalyzer()
+        assert analyzer.analyze({}) == []
+
+    def test_single_tracker_is_pareto(self):
+        analyzer = ParetoAnalyzer()
+        result = {"Solo": _make_result("Solo", 0.7, 100.0)}
+        points = analyzer.analyze(result)
+        assert len(points) == 1
+        assert points[0].is_pareto
+
+    def test_two_non_dominated_trackers_both_pareto(self):
+        """When one tracker wins on accuracy and the other on FPS, both are Pareto."""
+        results = {
+            "Fast": _make_result("Fast", 0.4, 400.0),
+            "Accurate": _make_result("Accurate", 0.9, 40.0),
+        }
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(results)
+        assert all(p.is_pareto for p in points)
+
+    def test_dominated_tracker_removed_from_frontier(self):
+        """A tracker strictly worse on both axes should be dominated."""
+        results = {
+            "Best": _make_result("Best", 0.9, 200.0),
+            "Worst": _make_result("Worst", 0.5, 100.0),
+        }
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(results)
+        worst = next(p for p in points if p.tracker == "Worst")
+        assert not worst.is_pareto
+
+    def test_custom_metrics(self):
+        results = {
+            "A": {
+                "summary": {"tracker": "A", "success_auc": 0.8, "latency_ms": 5.0},
+                "sequences": [],
+            },
+            "B": {
+                "summary": {"tracker": "B", "success_auc": 0.5, "latency_ms": 2.0},
+                "sequences": [],
+            },
+        }
+        analyzer = ParetoAnalyzer()
+        # Use latency_ms as efficiency (lower is better — not ideal, but tests the plumbing)
+        points = analyzer.analyze(
+            results, accuracy_metric="success_auc", efficiency_metric="latency_ms"
+        )
+        names = {p.tracker for p in points}
+        assert names == {"A", "B"}
+
+
+# ---------------------------------------------------------------------------
+# ParetoAnalyzer.pareto_scores()
+# ---------------------------------------------------------------------------
+
+
+class TestParetoScores:
+    def test_keys_match_tracker_names(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        scores = analyzer.pareto_scores(three_tracker_results)
+        assert set(scores) == {"CSRT", "MOSSE", "KCF"}
+
+    def test_scores_in_unit_range(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        scores = analyzer.pareto_scores(three_tracker_results)
+        for v in scores.values():
+            assert 0.0 <= v <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# ParetoAnalyzer.efficiency_frontier()
+# ---------------------------------------------------------------------------
+
+
+class TestEfficiencyFrontier:
+    def test_returns_only_pareto_points(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        frontier = analyzer.efficiency_frontier(three_tracker_results)
+        # Only CSRT and MOSSE are Pareto → 2 points
+        assert len(frontier) == 2
+
+    def test_sorted_by_efficiency_ascending(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        frontier = analyzer.efficiency_frontier(three_tracker_results)
+        effs = [t[0] for t in frontier]
+        assert effs == sorted(effs)
+
+    def test_tuple_structure(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        frontier = analyzer.efficiency_frontier(three_tracker_results)
+        for item in frontier:
+            eff, acc, name = item
+            assert isinstance(eff, float)
+            assert isinstance(acc, float)
+            assert isinstance(name, str)
+
+
+# ---------------------------------------------------------------------------
+# ParetoAnalyzer.to_markdown()
+# ---------------------------------------------------------------------------
+
+
+class TestToMarkdown:
+    def test_header_present(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        md = analyzer.to_markdown(points)
+        assert "| Rank |" in md
+        assert "| Tracker |" in md
+
+    def test_pareto_checkmark_present(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        md = analyzer.to_markdown(points)
+        assert "✓" in md
+
+    def test_all_tracker_names_present(self, three_tracker_results):
+        analyzer = ParetoAnalyzer()
+        points = analyzer.analyze(three_tracker_results)
+        md = analyzer.to_markdown(points)
+        for name in ["CSRT", "MOSSE", "KCF"]:
+            assert name in md

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,229 @@
+"""Tests for eovot.analysis.statistics."""
+
+import numpy as np
+import pytest
+
+from eovot.analysis.statistics import ComparisonResult, TrackerStatistics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(tracker: str, ious: list, fps_list: list) -> dict:
+    """Build a minimal BenchmarkResult.to_dict()-compatible dict."""
+    sequences = [
+        {
+            "sequence_name": f"seq{i}",
+            "mean_iou": ious[i],
+            "fps": fps_list[i],
+            "mean_latency_ms": 1_000.0 / max(fps_list[i], 1),
+            "peak_memory_mb": 50.0,
+        }
+        for i in range(len(ious))
+    ]
+    return {
+        "summary": {
+            "tracker": tracker,
+            "mean_iou": float(np.mean(ious)),
+            "mean_fps": float(np.mean(fps_list)),
+        },
+        "sequences": sequences,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def stats():
+    return TrackerStatistics(alpha=0.05, n_bootstrap=500, seed=42)
+
+
+@pytest.fixture()
+def high_iou_result():
+    rng = np.random.default_rng(0)
+    ious = rng.uniform(0.70, 0.90, 50).tolist()
+    return _make_result("CSRT", ious, [50.0] * 50)
+
+
+@pytest.fixture()
+def low_iou_result():
+    rng = np.random.default_rng(1)
+    ious = rng.uniform(0.10, 0.30, 50).tolist()
+    return _make_result("MOSSE", ious, [500.0] * 50)
+
+
+@pytest.fixture()
+def identical_result():
+    """Two results built from the same scores."""
+    rng = np.random.default_rng(2)
+    ious = rng.uniform(0.50, 0.60, 30).tolist()
+    fps = [100.0] * 30
+    return (
+        _make_result("TrackerA", ious, fps),
+        _make_result("TrackerB", ious, fps),
+    )
+
+
+# ---------------------------------------------------------------------------
+# compare()
+# ---------------------------------------------------------------------------
+
+
+class TestCompare:
+    def test_returns_comparison_result(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result)
+        assert isinstance(result, ComparisonResult)
+
+    def test_significant_when_distributions_differ(
+        self, stats, high_iou_result, low_iou_result
+    ):
+        result = stats.compare(high_iou_result, low_iou_result)
+        assert result.significant
+        assert result.p_value < 0.05
+
+    def test_not_significant_identical_distributions(self, stats, identical_result):
+        ra, rb = identical_result
+        result = stats.compare(ra, rb)
+        assert not result.significant
+
+    def test_tracker_names_propagated(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result)
+        assert result.tracker_a == "CSRT"
+        assert result.tracker_b == "MOSSE"
+
+    def test_effect_size_sign(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result)
+        # CSRT has higher IoU → positive Cohen's d
+        assert result.effect_size > 0
+
+    def test_ci_contains_mean_a(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result)
+        assert result.ci_lower <= result.mean_a <= result.ci_upper
+
+    def test_ci_is_ordered(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result)
+        assert result.ci_lower <= result.ci_upper
+
+    def test_fps_metric(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result, metric="fps")
+        assert result.metric == "fps"
+        assert 0.0 <= result.p_value <= 1.0
+
+    def test_winner_when_significant(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result)
+        assert result.winner == "CSRT"
+
+    def test_winner_none_when_not_significant(self, stats, identical_result):
+        ra, rb = identical_result
+        result = stats.compare(ra, rb)
+        assert result.winner is None
+
+    def test_p_value_in_unit_interval(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result)
+        assert 0.0 <= result.p_value <= 1.0
+
+    def test_metric_stored_on_result(self, stats, high_iou_result, low_iou_result):
+        result = stats.compare(high_iou_result, low_iou_result, metric="iou")
+        assert result.metric == "iou"
+
+    def test_missing_metric_raises(self, stats, high_iou_result, low_iou_result):
+        with pytest.raises(ValueError, match="No per-sequence data"):
+            stats.compare(high_iou_result, low_iou_result, metric="energy_j")
+
+
+# ---------------------------------------------------------------------------
+# pairwise_comparison()
+# ---------------------------------------------------------------------------
+
+
+class TestPairwiseComparison:
+    def test_three_trackers_produces_three_pairs(
+        self, stats, high_iou_result, low_iou_result
+    ):
+        rng = np.random.default_rng(3)
+        mid = _make_result("KCF", rng.uniform(0.4, 0.6, 50).tolist(), [150.0] * 50)
+        results = stats.pairwise_comparison(
+            [high_iou_result, low_iou_result, mid]
+        )
+        # C(3, 2) = 3 pairs
+        assert len(results) == 3
+
+    def test_two_trackers_produces_one_pair(
+        self, stats, high_iou_result, low_iou_result
+    ):
+        results = stats.pairwise_comparison([high_iou_result, low_iou_result])
+        assert len(results) == 1
+
+    def test_empty_list_returns_empty(self, stats):
+        assert stats.pairwise_comparison([]) == []
+
+    def test_single_tracker_returns_empty(self, stats, high_iou_result):
+        assert stats.pairwise_comparison([high_iou_result]) == []
+
+
+# ---------------------------------------------------------------------------
+# significance_table()
+# ---------------------------------------------------------------------------
+
+
+class TestSignificanceTable:
+    def test_markdown_header_present(self, stats, high_iou_result, low_iou_result):
+        comps = stats.pairwise_comparison([high_iou_result, low_iou_result])
+        table = stats.significance_table(comps)
+        assert "| Tracker A |" in table
+        assert "| Tracker B |" in table
+
+    def test_tracker_names_in_table(self, stats, high_iou_result, low_iou_result):
+        comps = stats.pairwise_comparison([high_iou_result, low_iou_result])
+        table = stats.significance_table(comps)
+        assert "CSRT" in table
+        assert "MOSSE" in table
+
+    def test_significance_column_present(self, stats, high_iou_result, low_iou_result):
+        comps = stats.pairwise_comparison([high_iou_result, low_iou_result])
+        table = stats.significance_table(comps)
+        assert "Yes" in table or "No" in table
+
+
+class TestLatexTable:
+    def test_booktabs_structure(self, stats, high_iou_result, low_iou_result):
+        comps = stats.pairwise_comparison([high_iou_result, low_iou_result])
+        latex = stats.latex_table(comps)
+        assert r"\begin{table}" in latex
+        assert r"\toprule" in latex
+        assert r"\midrule" in latex
+        assert r"\bottomrule" in latex
+        assert r"\end{table}" in latex
+
+    def test_checkmark_when_significant(self, stats, high_iou_result, low_iou_result):
+        comps = stats.pairwise_comparison([high_iou_result, low_iou_result])
+        latex = stats.latex_table(comps)
+        assert r"\checkmark" in latex
+
+
+# ---------------------------------------------------------------------------
+# auc_confidence_interval()
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapCI:
+    def test_lower_le_upper(self, stats, high_iou_result):
+        lo, hi = stats.auc_confidence_interval(high_iou_result)
+        assert lo <= hi
+
+    def test_ci_contains_mean(self, stats, high_iou_result):
+        mean_iou = high_iou_result["summary"]["mean_iou"]
+        lo, hi = stats.auc_confidence_interval(high_iou_result, ci=0.95)
+        assert lo <= mean_iou <= hi
+
+    def test_tighter_ci_at_higher_confidence(self, stats, high_iou_result):
+        lo_90, hi_90 = stats.auc_confidence_interval(high_iou_result, ci=0.90)
+        lo_99, hi_99 = stats.auc_confidence_interval(high_iou_result, ci=0.99)
+        width_90 = hi_90 - lo_90
+        width_99 = hi_99 - lo_99
+        assert width_99 >= width_90


### PR DESCRIPTION
## Summary

Introduces `eovot/analysis/` — a new sub-package that enables **publication-quality comparison** of tracker results with no external dependencies beyond NumPy and the Python standard library.

### What was added

**`eovot/analysis/statistics.py` — `TrackerStatistics`**
- **Mann-Whitney U test** (pure-NumPy implementation, no scipy) for pairwise significance testing between any two tracker result dicts
- **Bootstrap confidence intervals** (configurable resamples, default 2000) on mean IoU for each tracker
- **Cohen's d** effect size to quantify practical significance beyond the p-value
- Renders output as **Markdown** or **LaTeX booktabs** tables, ready for papers and GitHub READMEs
- Supports all benchmark metrics: `iou`, `fps`, `latency_ms`, `memory_mb`, `energy_j`

**`eovot/analysis/pareto.py` — `ParetoAnalyzer`**
- Identifies **Pareto-optimal trackers** on the accuracy–FPS plane (no other tracker is simultaneously more accurate *and* faster)
- Assigns a **composite score** (geometric mean of normalised accuracy × efficiency) for ranking
- Exposes the efficiency frontier as `(fps, iou, name)` triples for plotting
- Renders as a Markdown table with ✓ markers on optimal points

**`scripts/analyze_results.py` — CLI tool**
- Post-hoc analysis of saved JSON result files from the benchmark engine
- Flags: `--pareto`, `--ci`, `--metric`, `--latex`, `--output`

**44 unit tests** across `tests/test_statistics.py` and `tests/test_pareto.py`

### Why it matters

Current reporting (JSON, CSV, leaderboard) presents raw numbers but provides no statistical foundation for claims like "tracker A outperforms tracker B". This module closes that gap:

- Enables **reproducible hypothesis testing** between tracker variants
- The **Pareto frontier** directly supports the edge-deployment narrative: "pick the tracker that maximises accuracy *given* your FPS budget"
- LaTeX output is paste-ready for conference papers

### Example usage

```python
from eovot.analysis.statistics import TrackerStatistics
from eovot.analysis.pareto import ParetoAnalyzer

# Pairwise significance test
stats = TrackerStatistics()
result = stats.compare(mosse_result_dict, kcf_result_dict, metric="iou")
print(f"p={result.p_value:.4f}  significant={result.significant}  winner={result.winner}")

# All-pairs table
comparisons = stats.pairwise_comparison([mosse_result, kcf_result, csrt_result])
print(stats.significance_table(comparisons))   # Markdown
print(stats.latex_table(comparisons))          # LaTeX

# Bootstrap CI
lo, hi = stats.auc_confidence_interval(mosse_result)
print(f"MOSSE mean IoU: {mosse_result['summary']['mean_iou']:.4f}  95% CI [{lo:.4f}, {hi:.4f}]")

# Pareto analysis
analyzer = ParetoAnalyzer()
points = analyzer.analyze({"MOSSE": mosse_result, "KCF": kcf_result, "CSRT": csrt_result})
print(analyzer.to_markdown(points))
```

```bash
# CLI
python scripts/analyze_results.py results/mosse.json results/kcf.json results/csrt.json \
    --pareto --ci --metric iou --output analysis.md
```

### No breaking changes

All additions are in a new `eovot/analysis/` sub-package. Existing modules are untouched except for a one-line import addition in `eovot/__init__.py`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DsTbU5uV8Sr9r31gFXQ7FY)_