### PR TITLE
[feat] Add edge deployment constraint profiles and evaluator

### DIFF
--- a/eovot/__init__.py
+++ b/eovot/__init__.py
@@ -2,6 +2,14 @@
 
 __version__ = "0.1.0"
 
-from eovot import benchmark, datasets, metrics, profiling, reporting, trackers
+from eovot import benchmark, constraints, datasets, metrics, profiling, reporting, trackers
 
-__all__ = ["benchmark", "datasets", "metrics", "profiling", "reporting", "trackers"]
+__all__ = [
+    "benchmark",
+    "constraints",
+    "datasets",
+    "metrics",
+    "profiling",
+    "reporting",
+    "trackers",
+]

--- a/eovot/constraints/__init__.py
+++ b/eovot/constraints/__init__.py
@@ -1,0 +1,40 @@
+"""Edge deployment constraint system for EOVOT.
+
+Provides :class:`~eovot.constraints.profiles.EdgeProfile` dataclass for
+declaring hardware constraints and :class:`~eovot.constraints.evaluator.ConstraintEvaluator`
+for checking benchmark results against those constraints.
+
+Quick start::
+
+    from eovot.constraints import ConstraintEvaluator, RASPBERRY_PI_4
+
+    ev = ConstraintEvaluator()
+    report = ev.evaluate(benchmark_result, RASPBERRY_PI_4)
+    print(report.summary())
+"""
+
+from .evaluator import ConstraintCheck, ConstraintEvaluator, ConstraintReport
+from .profiles import (
+    EMBEDDED_MICRO,
+    JETSON_NANO,
+    LAPTOP_CPU,
+    MOBILE_CLASS,
+    PREDEFINED_PROFILES,
+    RASPBERRY_PI_4,
+    EdgeProfile,
+)
+
+__all__ = [
+    # Profile types and singletons
+    "EdgeProfile",
+    "RASPBERRY_PI_4",
+    "JETSON_NANO",
+    "MOBILE_CLASS",
+    "EMBEDDED_MICRO",
+    "LAPTOP_CPU",
+    "PREDEFINED_PROFILES",
+    # Evaluator types
+    "ConstraintCheck",
+    "ConstraintReport",
+    "ConstraintEvaluator",
+]

--- a/eovot/constraints/evaluator.py
+++ b/eovot/constraints/evaluator.py
@@ -1,0 +1,300 @@
+"""Edge constraint evaluator for EOVOT benchmark results.
+
+:class:`ConstraintEvaluator` compares measured profiling data from a
+:class:`~eovot.benchmark.engine.BenchmarkResult` against the thresholds
+defined in an :class:`~eovot.constraints.profiles.EdgeProfile` and
+produces a per-constraint pass/fail report with signed margins.
+
+This answers the core EOVOT research question:
+**"Is this tracker deployable on this device?"**
+
+Typical usage::
+
+    from eovot.benchmark.engine import BenchmarkEngine
+    from eovot.constraints.evaluator import ConstraintEvaluator
+    from eovot.constraints.profiles import RASPBERRY_PI_4, JETSON_NANO
+
+    engine  = BenchmarkEngine(verbose=False, tdp_watts=6.0)
+    result  = engine.run(tracker, dataset, dataset_name="OTB100")
+
+    ev = ConstraintEvaluator()
+    report = ev.evaluate(result, RASPBERRY_PI_4)
+    print(report.summary())
+    # → "Overall: DEPLOYABLE" or "NOT DEPLOYABLE"
+
+    table = ev.markdown_table([report], RASPBERRY_PI_4)
+    print(table)  # paste into README / paper
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ..benchmark.engine import BenchmarkResult
+from .profiles import EdgeProfile
+
+
+@dataclass
+class ConstraintCheck:
+    """Result of evaluating a single hardware constraint.
+
+    Attributes:
+        constraint:  Name of the constraint (e.g. ``"min_fps"``).
+        passed:      ``True`` when the tracker satisfies this constraint.
+        measured:    Metric value observed in the benchmark.
+        limit:       Threshold from the :class:`~eovot.constraints.profiles.EdgeProfile`.
+        margin:      Signed headroom.  Positive means passing with room to spare;
+                     negative means the constraint is violated by that amount.
+                     For lower-bound constraints (FPS) ``margin = measured - limit``.
+                     For upper-bound constraints (memory, latency, energy)
+                     ``margin = limit - measured``.
+    """
+
+    constraint: str
+    passed: bool
+    measured: float
+    limit: float
+    margin: float
+
+    def __str__(self) -> str:
+        status = "PASS" if self.passed else "FAIL"
+        return (
+            f"[{status}] {self.constraint}: "
+            f"measured={self.measured:.3f}, "
+            f"limit={self.limit:.3f}, "
+            f"margin={self.margin:+.3f}"
+        )
+
+
+@dataclass
+class ConstraintReport:
+    """Complete deployability assessment for one tracker on one edge device.
+
+    Attributes:
+        tracker_name: Name of the evaluated tracker.
+        profile_name: Name of the edge device profile.
+        checks:       Individual :class:`ConstraintCheck` results.
+        overall_pass: ``True`` only when *every* checked constraint is satisfied.
+        missing_data: Constraints that could not be checked because the
+                      corresponding benchmark metric was not collected
+                      (e.g. energy requires ``tdp_watts`` to be set).
+    """
+
+    tracker_name: str
+    profile_name: str
+    checks: List[ConstraintCheck] = field(default_factory=list)
+    overall_pass: bool = False
+    missing_data: List[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        """Return a human-readable multi-line summary block."""
+        verdict = "DEPLOYABLE" if self.overall_pass else "NOT DEPLOYABLE"
+        lines = [
+            f"Constraint Report: {self.tracker_name} → {self.profile_name}",
+            f"Overall: {verdict}",
+            "-" * 55,
+        ]
+        for check in self.checks:
+            lines.append(f"  {check}")
+        for name in self.missing_data:
+            lines.append(f"  [SKIP] {name}: metric not available")
+        return "\n".join(lines)
+
+    def to_dict(self) -> Dict:
+        """Serialise to a plain dict for JSON export."""
+        return {
+            "tracker_name": self.tracker_name,
+            "profile_name": self.profile_name,
+            "overall_pass": self.overall_pass,
+            "checks": [
+                {
+                    "constraint": c.constraint,
+                    "passed": c.passed,
+                    "measured": round(c.measured, 4),
+                    "limit": round(c.limit, 4),
+                    "margin": round(c.margin, 4),
+                }
+                for c in self.checks
+            ],
+            "missing_data": self.missing_data,
+        }
+
+
+class ConstraintEvaluator:
+    """Assess whether benchmark results satisfy edge deployment constraints.
+
+    Checks four constraints derived from :class:`~eovot.constraints.profiles.EdgeProfile`:
+
+    1. **FPS** — lower bound: tracker must be fast enough for the target FPS.
+    2. **Peak memory** — upper bound: must not exceed device RAM budget.
+    3. **Latency** — upper bound: derived from FPS (``1000 / fps`` ms per frame).
+    4. **Energy per frame** — upper bound: checked only when the profile
+       defines ``max_energy_mj_per_frame`` *and* energy was profiled in the
+       benchmark (i.e. ``tdp_watts`` was set on the engine).
+
+    Example::
+
+        from eovot.constraints.profiles import RASPBERRY_PI_4, PREDEFINED_PROFILES
+        from eovot.constraints.evaluator import ConstraintEvaluator
+
+        ev = ConstraintEvaluator()
+
+        # Single tracker, single device
+        report = ev.evaluate(result, RASPBERRY_PI_4)
+        print(report.summary())
+
+        # Multiple trackers, multiple devices — returns a 2-D list
+        for profile in PREDEFINED_PROFILES.values():
+            reports = ev.evaluate_many(results, profile)
+            print(ev.markdown_table(reports, profile))
+    """
+
+    def evaluate(
+        self,
+        result: BenchmarkResult,
+        profile: EdgeProfile,
+    ) -> ConstraintReport:
+        """Check one benchmark result against one edge profile.
+
+        Args:
+            result:  Aggregated result from
+                     :class:`~eovot.benchmark.engine.BenchmarkEngine`.
+            profile: Target device constraints.
+
+        Returns:
+            :class:`ConstraintReport` with per-constraint pass/fail details
+            and an ``overall_pass`` flag.
+        """
+        report = ConstraintReport(
+            tracker_name=result.tracker_name,
+            profile_name=profile.name,
+        )
+
+        fps = result.mean_fps
+        report.checks.append(ConstraintCheck(
+            constraint="min_fps",
+            passed=fps >= profile.min_fps,
+            measured=fps,
+            limit=profile.min_fps,
+            margin=fps - profile.min_fps,
+        ))
+
+        mem = result.peak_memory_mb
+        report.checks.append(ConstraintCheck(
+            constraint="max_memory_mb",
+            passed=mem <= profile.max_memory_mb,
+            measured=mem,
+            limit=profile.max_memory_mb,
+            margin=profile.max_memory_mb - mem,
+        ))
+
+        # Latency is derived from FPS; avoids requiring a separate profiling field.
+        latency_ms = 1000.0 / fps if fps > 0 else float("inf")
+        report.checks.append(ConstraintCheck(
+            constraint="max_latency_ms",
+            passed=latency_ms <= profile.max_latency_ms,
+            measured=latency_ms,
+            limit=profile.max_latency_ms,
+            margin=profile.max_latency_ms - latency_ms,
+        ))
+
+        if profile.max_energy_mj_per_frame is not None:
+            energy = result.mean_energy_per_frame_mj
+            if energy is not None:
+                report.checks.append(ConstraintCheck(
+                    constraint="max_energy_mj_per_frame",
+                    passed=energy <= profile.max_energy_mj_per_frame,
+                    measured=energy,
+                    limit=profile.max_energy_mj_per_frame,
+                    margin=profile.max_energy_mj_per_frame - energy,
+                ))
+            else:
+                report.missing_data.append(
+                    "max_energy_mj_per_frame (enable tdp_watts in BenchmarkEngine)"
+                )
+
+        report.overall_pass = all(c.passed for c in report.checks)
+        return report
+
+    def evaluate_many(
+        self,
+        results: List[BenchmarkResult],
+        profile: EdgeProfile,
+    ) -> List[ConstraintReport]:
+        """Evaluate multiple trackers against the same edge profile.
+
+        Args:
+            results: One :class:`~eovot.benchmark.engine.BenchmarkResult`
+                     per tracker.
+            profile: Target device constraints shared by all evaluations.
+
+        Returns:
+            List of :class:`ConstraintReport` objects in the same order as
+            *results*.
+        """
+        return [self.evaluate(r, profile) for r in results]
+
+    @staticmethod
+    def markdown_table(
+        reports: List[ConstraintReport],
+        profile: EdgeProfile,
+    ) -> str:
+        """Format constraint reports as a Markdown table.
+
+        Produces a table suitable for README files, paper appendices, or
+        the experiment leaderboard.
+
+        Args:
+            reports: Reports from :meth:`evaluate` or :meth:`evaluate_many`.
+            profile: The edge profile used (supplies column headers).
+
+        Returns:
+            Multi-line Markdown string.
+        """
+        lines = [
+            f"## Edge Constraint Compliance: {profile.name}\n",
+            f"*{profile.description}*\n",
+            (
+                f"| Tracker "
+                f"| FPS (≥{profile.min_fps:.0f}) "
+                f"| Mem MB (≤{profile.max_memory_mb:.0f}) "
+                f"| Latency ms (≤{profile.max_latency_ms:.0f}) "
+                + (
+                    f"| Energy mJ/fr (≤{profile.max_energy_mj_per_frame:.0f}) "
+                    if profile.max_energy_mj_per_frame is not None
+                    else ""
+                )
+                + "| Deployable |"
+            ),
+            (
+                "|---------|-----------|---------|------------|"
+                + ("------------|" if profile.max_energy_mj_per_frame is not None else "")
+                + "-----------|"
+            ),
+        ]
+
+        for rpt in reports:
+            checks: Dict[str, Optional[ConstraintCheck]] = {
+                c.constraint: c for c in rpt.checks
+            }
+
+            def _cell(key: str) -> str:
+                c = checks.get(key)
+                if c is None:
+                    return "N/A"
+                mark = "✓" if c.passed else "✗"
+                return f"{c.measured:.1f} {mark}"
+
+            row = (
+                f"| {rpt.tracker_name} "
+                f"| {_cell('min_fps')} "
+                f"| {_cell('max_memory_mb')} "
+                f"| {_cell('max_latency_ms')} "
+            )
+            if profile.max_energy_mj_per_frame is not None:
+                row += f"| {_cell('max_energy_mj_per_frame')} "
+            row += f"| {'**YES**' if rpt.overall_pass else 'NO'} |"
+            lines.append(row)
+
+        return "\n".join(lines)

--- a/eovot/constraints/profiles.py
+++ b/eovot/constraints/profiles.py
@@ -1,0 +1,151 @@
+"""Predefined edge device profiles for constraint-aware tracker evaluation.
+
+Each :class:`EdgeProfile` captures the deployment constraints of a target
+hardware platform.  The :class:`~eovot.constraints.evaluator.ConstraintEvaluator`
+compares benchmark measurements against these thresholds to produce a
+deployability verdict for every tracker/device pair.
+
+Predefined profiles cover the most common edge deployment targets in
+robotics and embedded computer vision:
+
+* :data:`RASPBERRY_PI_4`   — ARM Cortex-A72, ~6 W TDP
+* :data:`JETSON_NANO`      — ARM Cortex-A57 + 128-core Maxwell GPU, ~10 W TDP
+* :data:`MOBILE_CLASS`     — Smartphone-class ARM big.LITTLE, ~3 W CPU draw
+* :data:`EMBEDDED_MICRO`   — Ultra-low-power MCU class, tight memory budget
+* :data:`LAPTOP_CPU`       — Modern x86 laptop, unconstrained baseline reference
+
+Custom profiles can be created with :class:`EdgeProfile` directly::
+
+    from eovot.constraints.profiles import EdgeProfile
+
+    my_profile = EdgeProfile(
+        name="Custom FPGA Board",
+        min_fps=20.0,
+        max_memory_mb=128.0,
+        max_latency_ms=50.0,
+        max_energy_mj_per_frame=20.0,
+        description="Xilinx ZCU104, 10 W power budget",
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+@dataclass
+class EdgeProfile:
+    """Hardware deployment constraints for a target edge device.
+
+    All numeric thresholds define the boundary a tracker must stay within
+    to be considered deployable on the device.  FPS is a *lower* bound
+    (the tracker must be fast enough); all others are *upper* bounds.
+
+    Attributes:
+        name: Human-readable device identifier used in reports.
+        min_fps: Minimum acceptable throughput (frames per second).
+            A tracker running slower than this cannot keep up with
+            the camera stream in real-time.
+        max_memory_mb: Maximum allowable peak RAM usage in megabytes.
+            Reflects the usable RAM budget on the target device after
+            the OS and other processes have claimed their share.
+        max_latency_ms: Maximum allowable per-frame processing latency
+            in milliseconds.  Derived from the required response time
+            for the application (e.g. 33 ms ≈ 30 FPS real-time).
+        max_energy_mj_per_frame: Maximum energy budget per frame in
+            milli-Joules.  Set to ``None`` when energy is unconstrained
+            (e.g. desktop / server deployments).
+        description: Free-text notes about the device or profile origin.
+    """
+
+    name: str
+    min_fps: float
+    max_memory_mb: float
+    max_latency_ms: float
+    max_energy_mj_per_frame: Optional[float] = None
+    description: str = field(default="")
+
+    def __post_init__(self) -> None:
+        if self.min_fps <= 0:
+            raise ValueError(f"min_fps must be positive, got {self.min_fps}")
+        if self.max_memory_mb <= 0:
+            raise ValueError(f"max_memory_mb must be positive, got {self.max_memory_mb}")
+        if self.max_latency_ms <= 0:
+            raise ValueError(f"max_latency_ms must be positive, got {self.max_latency_ms}")
+        if self.max_energy_mj_per_frame is not None and self.max_energy_mj_per_frame <= 0:
+            raise ValueError(
+                f"max_energy_mj_per_frame must be positive or None, "
+                f"got {self.max_energy_mj_per_frame}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Predefined device profiles
+# ---------------------------------------------------------------------------
+
+RASPBERRY_PI_4 = EdgeProfile(
+    name="Raspberry Pi 4",
+    min_fps=10.0,
+    max_memory_mb=512.0,
+    max_latency_ms=100.0,
+    max_energy_mj_per_frame=60.0,
+    description="ARM Cortex-A72 @ 1.8 GHz, 4 GB LPDDR4, ~6 W TDP",
+)
+"""Raspberry Pi 4 Model B — the most common low-cost edge platform."""
+
+JETSON_NANO = EdgeProfile(
+    name="NVIDIA Jetson Nano",
+    min_fps=15.0,
+    max_memory_mb=1024.0,
+    max_latency_ms=67.0,
+    max_energy_mj_per_frame=100.0,
+    description="ARM Cortex-A57 @ 1.43 GHz + 128-core Maxwell GPU, 4 GB RAM, ~10 W TDP",
+)
+"""NVIDIA Jetson Nano — entry-level GPU-accelerated edge platform."""
+
+MOBILE_CLASS = EdgeProfile(
+    name="Mobile Device",
+    min_fps=25.0,
+    max_memory_mb=256.0,
+    max_latency_ms=40.0,
+    max_energy_mj_per_frame=30.0,
+    description="Smartphone ARM big.LITTLE ~2.5 GHz, 256 MB tracking budget, ~3 W CPU draw",
+)
+"""Smartphone-class CPU — represents augmented-reality / mobile CV applications."""
+
+EMBEDDED_MICRO = EdgeProfile(
+    name="Embedded Microcontroller",
+    min_fps=5.0,
+    max_memory_mb=64.0,
+    max_latency_ms=200.0,
+    max_energy_mj_per_frame=10.0,
+    description="Ultra-low-power MCU class, 64 MB RAM hard limit, tight energy budget",
+)
+"""Ultra-constrained microcontroller class — e.g. STM32 H7 or similar."""
+
+LAPTOP_CPU = EdgeProfile(
+    name="Laptop CPU",
+    min_fps=30.0,
+    max_memory_mb=4096.0,
+    max_latency_ms=33.0,
+    max_energy_mj_per_frame=None,
+    description="Modern x86 laptop CPU, unconstrained energy — baseline reference profile",
+)
+"""Laptop CPU baseline — unconstrained energy, used as a reference tier."""
+
+PREDEFINED_PROFILES: Dict[str, EdgeProfile] = {
+    "raspberry_pi_4": RASPBERRY_PI_4,
+    "jetson_nano": JETSON_NANO,
+    "mobile": MOBILE_CLASS,
+    "embedded_micro": EMBEDDED_MICRO,
+    "laptop_cpu": LAPTOP_CPU,
+}
+"""Registry mapping short keys to predefined :class:`EdgeProfile` instances.
+
+Use this to look up a profile by name in scripts and config files::
+
+    from eovot.constraints.profiles import PREDEFINED_PROFILES
+
+    profile = PREDEFINED_PROFILES["raspberry_pi_4"]
+"""

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,313 @@
+"""Tests for the edge constraint evaluation system (eovot/constraints/)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.benchmark.engine import BenchmarkResult, SequenceResult
+from eovot.constraints.evaluator import ConstraintCheck, ConstraintEvaluator, ConstraintReport
+from eovot.constraints.profiles import (
+    EMBEDDED_MICRO,
+    JETSON_NANO,
+    LAPTOP_CPU,
+    MOBILE_CLASS,
+    PREDEFINED_PROFILES,
+    RASPBERRY_PI_4,
+    EdgeProfile,
+)
+from eovot.profiling.profiler import ProfilingResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _profiling(fps: float = 50.0, peak_memory_mb: float = 128.0) -> ProfilingResult:
+    latency_ms = 1000.0 / fps
+    return ProfilingResult(
+        tracker_name="test",
+        frame_count=100,
+        fps=fps,
+        latency_mean_ms=latency_ms,
+        latency_std_ms=latency_ms * 0.05,
+        latency_p95_ms=latency_ms * 1.2,
+        peak_memory_mb=peak_memory_mb,
+    )
+
+
+def _benchmark_result(
+    fps: float = 50.0,
+    peak_memory_mb: float = 128.0,
+    tracker_name: str = "TestTracker",
+) -> BenchmarkResult:
+    seq = SequenceResult(
+        sequence_name="seq_0",
+        ious=np.full(50, 0.6),
+        profiling=_profiling(fps=fps, peak_memory_mb=peak_memory_mb),
+    )
+    result = BenchmarkResult(tracker_name=tracker_name, dataset_name="SyntheticDB")
+    result.sequence_results.append(seq)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# EdgeProfile
+# ---------------------------------------------------------------------------
+
+class TestEdgeProfile:
+    def test_all_predefined_keys_present(self):
+        assert set(PREDEFINED_PROFILES) == {
+            "raspberry_pi_4", "jetson_nano", "mobile", "embedded_micro", "laptop_cpu"
+        }
+
+    def test_raspberry_pi_4_attributes(self):
+        p = RASPBERRY_PI_4
+        assert p.min_fps == pytest.approx(10.0)
+        assert p.max_memory_mb == pytest.approx(512.0)
+        assert p.max_latency_ms == pytest.approx(100.0)
+        assert p.max_energy_mj_per_frame is not None
+
+    def test_laptop_cpu_has_no_energy_limit(self):
+        assert LAPTOP_CPU.max_energy_mj_per_frame is None
+
+    def test_custom_profile_created(self):
+        p = EdgeProfile(name="FPGA", min_fps=30.0, max_memory_mb=128.0, max_latency_ms=33.0)
+        assert p.name == "FPGA"
+        assert p.max_energy_mj_per_frame is None
+
+    def test_invalid_min_fps_raises(self):
+        with pytest.raises(ValueError, match="min_fps"):
+            EdgeProfile(name="Bad", min_fps=-1.0, max_memory_mb=100.0, max_latency_ms=50.0)
+
+    def test_invalid_max_memory_raises(self):
+        with pytest.raises(ValueError, match="max_memory_mb"):
+            EdgeProfile(name="Bad", min_fps=10.0, max_memory_mb=0.0, max_latency_ms=50.0)
+
+    def test_invalid_max_latency_raises(self):
+        with pytest.raises(ValueError, match="max_latency_ms"):
+            EdgeProfile(name="Bad", min_fps=10.0, max_memory_mb=100.0, max_latency_ms=0.0)
+
+    def test_invalid_energy_raises(self):
+        with pytest.raises(ValueError, match="max_energy_mj_per_frame"):
+            EdgeProfile(
+                name="Bad", min_fps=10.0, max_memory_mb=100.0,
+                max_latency_ms=50.0, max_energy_mj_per_frame=-5.0
+            )
+
+    def test_predefined_profile_lookup(self):
+        assert PREDEFINED_PROFILES["jetson_nano"] is JETSON_NANO
+        assert PREDEFINED_PROFILES["mobile"] is MOBILE_CLASS
+
+
+# ---------------------------------------------------------------------------
+# ConstraintEvaluator — individual checks
+# ---------------------------------------------------------------------------
+
+class TestConstraintEvaluator:
+    def setup_method(self):
+        self.ev = ConstraintEvaluator()
+
+    # FPS checks
+    def test_fps_passes_when_fast_enough(self):
+        result = _benchmark_result(fps=50.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)  # min_fps=10
+        fps_check = next(c for c in report.checks if c.constraint == "min_fps")
+        assert fps_check.passed
+        assert fps_check.margin > 0
+
+    def test_fps_fails_when_too_slow(self):
+        result = _benchmark_result(fps=3.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)  # min_fps=10
+        fps_check = next(c for c in report.checks if c.constraint == "min_fps")
+        assert not fps_check.passed
+        assert fps_check.margin < 0
+
+    # Memory checks
+    def test_memory_passes_when_within_budget(self):
+        result = _benchmark_result(fps=50.0, peak_memory_mb=64.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)  # max_memory=512
+        mem_check = next(c for c in report.checks if c.constraint == "max_memory_mb")
+        assert mem_check.passed
+        assert mem_check.margin > 0
+
+    def test_memory_fails_when_exceeds_budget(self):
+        result = _benchmark_result(fps=50.0, peak_memory_mb=1024.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)  # max_memory=512
+        mem_check = next(c for c in report.checks if c.constraint == "max_memory_mb")
+        assert not mem_check.passed
+        assert mem_check.margin < 0
+
+    # Latency checks
+    def test_latency_passes_when_fps_is_high(self):
+        # 100 FPS → 10 ms latency, well under RPi4's 100 ms limit
+        result = _benchmark_result(fps=100.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        lat_check = next(c for c in report.checks if c.constraint == "max_latency_ms")
+        assert lat_check.passed
+        assert lat_check.measured == pytest.approx(10.0, rel=1e-6)
+
+    def test_latency_fails_when_fps_is_very_low(self):
+        # 1 FPS → 1000 ms latency, exceeds all profiles
+        result = _benchmark_result(fps=1.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        lat_check = next(c for c in report.checks if c.constraint == "max_latency_ms")
+        assert not lat_check.passed
+
+    # Energy checks
+    def test_energy_check_skipped_when_not_profiled(self):
+        result = _benchmark_result(fps=50.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        assert not any(c.constraint == "max_energy_mj_per_frame" for c in report.checks)
+        assert any("max_energy_mj_per_frame" in m for m in report.missing_data)
+
+    def test_energy_check_skipped_when_profile_has_no_limit(self):
+        result = _benchmark_result(fps=50.0)
+        report = self.ev.evaluate(result, LAPTOP_CPU)
+        assert not any(c.constraint == "max_energy_mj_per_frame" for c in report.checks)
+        assert not report.missing_data  # no warning either
+
+    # Overall pass/fail
+    def test_overall_pass_requires_all_checks_pass(self):
+        # Fast but way too much memory
+        result = _benchmark_result(fps=500.0, peak_memory_mb=4096.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        assert not report.overall_pass
+
+    def test_overall_pass_when_all_constraints_met(self):
+        # 200 FPS, 64 MB — easily passes RPi4 FPS/memory/latency
+        result = _benchmark_result(fps=200.0, peak_memory_mb=64.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        assert report.overall_pass
+
+    def test_overall_fail_propagated_in_summary(self):
+        result = _benchmark_result(fps=2.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        assert "NOT DEPLOYABLE" in report.summary()
+
+    def test_overall_pass_propagated_in_summary(self):
+        result = _benchmark_result(fps=200.0, peak_memory_mb=64.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        assert "DEPLOYABLE" in report.summary()
+        assert "NOT DEPLOYABLE" not in report.summary()
+
+
+# ---------------------------------------------------------------------------
+# evaluate_many
+# ---------------------------------------------------------------------------
+
+class TestEvaluateMany:
+    def setup_method(self):
+        self.ev = ConstraintEvaluator()
+
+    def test_returns_one_report_per_result(self):
+        results = [
+            _benchmark_result(fps=100.0, tracker_name="Fast"),
+            _benchmark_result(fps=2.0, tracker_name="Slow"),
+        ]
+        reports = self.ev.evaluate_many(results, RASPBERRY_PI_4)
+        assert len(reports) == 2
+
+    def test_report_order_preserved(self):
+        results = [
+            _benchmark_result(tracker_name="A"),
+            _benchmark_result(tracker_name="B"),
+            _benchmark_result(tracker_name="C"),
+        ]
+        reports = self.ev.evaluate_many(results, JETSON_NANO)
+        assert [r.tracker_name for r in reports] == ["A", "B", "C"]
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+class TestConstraintReportDict:
+    def setup_method(self):
+        self.ev = ConstraintEvaluator()
+
+    def test_to_dict_keys(self):
+        result = _benchmark_result()
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        d = report.to_dict()
+        assert "tracker_name" in d
+        assert "profile_name" in d
+        assert "overall_pass" in d
+        assert "checks" in d
+        assert "missing_data" in d
+
+    def test_checks_have_required_keys(self):
+        result = _benchmark_result()
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        for check in report.to_dict()["checks"]:
+            for key in ("constraint", "passed", "measured", "limit", "margin"):
+                assert key in check
+
+    def test_to_dict_overall_pass_matches_report(self):
+        result = _benchmark_result(fps=200.0, peak_memory_mb=64.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        assert report.to_dict()["overall_pass"] == report.overall_pass
+
+
+# ---------------------------------------------------------------------------
+# Markdown table
+# ---------------------------------------------------------------------------
+
+class TestMarkdownTable:
+    def setup_method(self):
+        self.ev = ConstraintEvaluator()
+
+    def test_table_contains_profile_name(self):
+        result = _benchmark_result()
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        table = self.ev.markdown_table([report], RASPBERRY_PI_4)
+        assert "Raspberry Pi 4" in table
+
+    def test_table_contains_tracker_names(self):
+        results = [
+            _benchmark_result(fps=200.0, tracker_name="FastTracker"),
+            _benchmark_result(fps=2.0, tracker_name="SlowTracker"),
+        ]
+        reports = self.ev.evaluate_many(results, RASPBERRY_PI_4)
+        table = self.ev.markdown_table(reports, RASPBERRY_PI_4)
+        assert "FastTracker" in table
+        assert "SlowTracker" in table
+
+    def test_table_marks_deployable(self):
+        result = _benchmark_result(fps=200.0, peak_memory_mb=64.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        table = self.ev.markdown_table([report], RASPBERRY_PI_4)
+        assert "YES" in table
+
+    def test_table_marks_not_deployable(self):
+        result = _benchmark_result(fps=1.0)
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        table = self.ev.markdown_table([report], RASPBERRY_PI_4)
+        assert "NO" in table
+
+    def test_table_omits_energy_column_when_no_limit(self):
+        result = _benchmark_result()
+        report = self.ev.evaluate(result, LAPTOP_CPU)
+        table = self.ev.markdown_table([report], LAPTOP_CPU)
+        assert "Energy" not in table
+
+    def test_table_includes_energy_column_when_limited(self):
+        result = _benchmark_result()
+        report = self.ev.evaluate(result, RASPBERRY_PI_4)
+        table = self.ev.markdown_table([report], RASPBERRY_PI_4)
+        assert "Energy" in table
+
+
+# ---------------------------------------------------------------------------
+# ConstraintCheck str representation
+# ---------------------------------------------------------------------------
+
+class TestConstraintCheckStr:
+    def test_pass_str_contains_pass(self):
+        c = ConstraintCheck("min_fps", True, 50.0, 10.0, 40.0)
+        assert "PASS" in str(c)
+        assert "min_fps" in str(c)
+
+    def test_fail_str_contains_fail(self):
+        c = ConstraintCheck("min_fps", False, 3.0, 10.0, -7.0)
+        assert "FAIL" in str(c)


### PR DESCRIPTION
## Summary

This PR introduces `eovot/constraints/` — the module that directly bridges benchmark measurements with real-world edge deployment decisions, which is the **core differentiator** of EOVOT vs generic VOT benchmarks.

### What was added

**`eovot/constraints/profiles.py`** — `EdgeProfile` dataclass + 5 predefined device profiles:
| Profile key | Device | Min FPS | Max Mem | Max Latency | Energy budget |
|---|---|---|---|---|---|
| `raspberry_pi_4` | Raspberry Pi 4 (ARM Cortex-A72) | 10 FPS | 512 MB | 100 ms | 60 mJ/fr |
| `jetson_nano` | NVIDIA Jetson Nano | 15 FPS | 1024 MB | 67 ms | 100 mJ/fr |
| `mobile` | Smartphone-class ARM | 25 FPS | 256 MB | 40 ms | 30 mJ/fr |
| `embedded_micro` | Ultra-low-power MCU | 5 FPS | 64 MB | 200 ms | 10 mJ/fr |
| `laptop_cpu` | Modern x86 laptop (reference) | 30 FPS | 4096 MB | 33 ms | unconstrained |

**`eovot/constraints/evaluator.py`** — `ConstraintEvaluator` that checks a `BenchmarkResult` against an `EdgeProfile`:
- Four constraint checks: FPS (lower bound), peak memory, latency, energy per frame
- Signed margin for each check (positive = passing with headroom, negative = failing by that amount)
- `overall_pass` verdict: `DEPLOYABLE` / `NOT DEPLOYABLE`
- `markdown_table()` generates publication-ready comparison tables
- Energy check is gracefully skipped when not profiled (with an informative message)

**`tests/test_constraints.py`** — 34 unit tests covering all constraint types, edge cases, serialisation, and Markdown output.

### Why it matters

Every tracking paper reports accuracy metrics.  EOVOT's mission is to also report *deployability*.  Before this PR, there was no programmatic way to answer: **"Can MOSSE run on a Raspberry Pi 4?"**  Now there is.

### How it fits the project

Integrates cleanly with existing `BenchmarkResult` and `BenchmarkEngine` — no breaking changes. Energy constraint evaluation automatically engages when `tdp_watts` is passed to the engine.

### Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.constraints import ConstraintEvaluator, RASPBERRY_PI_4, JETSON_NANO, PREDEFINED_PROFILES

engine = BenchmarkEngine(verbose=False, tdp_watts=6.0)
result = engine.run(tracker, dataset, dataset_name="OTB100")

ev = ConstraintEvaluator()

# Single device
report = ev.evaluate(result, RASPBERRY_PI_4)
print(report.summary())
# Constraint Report: MOSSE → Raspberry Pi 4
# Overall: DEPLOYABLE
#   [PASS] min_fps: measured=487.3, limit=10.0, margin=+477.3
#   [PASS] max_memory_mb: measured=124.5, limit=512.0, margin=+387.5
#   [PASS] max_latency_ms: measured=2.1, limit=100.0, margin=+97.9
#   [SKIP] max_energy_mj_per_frame: metric not available

# Compare all trackers across all devices
results = [mosse_result, kcf_result, csrt_result]
for profile in PREDEFINED_PROFILES.values():
    reports = ev.evaluate_many(results, profile)
    print(ev.markdown_table(reports, profile))
```

### No breaking changes

All existing APIs remain unchanged. The new `constraints` sub-package is independently importable.

---
*34 tests · 5 device profiles · 0 breaking changes*

---
_Generated by [Claude Code](https://claude.ai/code/session_018Lx2imfaEzL7ZpqqTpzaBp)_