### PR TITLE
[experimental] Add hardware-aware deployment advisor with edge device profiles

### DIFF
--- a/configs/hardware_profiles.yaml
+++ b/configs/hardware_profiles.yaml
@@ -1,0 +1,100 @@
+# Hardware profiles for EOVOT deployment advisor
+#
+# Each profile defines the deployment constraints of a target device.
+# These values are used by DeploymentAdvisor to score tracker benchmark
+# results and generate go/no-go recommendations.
+#
+# Fields:
+#   tdp_watts          - CPU Thermal Design Power (W)
+#   memory_mb          - Available RAM (MB)
+#   target_fps         - Minimum real-time FPS requirement
+#   latency_budget_ms  - Maximum per-frame processing time (ms)
+#   power_budget_w     - Maximum sustained power draw (W)
+#
+# Note: memory_safety_factor (default 0.80) is applied by DeploymentAdvisor
+#       to reserve headroom for the OS and system processes.
+
+profiles:
+  raspberry_pi_4:
+    display_name: "Raspberry Pi 4 (4 GB)"
+    tdp_watts: 6.0
+    memory_mb: 4096
+    target_fps: 25.0
+    latency_budget_ms: 40.0
+    power_budget_w: 5.0
+    category: ultra_low
+    description: "Quad-core ARM Cortex-A72 @ 1.5 GHz, 4 GB LPDDR4, no GPU"
+
+  raspberry_pi_5:
+    display_name: "Raspberry Pi 5 (8 GB)"
+    tdp_watts: 12.0
+    memory_mb: 8192
+    target_fps: 30.0
+    latency_budget_ms: 33.0
+    power_budget_w: 10.0
+    category: ultra_low
+    description: "Quad-core ARM Cortex-A76 @ 2.4 GHz, 8 GB LPDDR4X"
+
+  jetson_nano:
+    display_name: "NVIDIA Jetson Nano (4 GB)"
+    tdp_watts: 10.0
+    memory_mb: 4096
+    target_fps: 30.0
+    latency_budget_ms: 33.0
+    power_budget_w: 10.0
+    category: edge
+    description: "Quad-core ARM Cortex-A57 @ 1.43 GHz, 128-core Maxwell GPU"
+
+  jetson_xavier_nx:
+    display_name: "NVIDIA Jetson Xavier NX (8 GB)"
+    tdp_watts: 15.0
+    memory_mb: 8192
+    target_fps: 60.0
+    latency_budget_ms: 16.0
+    power_budget_w: 15.0
+    category: edge
+    description: "6-core NVIDIA Carmel, 384-core Volta GPU, 8 GB LPDDR4x"
+
+  jetson_orin_nano:
+    display_name: "NVIDIA Jetson Orin Nano (8 GB)"
+    tdp_watts: 15.0
+    memory_mb: 8192
+    target_fps: 60.0
+    latency_budget_ms: 16.0
+    power_budget_w: 15.0
+    category: edge
+    description: "6-core Arm Cortex-A78AE, 1024-core Ampere GPU, 8 GB LPDDR5"
+
+  intel_nuc_i5:
+    display_name: "Intel NUC (i5-1135G7)"
+    tdp_watts: 28.0
+    memory_mb: 16384
+    target_fps: 60.0
+    latency_budget_ms: 16.0
+    power_budget_w: 20.0
+    category: embedded
+    description: "4-core Tiger Lake @ 2.4–4.2 GHz, Intel Iris Xe, 16 GB DDR4"
+
+  laptop_cpu:
+    display_name: "Generic Laptop CPU (15 W TDP)"
+    tdp_watts: 15.0
+    memory_mb: 8192
+    target_fps: 30.0
+    latency_budget_ms: 33.0
+    power_budget_w: 15.0
+    category: laptop
+    description: "Representative mobile CPU, ~15 W TDP class"
+
+  workstation:
+    display_name: "Workstation CPU (65 W TDP)"
+    tdp_watts: 65.0
+    memory_mb: 32768
+    target_fps: 120.0
+    latency_budget_ms: 8.0
+    power_budget_w: 65.0
+    category: workstation
+    description: "Desktop-class CPU, no strict power constraint"
+
+# Deployment advisor settings
+advisor:
+  memory_safety_factor: 0.80   # fraction of RAM available to the tracker

--- a/eovot/profiling/__init__.py
+++ b/eovot/profiling/__init__.py
@@ -2,5 +2,19 @@
 
 from .profiler import Profiler, ProfilingResult
 from .energy import EnergyProfiler, EnergyResult
+from .hardware_profiles import HardwareProfile, PROFILES, get_profile, list_profiles
+from .deployment_advisor import DeploymentAdvisor, DeploymentScore, ConstraintScore
 
-__all__ = ["Profiler", "ProfilingResult", "EnergyProfiler", "EnergyResult"]
+__all__ = [
+    "Profiler",
+    "ProfilingResult",
+    "EnergyProfiler",
+    "EnergyResult",
+    "HardwareProfile",
+    "PROFILES",
+    "get_profile",
+    "list_profiles",
+    "DeploymentAdvisor",
+    "DeploymentScore",
+    "ConstraintScore",
+]

--- a/eovot/profiling/deployment_advisor.py
+++ b/eovot/profiling/deployment_advisor.py
@@ -1,0 +1,463 @@
+"""Hardware-aware deployment advisor for tracker selection.
+
+Given one or more :class:`~eovot.benchmark.engine.BenchmarkResult` objects and
+a set of :class:`~eovot.profiling.hardware_profiles.HardwareProfile` targets,
+the :class:`DeploymentAdvisor` scores each (tracker, device) pair against four
+deployment constraints:
+
+- **FPS**: measured mean FPS vs device target FPS
+- **Latency**: measured mean latency vs device latency budget
+- **Memory**: measured peak memory vs device RAM limit
+- **Power**: measured mean power (if energy was profiled) vs device power budget
+
+Each constraint is scored 0–1, where 1 means the constraint is comfortably met.
+A tracker is ``deployable`` on a device only when *all hard constraints* are
+satisfied (FPS ≥ target, latency ≤ budget, memory ≤ RAM).  Power is treated as
+a soft constraint that lowers the overall score but does not block deployment.
+
+Usage::
+
+    from eovot.profiling.deployment_advisor import DeploymentAdvisor
+    from eovot.profiling.hardware_profiles import PROFILES
+
+    advisor = DeploymentAdvisor()
+    scores = advisor.rank(benchmark_results, PROFILES["jetson_nano"])
+    print(advisor.report_markdown(scores, PROFILES["jetson_nano"]))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from .hardware_profiles import HardwareProfile
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConstraintScore:
+    """Score for a single deployment constraint.
+
+    Attributes:
+        name:      Constraint name (e.g. ``"fps"``).
+        measured:  Observed value from benchmark.
+        required:  Device constraint threshold.
+        score:     Normalised score in ``[0, 1]``.
+        passed:    Whether the hard constraint is satisfied.
+    """
+
+    name: str
+    measured: float
+    required: float
+    score: float
+    passed: bool
+
+    def to_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "measured": round(self.measured, 4),
+            "required": round(self.required, 4),
+            "score": round(self.score, 4),
+            "passed": self.passed,
+        }
+
+
+@dataclass
+class DeploymentScore:
+    """Deployment evaluation for one (tracker, device) pair.
+
+    Attributes:
+        tracker_name:          Name of the tracker.
+        profile_name:          Name of the hardware profile.
+        constraints:           Individual constraint scores.
+        overall_score:         Weighted aggregate score in ``[0, 1]``.
+        deployable:            True when all hard constraints are met.
+        violations:            List of constraint names that failed.
+        recommendation:        Human-readable deployment verdict.
+    """
+
+    tracker_name: str
+    profile_name: str
+    constraints: List[ConstraintScore] = field(default_factory=list)
+    overall_score: float = 0.0
+    deployable: bool = False
+    violations: List[str] = field(default_factory=list)
+    recommendation: str = ""
+
+    def constraint(self, name: str) -> Optional[ConstraintScore]:
+        for c in self.constraints:
+            if c.name == name:
+                return c
+        return None
+
+    def to_dict(self) -> Dict:
+        return {
+            "tracker_name": self.tracker_name,
+            "profile_name": self.profile_name,
+            "overall_score": round(self.overall_score, 4),
+            "deployable": self.deployable,
+            "violations": self.violations,
+            "recommendation": self.recommendation,
+            "constraints": [c.to_dict() for c in self.constraints],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+
+def _fps_score(measured_fps: float, target_fps: float) -> ConstraintScore:
+    """Higher FPS is better; score = min(measured/target, 1)."""
+    ratio = measured_fps / target_fps if target_fps > 0 else 0.0
+    score = min(ratio, 1.0)
+    return ConstraintScore(
+        name="fps",
+        measured=measured_fps,
+        required=target_fps,
+        score=score,
+        passed=measured_fps >= target_fps,
+    )
+
+
+def _latency_score(measured_ms: float, budget_ms: float) -> ConstraintScore:
+    """Lower latency is better; score = min(budget/measured, 1)."""
+    if measured_ms <= 0:
+        score, passed = 1.0, True
+    else:
+        ratio = budget_ms / measured_ms
+        score = min(ratio, 1.0)
+        passed = measured_ms <= budget_ms
+    return ConstraintScore(
+        name="latency",
+        measured=measured_ms,
+        required=budget_ms,
+        score=score,
+        passed=passed,
+    )
+
+
+def _memory_score(measured_mb: float, limit_mb: float) -> ConstraintScore:
+    """Lower memory is better; score = min(limit/measured, 1)."""
+    if measured_mb <= 0:
+        score, passed = 1.0, True
+    else:
+        ratio = limit_mb / measured_mb
+        score = min(ratio, 1.0)
+        passed = measured_mb <= limit_mb
+    return ConstraintScore(
+        name="memory",
+        measured=measured_mb,
+        required=limit_mb,
+        score=score,
+        passed=passed,
+    )
+
+
+def _power_score(
+    mean_power_w: Optional[float], budget_w: float
+) -> Optional[ConstraintScore]:
+    """Returns None if energy data is unavailable."""
+    if mean_power_w is None:
+        return None
+    if mean_power_w <= 0:
+        return ConstraintScore(
+            name="power", measured=0.0, required=budget_w,
+            score=1.0, passed=True,
+        )
+    ratio = budget_w / mean_power_w
+    score = min(ratio, 1.0)
+    return ConstraintScore(
+        name="power",
+        measured=mean_power_w,
+        required=budget_w,
+        score=score,
+        passed=mean_power_w <= budget_w,
+    )
+
+
+# Weights for the overall score aggregation
+_WEIGHTS: Dict[str, float] = {
+    "fps": 0.35,
+    "latency": 0.35,
+    "memory": 0.20,
+    "power": 0.10,
+}
+
+
+def _overall_score(constraints: List[ConstraintScore]) -> float:
+    """Weighted average of available constraint scores."""
+    total_weight = 0.0
+    weighted_sum = 0.0
+    available = {c.name for c in constraints}
+    for c in constraints:
+        w = _WEIGHTS.get(c.name, 0.0)
+        if c.name == "power" and "power" not in available:
+            continue
+        weighted_sum += w * c.score
+        total_weight += w
+    if total_weight == 0:
+        return 0.0
+    # Re-normalise if power is absent so remaining weights sum to 1
+    return weighted_sum / total_weight
+
+
+def _recommendation(score: DeploymentScore, profile: HardwareProfile) -> str:
+    if score.deployable:
+        if score.overall_score >= 0.85:
+            return (
+                f"Highly recommended for {profile.display_name}. "
+                "All constraints met with comfortable margin."
+            )
+        elif score.overall_score >= 0.60:
+            return (
+                f"Suitable for {profile.display_name}. "
+                "Constraints met; some headroom is limited."
+            )
+        else:
+            return (
+                f"Marginally deployable on {profile.display_name}. "
+                "Constraints met but operating near limits — test on device."
+            )
+    else:
+        viol_str = ", ".join(score.violations)
+        return (
+            f"Not recommended for {profile.display_name}. "
+            f"Constraint(s) violated: {viol_str}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# DeploymentAdvisor
+# ---------------------------------------------------------------------------
+
+
+class DeploymentAdvisor:
+    """Score and rank trackers against hardware deployment constraints.
+
+    Args:
+        memory_safety_factor: Fraction of device RAM treated as usable
+            (default ``0.80`` — leaves 20% for OS and system processes).
+
+    Example::
+
+        advisor = DeploymentAdvisor()
+        scores = advisor.rank(results, PROFILES["raspberry_pi_4"])
+        for s in scores:
+            print(s.tracker_name, s.overall_score, s.deployable)
+        print(advisor.report_markdown(scores, PROFILES["raspberry_pi_4"]))
+    """
+
+    def __init__(self, memory_safety_factor: float = 0.80) -> None:
+        if not 0 < memory_safety_factor <= 1.0:
+            raise ValueError(
+                f"memory_safety_factor must be in (0, 1], got {memory_safety_factor}"
+            )
+        self.memory_safety_factor = memory_safety_factor
+
+    def score(
+        self,
+        result,  # BenchmarkResult — avoid circular import
+        profile: HardwareProfile,
+    ) -> DeploymentScore:
+        """Evaluate a single benchmark result against a hardware profile.
+
+        Args:
+            result:  A :class:`~eovot.benchmark.engine.BenchmarkResult`.
+            profile: Target :class:`HardwareProfile`.
+
+        Returns:
+            :class:`DeploymentScore` with per-constraint breakdown.
+        """
+        measured_fps = result.mean_fps
+        measured_latency = np.mean(
+            [sr.profiling.latency_mean_ms for sr in result.sequence_results]
+        )
+        measured_memory = result.peak_memory_mb
+        usable_memory = profile.memory_mb * self.memory_safety_factor
+
+        # Derive mean power from energy data if available
+        mean_power: Optional[float] = None
+        with_energy = [
+            sr.energy for sr in result.sequence_results if sr.energy is not None
+        ]
+        if with_energy:
+            mean_power = float(np.mean([e.mean_power_w for e in with_energy]))
+
+        # Compute per-constraint scores
+        c_fps = _fps_score(measured_fps, profile.target_fps)
+        c_lat = _latency_score(float(measured_latency), profile.latency_budget_ms)
+        c_mem = _memory_score(measured_memory, usable_memory)
+        constraints: List[ConstraintScore] = [c_fps, c_lat, c_mem]
+
+        c_pwr = _power_score(mean_power, profile.power_budget_w)
+        if c_pwr is not None:
+            constraints.append(c_pwr)
+
+        # Hard violations
+        hard = [c_fps, c_lat, c_mem]
+        violations = [c.name for c in hard if not c.passed]
+        deployable = len(violations) == 0
+
+        overall = _overall_score(constraints)
+
+        ds = DeploymentScore(
+            tracker_name=result.tracker_name,
+            profile_name=profile.name,
+            constraints=constraints,
+            overall_score=overall,
+            deployable=deployable,
+            violations=violations,
+        )
+        ds.recommendation = _recommendation(ds, profile)
+        return ds
+
+    def rank(
+        self,
+        results: List,  # List[BenchmarkResult]
+        profile: HardwareProfile,
+    ) -> List[DeploymentScore]:
+        """Score and sort all trackers for a given device.
+
+        Deployable trackers are ranked by overall score (descending), followed
+        by non-deployable trackers.
+
+        Args:
+            results: List of :class:`~eovot.benchmark.engine.BenchmarkResult`.
+            profile: Target :class:`HardwareProfile`.
+
+        Returns:
+            Sorted list of :class:`DeploymentScore` objects.
+        """
+        scores = [self.score(r, profile) for r in results]
+        deployable = sorted(
+            [s for s in scores if s.deployable],
+            key=lambda s: s.overall_score,
+            reverse=True,
+        )
+        not_deployable = sorted(
+            [s for s in scores if not s.deployable],
+            key=lambda s: s.overall_score,
+            reverse=True,
+        )
+        return deployable + not_deployable
+
+    def multi_profile_summary(
+        self,
+        results: List,  # List[BenchmarkResult]
+        profiles: List[HardwareProfile],
+    ) -> Dict[str, List[DeploymentScore]]:
+        """Rank all trackers against multiple profiles.
+
+        Args:
+            results:  List of benchmark results.
+            profiles: List of target hardware profiles.
+
+        Returns:
+            Mapping from profile name to ranked list of deployment scores.
+        """
+        return {p.name: self.rank(results, p) for p in profiles}
+
+    # ------------------------------------------------------------------
+    # Reporting
+    # ------------------------------------------------------------------
+
+    def report_markdown(
+        self,
+        scores: List[DeploymentScore],
+        profile: HardwareProfile,
+    ) -> str:
+        """Render a deployment report for one device as Markdown.
+
+        Args:
+            scores:  Ranked list returned by :meth:`rank`.
+            profile: The hardware profile used.
+
+        Returns:
+            Markdown string suitable for README sections or wiki pages.
+        """
+        lines = [
+            f"## Deployment Report: {profile.display_name}\n",
+            f"> {profile.description}  ",
+            f"> TDP: {profile.tdp_watts} W | RAM: {profile.memory_mb} MB | "
+            f"Target FPS: {profile.target_fps} | Latency budget: "
+            f"{profile.latency_budget_ms} ms\n",
+            "### Tracker Rankings\n",
+            "| Rank | Tracker | Score | FPS | Latency (ms) | Memory (MB) | Deployable | Violations |",
+            "|------|---------|-------|-----|--------------|-------------|------------|------------|",
+        ]
+
+        for rank, s in enumerate(scores, 1):
+            dep = "✓" if s.deployable else "✗"
+            viol = ", ".join(s.violations) if s.violations else "—"
+            c_fps = s.constraint("fps")
+            c_lat = s.constraint("latency")
+            c_mem = s.constraint("memory")
+            fps_str = f"{c_fps.measured:.1f}" if c_fps else "—"
+            lat_str = f"{c_lat.measured:.1f}" if c_lat else "—"
+            mem_str = f"{c_mem.measured:.1f}" if c_mem else "—"
+            lines.append(
+                f"| {rank} | {s.tracker_name} | {s.overall_score:.3f} "
+                f"| {fps_str} | {lat_str} | {mem_str} | {dep} | {viol} |"
+            )
+
+        lines.append("\n### Recommendations\n")
+        for s in scores:
+            icon = "✅" if s.deployable else "❌"
+            lines.append(f"- {icon} **{s.tracker_name}**: {s.recommendation}")
+
+        return "\n".join(lines)
+
+    def report_multi_profile_markdown(
+        self,
+        summary: Dict[str, List[DeploymentScore]],
+        profiles: List[HardwareProfile],
+    ) -> str:
+        """Render a cross-device compatibility matrix as Markdown.
+
+        Rows are trackers; columns are devices.  Cells show the overall score
+        and a ✓/✗ deployability indicator.
+
+        Args:
+            summary:  Output of :meth:`multi_profile_summary`.
+            profiles: Profiles in the desired column order.
+
+        Returns:
+            Markdown string with the compatibility matrix.
+        """
+        # Collect all tracker names (preserve per-device ranking order)
+        seen: Dict[str, None] = {}
+        for scores in summary.values():
+            for s in scores:
+                seen[s.tracker_name] = None
+        tracker_names = list(seen.keys())
+
+        # Header
+        profile_headers = " | ".join(p.display_name for p in profiles)
+        sep_cols = " | ".join(["---"] * len(profiles))
+        lines = [
+            "## Cross-Device Deployment Compatibility\n",
+            f"| Tracker | {profile_headers} |",
+            f"|---------|{sep_cols}|",
+        ]
+
+        for tracker in tracker_names:
+            cells: List[str] = []
+            for p in profiles:
+                p_scores = summary.get(p.name, [])
+                match = next((s for s in p_scores if s.tracker_name == tracker), None)
+                if match is None:
+                    cells.append("—")
+                elif match.deployable:
+                    cells.append(f"✓ {match.overall_score:.2f}")
+                else:
+                    cells.append(f"✗ {match.overall_score:.2f}")
+            lines.append(f"| {tracker} | " + " | ".join(cells) + " |")
+
+        return "\n".join(lines)

--- a/eovot/profiling/hardware_profiles.py
+++ b/eovot/profiling/hardware_profiles.py
@@ -1,0 +1,221 @@
+"""Hardware profiles for edge-device deployment targeting.
+
+Defines :class:`HardwareProfile` — a dataclass that captures the key
+deployment constraints of a target device — and a curated registry of common
+edge, embedded, and desktop platforms.
+
+These profiles are used by :class:`~eovot.profiling.deployment_advisor.DeploymentAdvisor`
+to score tracker benchmark results against real-world constraints.
+
+Typical usage::
+
+    from eovot.profiling.hardware_profiles import PROFILES, get_profile
+
+    profile = get_profile("jetson_nano")
+    print(profile.target_fps)   # 30.0
+    print(profile.memory_mb)    # 4096
+
+Custom profiles can be created directly::
+
+    custom = HardwareProfile(
+        name="my_device",
+        display_name="Custom MCU",
+        tdp_watts=3.0,
+        memory_mb=512,
+        target_fps=15.0,
+        latency_budget_ms=66.6,
+        power_budget_w=2.5,
+        description="Custom microcontroller board",
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class HardwareProfile:
+    """Deployment constraints for a target hardware platform.
+
+    Attributes:
+        name:               Canonical identifier (used as dict key).
+        display_name:       Human-readable label for reports.
+        tdp_watts:          CPU Thermal Design Power in Watts.
+        memory_mb:          Available RAM in megabytes.
+        target_fps:         Minimum frames per second for real-time operation.
+        latency_budget_ms:  Maximum per-frame processing time in milliseconds.
+        power_budget_w:     Maximum sustained power draw in Watts.
+        description:        Free-text device specification summary.
+        category:           Device tier: ``"ultra_low"``, ``"edge"``,
+                            ``"embedded"``, ``"laptop"``, or ``"workstation"``.
+    """
+
+    name: str
+    display_name: str
+    tdp_watts: float
+    memory_mb: float
+    target_fps: float
+    latency_budget_ms: float
+    power_budget_w: float
+    description: str = ""
+    category: str = "edge"
+
+    def __post_init__(self) -> None:
+        if self.tdp_watts <= 0:
+            raise ValueError(f"tdp_watts must be positive, got {self.tdp_watts}")
+        if self.memory_mb <= 0:
+            raise ValueError(f"memory_mb must be positive, got {self.memory_mb}")
+        if self.target_fps <= 0:
+            raise ValueError(f"target_fps must be positive, got {self.target_fps}")
+        if self.latency_budget_ms <= 0:
+            raise ValueError(f"latency_budget_ms must be positive")
+        if self.power_budget_w <= 0:
+            raise ValueError(f"power_budget_w must be positive")
+
+    def to_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "tdp_watts": self.tdp_watts,
+            "memory_mb": self.memory_mb,
+            "target_fps": self.target_fps,
+            "latency_budget_ms": self.latency_budget_ms,
+            "power_budget_w": self.power_budget_w,
+            "description": self.description,
+            "category": self.category,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Built-in device registry
+# ---------------------------------------------------------------------------
+
+PROFILES: Dict[str, HardwareProfile] = {
+    "raspberry_pi_4": HardwareProfile(
+        name="raspberry_pi_4",
+        display_name="Raspberry Pi 4 (4 GB)",
+        tdp_watts=6.0,
+        memory_mb=4096,
+        target_fps=25.0,
+        latency_budget_ms=40.0,
+        power_budget_w=5.0,
+        description="Quad-core ARM Cortex-A72 @ 1.5 GHz, 4 GB LPDDR4, no GPU",
+        category="ultra_low",
+    ),
+    "raspberry_pi_5": HardwareProfile(
+        name="raspberry_pi_5",
+        display_name="Raspberry Pi 5 (8 GB)",
+        tdp_watts=12.0,
+        memory_mb=8192,
+        target_fps=30.0,
+        latency_budget_ms=33.0,
+        power_budget_w=10.0,
+        description="Quad-core ARM Cortex-A76 @ 2.4 GHz, 8 GB LPDDR4X, no GPU",
+        category="ultra_low",
+    ),
+    "jetson_nano": HardwareProfile(
+        name="jetson_nano",
+        display_name="NVIDIA Jetson Nano (4 GB)",
+        tdp_watts=10.0,
+        memory_mb=4096,
+        target_fps=30.0,
+        latency_budget_ms=33.0,
+        power_budget_w=10.0,
+        description=(
+            "Quad-core ARM Cortex-A57 @ 1.43 GHz, "
+            "128-core Maxwell GPU, 4 GB LPDDR4"
+        ),
+        category="edge",
+    ),
+    "jetson_xavier_nx": HardwareProfile(
+        name="jetson_xavier_nx",
+        display_name="NVIDIA Jetson Xavier NX (8 GB)",
+        tdp_watts=15.0,
+        memory_mb=8192,
+        target_fps=60.0,
+        latency_budget_ms=16.0,
+        power_budget_w=15.0,
+        description=(
+            "6-core NVIDIA Carmel ARM @ 1.4 GHz, "
+            "384-core Volta GPU, 8 GB LPDDR4x"
+        ),
+        category="edge",
+    ),
+    "jetson_orin_nano": HardwareProfile(
+        name="jetson_orin_nano",
+        display_name="NVIDIA Jetson Orin Nano (8 GB)",
+        tdp_watts=15.0,
+        memory_mb=8192,
+        target_fps=60.0,
+        latency_budget_ms=16.0,
+        power_budget_w=15.0,
+        description=(
+            "6-core Arm Cortex-A78AE, "
+            "1024-core Ampere GPU, 8 GB LPDDR5"
+        ),
+        category="edge",
+    ),
+    "intel_nuc_i5": HardwareProfile(
+        name="intel_nuc_i5",
+        display_name="Intel NUC (i5-1135G7)",
+        tdp_watts=28.0,
+        memory_mb=16384,
+        target_fps=60.0,
+        latency_budget_ms=16.0,
+        power_budget_w=20.0,
+        description=(
+            "4-core/8-thread Tiger Lake @ 2.4–4.2 GHz, "
+            "Intel Iris Xe, 16 GB DDR4"
+        ),
+        category="embedded",
+    ),
+    "laptop_cpu": HardwareProfile(
+        name="laptop_cpu",
+        display_name="Generic Laptop CPU (15 W TDP)",
+        tdp_watts=15.0,
+        memory_mb=8192,
+        target_fps=30.0,
+        latency_budget_ms=33.0,
+        power_budget_w=15.0,
+        description="Representative mobile CPU, ~15 W TDP class",
+        category="laptop",
+    ),
+    "workstation": HardwareProfile(
+        name="workstation",
+        display_name="Workstation CPU (65 W TDP)",
+        tdp_watts=65.0,
+        memory_mb=32768,
+        target_fps=120.0,
+        latency_budget_ms=8.0,
+        power_budget_w=65.0,
+        description="Desktop-class CPU, no strict power constraint",
+        category="workstation",
+    ),
+}
+
+
+def get_profile(name: str) -> HardwareProfile:
+    """Retrieve a profile by canonical name.
+
+    Args:
+        name: One of the keys in :data:`PROFILES`.
+
+    Returns:
+        The corresponding :class:`HardwareProfile`.
+
+    Raises:
+        KeyError: If *name* is not in the registry.
+    """
+    if name not in PROFILES:
+        available = ", ".join(sorted(PROFILES))
+        raise KeyError(
+            f"Unknown hardware profile {name!r}. Available: {available}"
+        )
+    return PROFILES[name]
+
+
+def list_profiles() -> List[HardwareProfile]:
+    """Return all built-in profiles sorted by TDP (ascending)."""
+    return sorted(PROFILES.values(), key=lambda p: p.tdp_watts)

--- a/scripts/advise_deployment.py
+++ b/scripts/advise_deployment.py
@@ -1,0 +1,213 @@
+"""CLI tool: load saved benchmark results and generate a deployment report.
+
+Usage examples::
+
+    # Single device
+    python scripts/advise_deployment.py \\
+        results/mosse.json results/kcf.json results/csrt.json \\
+        --profile jetson_nano
+
+    # All built-in devices
+    python scripts/advise_deployment.py results/*.json --all-profiles
+
+    # Save Markdown report
+    python scripts/advise_deployment.py results/*.json \\
+        --profile raspberry_pi_4 \\
+        --output reports/deployment_rpi4.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+# Ensure the project root is on sys.path when run as a script
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eovot.profiling.deployment_advisor import DeploymentAdvisor
+from eovot.profiling.hardware_profiles import PROFILES, list_profiles
+
+
+# ---------------------------------------------------------------------------
+# Lightweight result stub — mirrors BenchmarkResult public API so the advisor
+# works without needing a full dataset on disk.
+# ---------------------------------------------------------------------------
+
+
+class _ProfilingStub:
+    def __init__(self, fps: float, latency_ms: float, memory_mb: float) -> None:
+        self.fps = fps
+        self.latency_mean_ms = latency_ms
+        self.peak_memory_mb = memory_mb
+
+
+class _EnergyStub:
+    def __init__(self, mean_power_w: float) -> None:
+        self.mean_power_w = mean_power_w
+
+
+class _SeqStub:
+    def __init__(
+        self,
+        seq_name: str,
+        fps: float,
+        latency_ms: float,
+        memory_mb: float,
+        mean_power_w: float | None,
+    ) -> None:
+        self.sequence_name = seq_name
+        self.profiling = _ProfilingStub(fps, latency_ms, memory_mb)
+        self.energy = _EnergyStub(mean_power_w) if mean_power_w is not None else None
+
+
+class _BenchmarkResultStub:
+    """Minimal BenchmarkResult reconstructed from a JSON file."""
+
+    def __init__(self, path: Path) -> None:
+        data = json.loads(path.read_text())
+        summary = data.get("summary", {})
+        sequences_data = data.get("sequences", [])
+
+        self.tracker_name: str = summary.get("tracker", path.stem)
+        self.dataset_name: str = summary.get("dataset", "unknown")
+
+        # Reconstruct per-sequence stubs from the serialised sequence list.
+        # Fields available from BenchmarkResult.to_dict():
+        #   sequence_name, mean_iou, fps, mean_latency_ms, peak_memory_mb
+        #   [optional] energy_j, energy_per_frame_mj
+        self.sequence_results = []
+        for s in sequences_data:
+            seq_name = s.get("sequence_name", "unknown")
+            fps = float(s.get("fps", 0.0))
+            lat = float(s.get("mean_latency_ms", 0.0))
+            mem = float(s.get("peak_memory_mb", 0.0))
+            # Approximate mean power from energy_per_frame_mj if available
+            mean_power: float | None = None
+            epf = s.get("energy_per_frame_mj")
+            lat_s = lat / 1000.0
+            if epf is not None and lat_s > 0:
+                mean_power = (float(epf) / 1000.0) / lat_s  # mJ → J / s = W
+            self.sequence_results.append(
+                _SeqStub(seq_name, fps, lat, mem, mean_power)
+            )
+
+        # Aggregate properties expected by DeploymentAdvisor
+        fpss = [s.profiling.fps for s in self.sequence_results] or [0.0]
+        mems = [s.profiling.peak_memory_mb for s in self.sequence_results] or [0.0]
+        self._mean_fps = float(sum(fpss) / len(fpss))
+        self._peak_memory_mb = float(max(mems))
+
+    @property
+    def mean_fps(self) -> float:
+        return self._mean_fps
+
+    @property
+    def peak_memory_mb(self) -> float:
+        return self._peak_memory_mb
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a hardware deployment report from EOVOT JSON results.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "result_files",
+        nargs="+",
+        metavar="RESULT_JSON",
+        help="One or more JSON files produced by the EOVOT benchmark engine.",
+    )
+    profile_group = parser.add_mutually_exclusive_group(required=True)
+    profile_group.add_argument(
+        "--profile",
+        metavar="PROFILE_NAME",
+        help=(
+            "Target hardware profile. "
+            f"Choices: {', '.join(sorted(PROFILES))}"
+        ),
+    )
+    profile_group.add_argument(
+        "--all-profiles",
+        action="store_true",
+        help="Evaluate against all built-in hardware profiles.",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Write Markdown report to this file (default: print to stdout).",
+    )
+    parser.add_argument(
+        "--memory-safety",
+        type=float,
+        default=0.80,
+        metavar="FRACTION",
+        help="Fraction of device RAM treated as usable (default: 0.80).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    # Load results
+    results: List[_BenchmarkResultStub] = []
+    for path_str in args.result_files:
+        p = Path(path_str)
+        if not p.is_file():
+            print(f"[WARNING] File not found, skipping: {p}", file=sys.stderr)
+            continue
+        try:
+            results.append(_BenchmarkResultStub(p))
+        except (json.JSONDecodeError, KeyError) as exc:
+            print(f"[ERROR] Could not parse {p}: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    if not results:
+        print("[ERROR] No valid result files loaded.", file=sys.stderr)
+        sys.exit(1)
+
+    advisor = DeploymentAdvisor(memory_safety_factor=args.memory_safety)
+
+    if args.all_profiles:
+        profiles = list_profiles()
+        summary = advisor.multi_profile_summary(results, profiles)
+        report = advisor.report_multi_profile_markdown(summary, profiles)
+        # Append per-device tables
+        per_device_parts: List[str] = []
+        for p in profiles:
+            ranked = summary[p.name]
+            per_device_parts.append(advisor.report_markdown(ranked, p))
+        report = report + "\n\n---\n\n" + "\n\n---\n\n".join(per_device_parts)
+    else:
+        if args.profile not in PROFILES:
+            print(
+                f"[ERROR] Unknown profile {args.profile!r}. "
+                f"Available: {', '.join(sorted(PROFILES))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        profile = PROFILES[args.profile]
+        ranked = advisor.rank(results, profile)
+        report = advisor.report_markdown(ranked, profile)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(report)
+        print(f"Report written to {out}")
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deployment_advisor.py
+++ b/tests/test_deployment_advisor.py
@@ -1,0 +1,331 @@
+"""Tests for eovot.profiling.hardware_profiles and deployment_advisor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import pytest
+
+from eovot.profiling.deployment_advisor import (
+    DeploymentAdvisor,
+    DeploymentScore,
+    _fps_score,
+    _latency_score,
+    _memory_score,
+    _power_score,
+)
+from eovot.profiling.hardware_profiles import (
+    PROFILES,
+    HardwareProfile,
+    get_profile,
+    list_profiles,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal BenchmarkResult stubs — mirrors the public API used by the advisor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeProfiling:
+    fps: float = 30.0
+    latency_mean_ms: float = 33.0
+    peak_memory_mb: float = 100.0
+
+
+@dataclass
+class _FakeEnergy:
+    mean_power_w: float = 5.0
+
+
+@dataclass
+class _FakeSeqResult:
+    sequence_name: str = "seq1"
+    profiling: _FakeProfiling = field(default_factory=_FakeProfiling)
+    energy: Optional[_FakeEnergy] = None
+
+
+@dataclass
+class _FakeBenchmarkResult:
+    tracker_name: str
+    dataset_name: str = "OTB100"
+    sequence_results: List[_FakeSeqResult] = field(default_factory=list)
+
+    @property
+    def mean_fps(self) -> float:
+        if not self.sequence_results:
+            return 0.0
+        return float(sum(s.profiling.fps for s in self.sequence_results) / len(self.sequence_results))
+
+    @property
+    def peak_memory_mb(self) -> float:
+        if not self.sequence_results:
+            return 0.0
+        return float(max(s.profiling.peak_memory_mb for s in self.sequence_results))
+
+
+def _make_result(
+    name: str,
+    fps: float = 30.0,
+    latency_ms: float = 33.0,
+    memory_mb: float = 100.0,
+    mean_power_w: Optional[float] = None,
+    n_seqs: int = 3,
+) -> _FakeBenchmarkResult:
+    seqs = []
+    for i in range(n_seqs):
+        profiling = _FakeProfiling(fps=fps, latency_mean_ms=latency_ms, peak_memory_mb=memory_mb)
+        energy = _FakeEnergy(mean_power_w=mean_power_w) if mean_power_w is not None else None
+        seqs.append(_FakeSeqResult(sequence_name=f"seq{i}", profiling=profiling, energy=energy))
+    return _FakeBenchmarkResult(tracker_name=name, sequence_results=seqs)
+
+
+# ---------------------------------------------------------------------------
+# HardwareProfile
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareProfile:
+    def test_all_built_in_profiles_exist(self) -> None:
+        for key in ("raspberry_pi_4", "jetson_nano", "jetson_xavier_nx", "workstation", "laptop_cpu"):
+            assert key in PROFILES
+
+    def test_profile_fields_positive(self) -> None:
+        for p in PROFILES.values():
+            assert p.tdp_watts > 0
+            assert p.memory_mb > 0
+            assert p.target_fps > 0
+            assert p.latency_budget_ms > 0
+            assert p.power_budget_w > 0
+
+    def test_get_profile_known(self) -> None:
+        p = get_profile("jetson_nano")
+        assert p.name == "jetson_nano"
+
+    def test_get_profile_unknown_raises(self) -> None:
+        with pytest.raises(KeyError, match="Unknown hardware profile"):
+            get_profile("nonexistent_device_xyz")
+
+    def test_list_profiles_sorted_by_tdp(self) -> None:
+        profiles = list_profiles()
+        tdps = [p.tdp_watts for p in profiles]
+        assert tdps == sorted(tdps)
+
+    def test_invalid_tdp_raises(self) -> None:
+        with pytest.raises(ValueError, match="tdp_watts"):
+            HardwareProfile(
+                name="bad", display_name="Bad", tdp_watts=-1,
+                memory_mb=1024, target_fps=30, latency_budget_ms=33,
+                power_budget_w=5,
+            )
+
+    def test_to_dict_has_all_keys(self) -> None:
+        p = get_profile("raspberry_pi_4")
+        d = p.to_dict()
+        for key in ("name", "display_name", "tdp_watts", "memory_mb", "target_fps",
+                    "latency_budget_ms", "power_budget_w", "description", "category"):
+            assert key in d
+
+    def test_category_field(self) -> None:
+        assert get_profile("raspberry_pi_4").category == "ultra_low"
+        assert get_profile("workstation").category == "workstation"
+
+
+# ---------------------------------------------------------------------------
+# Constraint score helpers
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintScoreHelpers:
+    def test_fps_score_exact_target(self) -> None:
+        cs = _fps_score(30.0, 30.0)
+        assert cs.score == pytest.approx(1.0)
+        assert cs.passed
+
+    def test_fps_score_below_target(self) -> None:
+        cs = _fps_score(15.0, 30.0)
+        assert cs.score == pytest.approx(0.5)
+        assert not cs.passed
+
+    def test_fps_score_exceeds_target_capped_at_1(self) -> None:
+        cs = _fps_score(120.0, 30.0)
+        assert cs.score == pytest.approx(1.0)
+        assert cs.passed
+
+    def test_latency_score_within_budget(self) -> None:
+        cs = _latency_score(20.0, 33.0)
+        assert cs.score == pytest.approx(min(33.0 / 20.0, 1.0))
+        assert cs.passed
+
+    def test_latency_score_exceeds_budget(self) -> None:
+        cs = _latency_score(50.0, 33.0)
+        assert not cs.passed
+        assert cs.score < 1.0
+
+    def test_memory_score_within_limit(self) -> None:
+        cs = _memory_score(256.0, 1024.0)
+        assert cs.score == pytest.approx(1.0)
+        assert cs.passed
+
+    def test_memory_score_exceeds_limit(self) -> None:
+        cs = _memory_score(5000.0, 4096.0)
+        assert not cs.passed
+
+    def test_power_score_none_when_no_data(self) -> None:
+        assert _power_score(None, 10.0) is None
+
+    def test_power_score_within_budget(self) -> None:
+        cs = _power_score(4.0, 10.0)
+        assert cs is not None
+        assert cs.passed
+        assert cs.score == pytest.approx(1.0)
+
+    def test_power_score_exceeds_budget(self) -> None:
+        cs = _power_score(15.0, 10.0)
+        assert cs is not None
+        assert not cs.passed
+
+
+# ---------------------------------------------------------------------------
+# DeploymentAdvisor.score
+# ---------------------------------------------------------------------------
+
+
+class TestDeploymentAdvisorScore:
+    def _advisor(self) -> DeploymentAdvisor:
+        return DeploymentAdvisor(memory_safety_factor=0.80)
+
+    def test_fast_low_mem_tracker_deployable_on_rpi4(self) -> None:
+        advisor = self._advisor()
+        profile = get_profile("raspberry_pi_4")
+        result = _make_result("MOSSE", fps=50.0, latency_ms=20.0, memory_mb=50.0)
+        ds = advisor.score(result, profile)
+        assert ds.deployable
+        assert ds.overall_score > 0.8
+
+    def test_slow_tracker_not_deployable_on_rpi4(self) -> None:
+        advisor = self._advisor()
+        profile = get_profile("raspberry_pi_4")
+        result = _make_result("SlowTracker", fps=5.0, latency_ms=200.0, memory_mb=50.0)
+        ds = advisor.score(result, profile)
+        assert not ds.deployable
+        assert "fps" in ds.violations or "latency" in ds.violations
+
+    def test_high_memory_tracker_not_deployable(self) -> None:
+        advisor = self._advisor()
+        profile = get_profile("raspberry_pi_4")
+        # 80% of 4096 MB = 3276.8 MB; use 4000 MB to exceed that
+        result = _make_result("HeavyTracker", fps=60.0, latency_ms=10.0, memory_mb=4000.0)
+        ds = advisor.score(result, profile)
+        assert not ds.deployable
+        assert "memory" in ds.violations
+
+    def test_energy_data_contributes_to_score(self) -> None:
+        advisor = self._advisor()
+        profile = get_profile("laptop_cpu")
+        # One tracker with energy data within budget
+        r_with_energy = _make_result("GreenTracker", fps=35.0, latency_ms=28.0,
+                                      memory_mb=200.0, mean_power_w=8.0)
+        ds = advisor.score(r_with_energy, profile)
+        has_power = ds.constraint("power") is not None
+        assert has_power
+
+    def test_score_returns_deployment_score_type(self) -> None:
+        advisor = self._advisor()
+        result = _make_result("T1")
+        ds = advisor.score(result, get_profile("workstation"))
+        assert isinstance(ds, DeploymentScore)
+
+    def test_to_dict_structure(self) -> None:
+        advisor = self._advisor()
+        ds = advisor.score(_make_result("T1"), get_profile("workstation"))
+        d = ds.to_dict()
+        for key in ("tracker_name", "profile_name", "overall_score",
+                    "deployable", "violations", "recommendation", "constraints"):
+            assert key in d
+
+    def test_recommendation_non_empty(self) -> None:
+        advisor = self._advisor()
+        ds = advisor.score(_make_result("T1"), get_profile("jetson_nano"))
+        assert len(ds.recommendation) > 0
+
+
+# ---------------------------------------------------------------------------
+# DeploymentAdvisor.rank
+# ---------------------------------------------------------------------------
+
+
+class TestDeploymentAdvisorRank:
+    def test_deployable_trackers_ranked_first(self) -> None:
+        advisor = DeploymentAdvisor()
+        profile = get_profile("raspberry_pi_4")
+        results = [
+            _make_result("SlowTracker", fps=3.0, latency_ms=333.0, memory_mb=50.0),
+            _make_result("FastTracker", fps=80.0, latency_ms=12.0, memory_mb=80.0),
+        ]
+        ranked = advisor.rank(results, profile)
+        assert ranked[0].tracker_name == "FastTracker"
+        assert ranked[0].deployable
+
+    def test_rank_returns_all_trackers(self) -> None:
+        advisor = DeploymentAdvisor()
+        profile = get_profile("jetson_xavier_nx")
+        results = [_make_result(f"T{i}", fps=10.0 * i + 1) for i in range(4)]
+        ranked = advisor.rank(results, profile)
+        assert len(ranked) == 4
+
+    def test_multi_profile_summary_keys(self) -> None:
+        advisor = DeploymentAdvisor()
+        profiles = [get_profile("raspberry_pi_4"), get_profile("workstation")]
+        results = [_make_result("T1"), _make_result("T2")]
+        summary = advisor.multi_profile_summary(results, profiles)
+        assert set(summary.keys()) == {"raspberry_pi_4", "workstation"}
+
+
+# ---------------------------------------------------------------------------
+# DeploymentAdvisor reporting
+# ---------------------------------------------------------------------------
+
+
+class TestDeploymentAdvisorReporting:
+    def test_report_markdown_contains_tracker_name(self) -> None:
+        advisor = DeploymentAdvisor()
+        profile = get_profile("jetson_nano")
+        results = [_make_result("CSRT", fps=35.0, latency_ms=28.0, memory_mb=150.0)]
+        ranked = advisor.rank(results, profile)
+        md = advisor.report_markdown(ranked, profile)
+        assert "CSRT" in md
+        assert "Jetson Nano" in md
+
+    def test_report_multi_profile_markdown_contains_devices(self) -> None:
+        advisor = DeploymentAdvisor()
+        profiles = [get_profile("raspberry_pi_4"), get_profile("jetson_nano")]
+        results = [_make_result("KCF"), _make_result("MOSSE")]
+        summary = advisor.multi_profile_summary(results, profiles)
+        md = advisor.report_multi_profile_markdown(summary, profiles)
+        assert "Raspberry Pi 4" in md
+        assert "Jetson Nano" in md
+        assert "KCF" in md
+        assert "MOSSE" in md
+
+    def test_memory_safety_factor_applied(self) -> None:
+        """A tracker using 85% of device RAM should fail with 80% safety factor
+        but pass with a 90% safety factor."""
+        profile = get_profile("raspberry_pi_4")  # 4096 MB
+        target_mb = 4096 * 0.87  # 87% of RAM
+        result = _make_result("BigTracker", fps=50.0, latency_ms=20.0, memory_mb=target_mb)
+
+        advisor_strict = DeploymentAdvisor(memory_safety_factor=0.80)
+        advisor_lenient = DeploymentAdvisor(memory_safety_factor=0.90)
+
+        ds_strict = advisor_strict.score(result, profile)
+        ds_lenient = advisor_lenient.score(result, profile)
+
+        assert not ds_strict.deployable
+        assert ds_lenient.deployable
+
+    def test_invalid_memory_safety_factor(self) -> None:
+        with pytest.raises(ValueError, match="memory_safety_factor"):
+            DeploymentAdvisor(memory_safety_factor=1.5)


### PR DESCRIPTION
## What was added

EOVOT's mission is to bridge academic tracking research and real-world edge deployment.  This PR makes that concrete: given any set of benchmark results, the `DeploymentAdvisor` tells you *exactly* which trackers can run on which devices and by how much.

### 1. Hardware Profile Registry (`eovot/profiling/hardware_profiles.py`)

`HardwareProfile` dataclass capturing five deployment constraints:

| Field | Meaning |
|-------|---------|
| `tdp_watts` | CPU Thermal Design Power |
| `memory_mb` | Available RAM |
| `target_fps` | Minimum real-time FPS |
| `latency_budget_ms` | Maximum per-frame latency |
| `power_budget_w` | Maximum sustained power draw |

8 built-in device profiles across the full edge-to-workstation spectrum:

| Profile key | Device | TDP | RAM |
|-------------|--------|-----|-----|
| `raspberry_pi_4` | RPi 4 (4 GB) | 6 W | 4 GB |
| `raspberry_pi_5` | RPi 5 (8 GB) | 12 W | 8 GB |
| `jetson_nano` | Jetson Nano | 10 W | 4 GB |
| `jetson_xavier_nx` | Jetson Xavier NX | 15 W | 8 GB |
| `jetson_orin_nano` | Jetson Orin Nano | 15 W | 8 GB |
| `intel_nuc_i5` | Intel NUC i5 | 28 W | 16 GB |
| `laptop_cpu` | Generic laptop | 15 W | 8 GB |
| `workstation` | Desktop CPU | 65 W | 32 GB |

### 2. Deployment Advisor (`eovot/profiling/deployment_advisor.py`)

Scores each `(tracker, device)` pair on four normalised `[0,1]` constraints:

- **FPS** (35% weight): `min(measured_fps / target_fps, 1.0)` — hard constraint
- **Latency** (35% weight): `min(budget_ms / measured_ms, 1.0)` — hard constraint  
- **Memory** (20% weight): `min(usable_ram / peak_mb, 1.0)` — hard constraint
- **Power** (10% weight): `min(budget_w / mean_power_w, 1.0)` — soft constraint

A tracker is **deployable** only when all three hard constraints are satisfied.  `rank()` returns deployable trackers first, sorted by overall score.

Reporting:
- `report_markdown()` — single-device ranked table with recommendations
- `report_multi_profile_markdown()` — cross-device compatibility matrix (trackers × devices)

### 3. CLI tool (`scripts/advise_deployment.py`)

Works directly from saved JSON benchmark result files — no dataset required:

```bash
# Single device
python scripts/advise_deployment.py results/mosse.json results/kcf.json \
    --profile jetson_nano

# All devices at once
python scripts/advise_deployment.py results/*.json --all-profiles

# Save to file
python scripts/advise_deployment.py results/*.json \
    --profile raspberry_pi_4 --output reports/rpi4_deployment.md
```

### 4. Config (`configs/hardware_profiles.yaml`)

YAML specification of all built-in profiles — usable as reference documentation or for constructing custom profiles.

## Why it matters

Without this module, EOVOT only tells you *how good* a tracker is.  Now it also tells you *where* it can run.  A research paper can now include a table like:

```
| Tracker  | RPi 4 | Jetson Nano | Xavier NX | Laptop |
|----------|-------|-------------|-----------|--------|
| MOSSE    | ✓ 0.91| ✓ 0.94      | ✓ 0.97    | ✓ 0.98 |
| KCF      | ✓ 0.82| ✓ 0.89      | ✓ 0.95    | ✓ 0.97 |
| CSRT     | ✗ 0.48| ✓ 0.71      | ✓ 0.88    | ✓ 0.93 |
| DaSiamRPN| ✗ 0.12| ✗ 0.31      | ✓ 0.64    | ✓ 0.79 |
```

## Files changed

| File | Change |
|------|--------|
| `eovot/profiling/hardware_profiles.py` | New — profile registry (~160 LoC) |
| `eovot/profiling/deployment_advisor.py` | New — scoring & reporting (~310 LoC) |
| `eovot/profiling/__init__.py` | Export new symbols |
| `scripts/advise_deployment.py` | New — CLI tool (~190 LoC) |
| `configs/hardware_profiles.yaml` | New — YAML device specs |
| `tests/test_deployment_advisor.py` | New — 32 unit tests |

## Example usage

```python
from eovot.profiling.hardware_profiles import PROFILES
from eovot.profiling.deployment_advisor import DeploymentAdvisor

advisor = DeploymentAdvisor(memory_safety_factor=0.80)

# Score against Jetson Nano
scores = advisor.rank(benchmark_results, PROFILES["jetson_nano"])
for s in scores:
    icon = "✓" if s.deployable else "✗"
    print(f"{icon} {s.tracker_name}: {s.overall_score:.3f}")

# Cross-device matrix
profiles = [PROFILES["raspberry_pi_4"], PROFILES["jetson_nano"], PROFILES["workstation"]]
summary = advisor.multi_profile_summary(benchmark_results, profiles)
print(advisor.report_multi_profile_markdown(summary, profiles))
```

## Design decisions

- **20% RAM safety factor** (configurable): reserves headroom for OS/system processes so scores reflect real-world deployment, not best-case lab conditions
- **Hard vs soft constraints**: power is soft because many edge deployments are not power-constrained (plugged in); FPS/latency/memory are always hard
- **Weighted scoring without power**: when energy profiling was not enabled, weights for FPS/latency/memory are re-normalised to sum to 1 — scores remain comparable

## Test coverage

32 tests across `TestHardwareProfile`, `TestConstraintScoreHelpers`, `TestDeploymentAdvisorScore`, `TestDeploymentAdvisorRank`, `TestDeploymentAdvisorReporting`:
- Profile validation (positive fields, sorting, unknown key error)
- Each constraint helper (exact target, below target, cap at 1.0)
- Deployability logic (fast tracker ✓, slow tracker ✗, high-memory tracker ✗)
- Memory safety factor boundary test
- Markdown output content verification
- Cross-device multi-profile summary keys

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScsgW4yqHzXMhdr3SGNeMu)_