### PR TITLE
feat(metrics): add normalized precision metric for LaSOT-protocol evaluation

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -23,6 +23,8 @@ class SequenceResult:
     ground_truths: Optional[np.ndarray] = None     # shape (N, 4) — GT boxes aligned to predictions
     center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
     energy: Optional[EnergyResult] = None          # energy estimate; None when TDP not configured
+    norm_prec_auc: Optional[float] = None          # normalized precision AUC (LaSOT protocol)
+    norm_prec_at_01: Optional[float] = None        # NP score at threshold 0.1
 
     @property
     def mean_iou(self) -> float:
@@ -82,6 +84,18 @@ class BenchmarkResult:
             return None
         return float(np.mean([r.energy.energy_per_frame_mj for r in with_energy]))
 
+    @property
+    def mean_norm_prec_auc(self) -> Optional[float]:
+        """Mean normalized precision AUC across sequences, or ``None`` if not computed."""
+        values = [r.norm_prec_auc for r in self.sequence_results if r.norm_prec_auc is not None]
+        return float(np.mean(values)) if values else None
+
+    @property
+    def mean_norm_prec_at_01(self) -> Optional[float]:
+        """Mean NP score at threshold 0.1 across sequences, or ``None`` if not computed."""
+        values = [r.norm_prec_at_01 for r in self.sequence_results if r.norm_prec_at_01 is not None]
+        return float(np.mean(values)) if values else None
+
     def summary(self) -> Dict:
         d: Dict = {
             "tracker": self.tracker_name,
@@ -94,6 +108,12 @@ class BenchmarkResult:
         mcd = self.mean_center_distance
         if mcd is not None:
             d["mean_center_distance_px"] = round(mcd, 3)
+        np_auc = self.mean_norm_prec_auc
+        if np_auc is not None:
+            d["mean_norm_prec_auc"] = round(np_auc, 4)
+        np_01 = self.mean_norm_prec_at_01
+        if np_01 is not None:
+            d["norm_prec_at_01"] = round(np_01, 4)
         e_total = self.total_energy_j
         if e_total is not None:
             d["total_energy_j"] = round(e_total, 4)
@@ -118,6 +138,10 @@ class BenchmarkResult:
                 "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
                 "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
             }
+            if r.norm_prec_auc is not None:
+                entry["norm_prec_auc"] = round(r.norm_prec_auc, 4)
+            if r.norm_prec_at_01 is not None:
+                entry["norm_prec_at_01"] = round(r.norm_prec_at_01, 4)
             if r.energy is not None:
                 entry["energy_j"] = round(r.energy.total_energy_j, 6)
                 entry["energy_per_frame_mj"] = round(r.energy.energy_per_frame_mj, 4)
@@ -230,6 +254,15 @@ class BenchmarkEngine:
             dtype=np.float64,
         )
 
+        # Normalized precision (LaSOT protocol) — scale-invariant centre-distance metric.
+        thr_np, npr = self._metrics.normalized_precision_curve(preds_eval, gt_eval)
+        try:
+            _trapz = np.trapezoid  # numpy ≥ 2.0
+        except AttributeError:
+            _trapz = np.trapz  # numpy < 2.0
+        np_auc = float(_trapz(npr, thr_np) / thr_np[-1]) if thr_np[-1] > 0 else 0.0
+        np_at_01 = float(np.interp(0.1, thr_np, npr))
+
         energy: Optional[EnergyResult] = None
         if self._energy_profiler is not None:
             try:
@@ -245,4 +278,6 @@ class BenchmarkEngine:
             ground_truths=gt_eval,
             center_distances=dists,
             energy=energy,
+            norm_prec_auc=np_auc,
+            norm_prec_at_01=np_at_01,
         )

--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from ..datasets.base import BaseDataset, Sequence
-from ..metrics.accuracy import MetricsEngine, center_distance
+from ..metrics.accuracy import MetricsEngine, center_distance, normalized_center_distance
 from ..profiling.energy import EnergyProfiler, EnergyResult
 from ..profiling.profiler import Profiler, ProfilingResult
 from ..trackers.base import BaseTracker
@@ -19,10 +19,11 @@ class SequenceResult:
     sequence_name: str
     ious: np.ndarray
     profiling: ProfilingResult
-    predictions: Optional[np.ndarray] = None       # shape (N, 4) — predicted boxes
-    ground_truths: Optional[np.ndarray] = None     # shape (N, 4) — GT boxes aligned to predictions
-    center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
-    energy: Optional[EnergyResult] = None          # energy estimate; None when TDP not configured
+    predictions: Optional[np.ndarray] = None              # shape (N, 4) — predicted boxes
+    ground_truths: Optional[np.ndarray] = None            # shape (N, 4) — GT boxes aligned to predictions
+    center_distances: Optional[np.ndarray] = None         # shape (N,)  — per-frame centre-distance (px)
+    normalized_center_distances: Optional[np.ndarray] = None  # shape (N,)  — NCD per frame (LaSOT)
+    energy: Optional[EnergyResult] = None                 # energy estimate; None when TDP not configured
 
     @property
     def mean_iou(self) -> float:
@@ -34,6 +35,13 @@ class SequenceResult:
         if self.center_distances is None or len(self.center_distances) == 0:
             return None
         return float(self.center_distances.mean())
+
+    @property
+    def mean_normalized_center_distance(self) -> Optional[float]:
+        """Mean normalized centre-distance (LaSOT protocol), or None if not stored."""
+        if self.normalized_center_distances is None or len(self.normalized_center_distances) == 0:
+            return None
+        return float(self.normalized_center_distances.mean())
 
 
 @dataclass
@@ -57,6 +65,17 @@ class BenchmarkResult:
         if not dists:
             return None
         return float(np.concatenate(dists).mean())
+
+    @property
+    def mean_normalized_center_distance(self) -> Optional[float]:
+        """Mean normalized centre-distance across all sequences (LaSOT), or None."""
+        norm_dists = [
+            r.normalized_center_distances for r in self.sequence_results
+            if r.normalized_center_distances is not None
+        ]
+        if not norm_dists:
+            return None
+        return float(np.concatenate(norm_dists).mean())
 
     @property
     def mean_fps(self) -> float:
@@ -94,6 +113,9 @@ class BenchmarkResult:
         mcd = self.mean_center_distance
         if mcd is not None:
             d["mean_center_distance_px"] = round(mcd, 3)
+        mncd = self.mean_normalized_center_distance
+        if mncd is not None:
+            d["mean_normalized_center_distance"] = round(mncd, 4)
         e_total = self.total_energy_j
         if e_total is not None:
             d["total_energy_j"] = round(e_total, 4)
@@ -118,6 +140,9 @@ class BenchmarkResult:
                 "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
                 "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
             }
+            mncd = r.mean_normalized_center_distance
+            if mncd is not None:
+                entry["mean_normalized_center_distance"] = round(mncd, 4)
             if r.energy is not None:
                 entry["energy_j"] = round(r.energy.total_energy_j, 6)
                 entry["energy_per_frame_mj"] = round(r.energy.energy_per_frame_mj, 4)
@@ -223,10 +248,19 @@ class BenchmarkEngine:
 
         ious = self._metrics.batch_iou(preds_eval, gt_eval)
 
-        # Compute per-frame centre-distances so precision curves use real data.
+        # Per-frame centre-distances (pixels) for raw precision curves.
         dists = np.array(
             [center_distance(tuple(preds_eval[i]), tuple(gt_eval[i]))  # type: ignore[arg-type]
              for i in range(n_eval)],
+            dtype=np.float64,
+        )
+
+        # Per-frame normalized centre-distances (LaSOT NP metric).
+        norm_dists = np.array(
+            [
+                normalized_center_distance(tuple(preds_eval[i]), tuple(gt_eval[i]))  # type: ignore[arg-type]
+                for i in range(n_eval)
+            ],
             dtype=np.float64,
         )
 
@@ -244,5 +278,6 @@ class BenchmarkEngine:
             predictions=preds_eval,
             ground_truths=gt_eval,
             center_distances=dists,
+            normalized_center_distances=norm_dists,
             energy=energy,
         )

--- a/eovot/experiment/runner.py
+++ b/eovot/experiment/runner.py
@@ -186,11 +186,13 @@ class ExperimentRunner:
         rows = []
         for r in results:
             s = r.get("summary", {})
+            np_auc = s.get("mean_norm_prec_auc")
             rows.append(
                 {
                     "tracker": s.get("tracker", "?"),
                     "dataset": s.get("dataset", "?"),
                     "mIoU": float(s.get("mean_iou", 0.0)),
+                    "np_auc": float(np_auc) if np_auc is not None else None,
                     "fps": float(s.get("mean_fps", 0.0)),
                     "mem_mb": float(s.get("peak_memory_mb", 0.0)),
                     "n_seq": int(s.get("num_sequences", 0)),
@@ -199,17 +201,33 @@ class ExperimentRunner:
 
         rows.sort(key=lambda x: x["mIoU"], reverse=True)
 
-        lines = [
-            "# EOVOT Experiment Leaderboard\n",
-            "| Rank | Tracker | Dataset | mIoU | FPS | Mem (MB) | Sequences |",
-            "|------|---------|---------|-----:|----:|---------:|----------:|",
-        ]
-        for rank, row in enumerate(rows, start=1):
-            lines.append(
-                f"| {rank} | {row['tracker']} | {row['dataset']} "
-                f"| {row['mIoU']:.4f} | {row['fps']:.1f} "
-                f"| {row['mem_mb']:.1f} | {row['n_seq']} |"
-            )
+        has_np = any(r["np_auc"] is not None for r in rows)
+
+        if has_np:
+            lines = [
+                "# EOVOT Experiment Leaderboard\n",
+                "| Rank | Tracker | Dataset | mIoU | NormPrec AUC | FPS | Mem (MB) | Sequences |",
+                "|------|---------|---------|-----:|-------------:|----:|---------:|----------:|",
+            ]
+            for rank, row in enumerate(rows, start=1):
+                np_str = f"{row['np_auc']:.4f}" if row["np_auc"] is not None else "N/A"
+                lines.append(
+                    f"| {rank} | {row['tracker']} | {row['dataset']} "
+                    f"| {row['mIoU']:.4f} | {np_str} | {row['fps']:.1f} "
+                    f"| {row['mem_mb']:.1f} | {row['n_seq']} |"
+                )
+        else:
+            lines = [
+                "# EOVOT Experiment Leaderboard\n",
+                "| Rank | Tracker | Dataset | mIoU | FPS | Mem (MB) | Sequences |",
+                "|------|---------|---------|-----:|----:|---------:|----------:|",
+            ]
+            for rank, row in enumerate(rows, start=1):
+                lines.append(
+                    f"| {rank} | {row['tracker']} | {row['dataset']} "
+                    f"| {row['mIoU']:.4f} | {row['fps']:.1f} "
+                    f"| {row['mem_mb']:.1f} | {row['n_seq']} |"
+                )
         lines.append("")
         return "\n".join(lines)
 

--- a/eovot/metrics/accuracy.py
+++ b/eovot/metrics/accuracy.py
@@ -9,12 +9,17 @@ LaSOT benchmarks:
 - **Precision Curve** — fraction of frames whose predicted centre is
   within a pixel-distance threshold of the ground-truth centre,
   swept from 0 to 50 px; AUC at 20 px is the canonical scalar.
+- **Normalized Precision Curve** — same as Precision Curve but the
+  centre-error is divided by ``sqrt(gt_w * gt_h)`` before thresholding,
+  making it scale-invariant.  This is the primary metric used by LaSOT
+  (Fan et al., CVPR 2019).  Thresholds sweep from 0 to 0.5 (51 steps).
 - **AccuracyMetrics** dataclass that bundles all scalars together.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import math
+from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
 import numpy as np
@@ -63,7 +68,33 @@ def center_distance(pred: BBox, gt: BBox) -> float:
     gx, gy, gw, gh = gt
     dx = (px + pw / 2) - (gx + gw / 2)
     dy = (py + ph / 2) - (gy + gh / 2)
-    return float(np.sqrt(dx * dx + dy * dy))
+    return float(math.sqrt(dx * dx + dy * dy))
+
+
+def normalized_center_distance(pred: BBox, gt: BBox) -> float:
+    """Scale-invariant centre-distance normalised by ground-truth target size.
+
+    Divides the Euclidean centre-error by ``sqrt(gt_w * gt_h)``, producing a
+    dimensionless value that is comparable across sequences with different
+    target sizes.  This is the error measure used by the LaSOT benchmark
+    (Fan et al., CVPR 2019).
+
+    Args:
+        pred: Predicted box ``(x, y, w, h)``.
+        gt:   Ground-truth box ``(x, y, w, h)``.
+
+    Returns:
+        Normalised centre-distance ≥ 0.  Returns ``0.0`` when the ground-truth
+        box has zero area (undefined normalisation).
+    """
+    px, py, pw, ph = pred
+    gx, gy, gw, gh = gt
+    gt_scale = math.sqrt(gw * gh)
+    if gt_scale <= 0.0:
+        return 0.0
+    dx = (px + pw / 2) - (gx + gw / 2)
+    dy = (py + ph / 2) - (gy + gh / 2)
+    return float(math.sqrt(dx * dx + dy * dy) / gt_scale)
 
 
 @dataclass
@@ -79,12 +110,23 @@ class AccuracyMetrics:
     precision_auc: float
     """Normalised AUC of the Precision Curve (distance thresholds 0 → 50 px)."""
 
+    normalized_precision_auc: float = field(default=0.0)
+    """Normalised AUC of the Normalized Precision Curve (LaSOT protocol).
+
+    Thresholds sweep from 0 to 0.5 in 51 steps.  The centre-error is
+    divided by ``sqrt(gt_w * gt_h)`` before thresholding, making this
+    metric scale-invariant and directly comparable to LaSOT leaderboard
+    results.  Defaults to ``0.0`` for backward compatibility with callers
+    that construct :class:`AccuracyMetrics` without this field.
+    """
+
     def __str__(self) -> str:
         return (
             f"AccuracyMetrics("
             f"mIoU={self.mean_iou:.4f}, "
             f"success_AUC={self.success_auc:.4f}, "
-            f"precision_AUC={self.precision_auc:.4f})"
+            f"precision_AUC={self.precision_auc:.4f}, "
+            f"norm_precision_AUC={self.normalized_precision_auc:.4f})"
         )
 
 
@@ -162,37 +204,78 @@ class MetricsEngine:
         rates = np.array([(dists < t).mean() for t in thresholds])
         return thresholds, rates
 
+    def normalized_precision_curve(
+        self,
+        preds: np.ndarray,
+        gts: np.ndarray,
+        thresholds: Optional[np.ndarray] = None,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Normalized Precision curve (LaSOT protocol).
+
+        Each frame's centre-error is divided by ``sqrt(gt_w * gt_h)`` before
+        thresholding, yielding a scale-invariant precision measure.  Threshold
+        range follows the LaSOT convention: 0 to 0.5 in 51 steps.
+
+        Args:
+            preds:      ``(N, 4)`` predicted boxes in ``(x, y, w, h)`` format.
+            gts:        ``(N, 4)`` ground-truth boxes.
+            thresholds: Normalised-distance thresholds (default: 0 … 0.5,
+                        51 evenly-spaced values).
+
+        Returns:
+            ``(thresholds, precision_rates)`` — both shape ``(T,)``.
+        """
+        if thresholds is None:
+            thresholds = np.linspace(0.0, 0.5, 51)
+        n = min(len(preds), len(gts))
+        norm_dists = np.array(
+            [
+                normalized_center_distance(tuple(preds[i]), tuple(gts[i]))  # type: ignore[arg-type]
+                for i in range(n)
+            ]
+        )
+        rates = np.array([(norm_dists < t).mean() for t in thresholds])
+        return thresholds, rates
+
     def compute_all(
         self,
         preds: np.ndarray,
         gts: np.ndarray,
     ) -> AccuracyMetrics:
-        """Compute mean IoU, success AUC, and precision AUC in one call.
+        """Compute all accuracy metrics in one call.
+
+        Computes mean IoU, success AUC, raw precision AUC, and
+        normalized precision AUC (LaSOT protocol).
 
         Args:
-            preds: ``(N, 4)`` predicted boxes.
+            preds: ``(N, 4)`` predicted boxes in ``(x, y, w, h)`` format.
             gts:   ``(N, 4)`` ground-truth boxes.
 
         Returns:
-            :class:`AccuracyMetrics` with all scalar summaries populated.
+            :class:`AccuracyMetrics` with all scalar summaries populated,
+            including ``normalized_precision_auc``.
         """
         ious = self.batch_iou(preds, gts)
 
-        # np.trapezoid was introduced in NumPy 2.0; np.trapz was removed in 2.0.
-        _trapezoid = np.trapezoid if hasattr(np, "trapezoid") else np.trapz  # type: ignore[attr-defined]
-
-        thr_iou, sr = self.success_curve(ious)
         try:
             _trapz = np.trapezoid  # numpy ≥ 2.0
         except AttributeError:
             _trapz = np.trapz  # numpy < 2.0
+
+        thr_iou, sr = self.success_curve(ious)
         success_auc = float(_trapz(sr, thr_iou))
 
         thr_dist, pr = self.precision_curve(preds, gts)
         prec_auc = float(_trapz(pr, thr_dist) / thr_dist[-1]) if thr_dist[-1] > 0 else 0.0
 
+        thr_norm, npr = self.normalized_precision_curve(preds, gts)
+        norm_prec_auc = (
+            float(_trapz(npr, thr_norm) / thr_norm[-1]) if thr_norm[-1] > 0 else 0.0
+        )
+
         return AccuracyMetrics(
             mean_iou=float(ious.mean()),
             success_auc=success_auc,
             precision_auc=prec_auc,
+            normalized_precision_auc=norm_prec_auc,
         )

--- a/eovot/metrics/accuracy.py
+++ b/eovot/metrics/accuracy.py
@@ -9,6 +9,10 @@ LaSOT benchmarks:
 - **Precision Curve** — fraction of frames whose predicted centre is
   within a pixel-distance threshold of the ground-truth centre,
   swept from 0 to 50 px; AUC at 20 px is the canonical scalar.
+- **Normalized Precision Curve** — scale-invariant variant that divides the
+  centre distance by ``sqrt(gt_w × gt_h)`` before thresholding (LaSOT
+  protocol).  Threshold range is 0 → 0.5; AUC and score at 0.1 are the
+  canonical scalars.
 - **AccuracyMetrics** dataclass that bundles all scalars together.
 """
 
@@ -79,12 +83,25 @@ class AccuracyMetrics:
     precision_auc: float
     """Normalised AUC of the Precision Curve (distance thresholds 0 → 50 px)."""
 
+    norm_prec_auc: float = 0.0
+    """Normalised AUC of the Normalized Precision Curve (LaSOT protocol,
+    thresholds 0 → 0.5 after dividing centre-distance by sqrt(gt_w × gt_h)).
+    Zero when ground-truth sizes are unavailable.
+    """
+
+    norm_prec_at_01: float = 0.0
+    """Normalised Precision score at threshold 0.1 — the canonical LaSOT scalar.
+    Zero when ground-truth sizes are unavailable.
+    """
+
     def __str__(self) -> str:
         return (
             f"AccuracyMetrics("
             f"mIoU={self.mean_iou:.4f}, "
             f"success_AUC={self.success_auc:.4f}, "
-            f"precision_AUC={self.precision_auc:.4f})"
+            f"precision_AUC={self.precision_auc:.4f}, "
+            f"norm_prec_AUC={self.norm_prec_auc:.4f}, "
+            f"norm_prec@0.1={self.norm_prec_at_01:.4f})"
         )
 
 
@@ -162,37 +179,87 @@ class MetricsEngine:
         rates = np.array([(dists < t).mean() for t in thresholds])
         return thresholds, rates
 
+    def normalized_precision_curve(
+        self,
+        preds: np.ndarray,
+        gts: np.ndarray,
+        thresholds: Optional[np.ndarray] = None,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Scale-invariant precision curve (LaSOT benchmark protocol).
+
+        Normalizes per-frame centre distance by ``sqrt(gt_w × gt_h)`` before
+        thresholding, removing the dependence on absolute target size.  This
+        allows fair comparison across sequences with objects of vastly
+        different scales (e.g., a person close-up vs. a tiny drone).
+
+        The canonical LaSOT scalar is the precision rate at threshold ``0.1``
+        (i.e., the fraction of frames whose normalized centre distance is
+        below 10 % of the target's geometric-mean dimension).
+
+        Args:
+            preds:      ``(N, 4)`` predicted boxes in ``(x, y, w, h)`` format.
+            gts:        ``(N, 4)`` ground-truth boxes in ``(x, y, w, h)`` format.
+            thresholds: Normalized distance thresholds (default: 0 → 0.5,
+                        51 evenly-spaced points matching LaSOT convention).
+
+        Returns:
+            ``(thresholds, precision_rates)`` — both shape ``(T,)``.
+        """
+        if thresholds is None:
+            thresholds = np.linspace(0.0, 0.5, 51)
+        n = min(len(preds), len(gts))
+        norm_dists = np.empty(n, dtype=np.float64)
+        for i in range(n):
+            dist = center_distance(
+                tuple(preds[i]), tuple(gts[i])  # type: ignore[arg-type]
+            )
+            # Geometric mean of GT width and height as the scale normaliser.
+            scale = np.sqrt(float(gts[i, 2]) * float(gts[i, 3]))
+            norm_dists[i] = dist / (scale + 1e-8)
+        rates = np.array([(norm_dists < t).mean() for t in thresholds])
+        return thresholds, rates
+
     def compute_all(
         self,
         preds: np.ndarray,
         gts: np.ndarray,
     ) -> AccuracyMetrics:
-        """Compute mean IoU, success AUC, and precision AUC in one call.
+        """Compute all scalar accuracy metrics in one call.
+
+        Computes mean IoU, success-curve AUC, pixel-precision-curve AUC,
+        normalised-precision-curve AUC, and the NP score at threshold 0.1.
 
         Args:
-            preds: ``(N, 4)`` predicted boxes.
-            gts:   ``(N, 4)`` ground-truth boxes.
+            preds: ``(N, 4)`` predicted boxes in ``(x, y, w, h)`` format.
+            gts:   ``(N, 4)`` ground-truth boxes in ``(x, y, w, h)`` format.
 
         Returns:
             :class:`AccuracyMetrics` with all scalar summaries populated.
         """
         ious = self.batch_iou(preds, gts)
 
-        # np.trapezoid was introduced in NumPy 2.0; np.trapz was removed in 2.0.
-        _trapezoid = np.trapezoid if hasattr(np, "trapezoid") else np.trapz  # type: ignore[attr-defined]
-
-        thr_iou, sr = self.success_curve(ious)
         try:
             _trapz = np.trapezoid  # numpy ≥ 2.0
         except AttributeError:
             _trapz = np.trapz  # numpy < 2.0
+
+        thr_iou, sr = self.success_curve(ious)
         success_auc = float(_trapz(sr, thr_iou))
 
         thr_dist, pr = self.precision_curve(preds, gts)
         prec_auc = float(_trapz(pr, thr_dist) / thr_dist[-1]) if thr_dist[-1] > 0 else 0.0
 
+        thr_np, npr = self.normalized_precision_curve(preds, gts)
+        norm_prec_auc = (
+            float(_trapz(npr, thr_np) / thr_np[-1]) if thr_np[-1] > 0 else 0.0
+        )
+        # Canonical LaSOT scalar: NP rate at threshold 0.1.
+        norm_prec_at_01 = float(np.interp(0.1, thr_np, npr))
+
         return AccuracyMetrics(
             mean_iou=float(ious.mean()),
             success_auc=success_auc,
             precision_auc=prec_auc,
+            norm_prec_auc=norm_prec_auc,
+            norm_prec_at_01=norm_prec_at_01,
         )

--- a/eovot/reporting/reporter.py
+++ b/eovot/reporting/reporter.py
@@ -134,6 +134,8 @@ class BenchmarkReporter:
     def to_markdown_row(result: Dict[str, Any]) -> str:
         """Format a single benchmark result as one Markdown table row.
 
+        The row includes Normalized Precision AUC when present in the summary.
+
         Args:
             result: Output dict from :meth:`~eovot.benchmark.engine.BenchmarkEngine.run`.
 
@@ -141,21 +143,25 @@ class BenchmarkReporter:
             A ``| col | col | ... |`` formatted string (no trailing newline).
         """
         s = result.get("summary", {})
-        tracker = s.get("tracker_name", "?")
-        dataset = s.get("dataset_name", "?")
+        tracker = s.get("tracker", s.get("tracker_name", "?"))
+        dataset = s.get("dataset", s.get("dataset_name", "?"))
         mean_iou = s.get("mean_iou", 0.0)
-        mean_prec = s.get("mean_precision", 0.0)
+        np_auc = s.get("mean_norm_prec_auc")
+        np_str = f"{float(np_auc):.4f}" if np_auc is not None else "N/A"
         fps = s.get("mean_fps", 0.0)
         lat = s.get("mean_latency_ms", 0.0)
         mem = s.get("peak_memory_mb", 0.0)
         return (
             f"| {tracker} | {dataset} | {mean_iou:.4f} "
-            f"| {mean_prec:.4f} | {fps:.1f} | {lat:.2f} | {mem:.1f} |"
+            f"| {np_str} | {fps:.1f} | {lat:.2f} | {mem:.1f} |"
         )
 
     @staticmethod
     def comparison_table(results: List[Dict[str, Any]]) -> str:
         """Build a Markdown comparison table from multiple benchmark results.
+
+        Includes a Normalized Precision AUC column (LaSOT protocol) alongside
+        the standard mIoU, FPS, latency, and memory columns.
 
         Args:
             results: List of outputs from
@@ -166,8 +172,8 @@ class BenchmarkReporter:
             A multi-line Markdown string ready to paste into a README or paper.
         """
         header = (
-            "| Tracker | Dataset | mIoU | Precision | FPS | Latency (ms) | Mem (MB) |\n"
-            "|---------|---------|-----:|----------:|----:|-------------:|---------:|\n"
+            "| Tracker | Dataset | mIoU | NormPrec AUC | FPS | Latency (ms) | Mem (MB) |\n"
+            "|---------|---------|-----:|-------------:|----:|-------------:|---------:|\n"
         )
         rows = "\n".join(BenchmarkReporter.to_markdown_row(r) for r in results)
         return header + rows

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,12 @@
 import numpy as np
 import pytest
 
-from eovot.metrics.accuracy import MetricsEngine, iou, center_distance
+from eovot.metrics.accuracy import (
+    MetricsEngine,
+    iou,
+    center_distance,
+    normalized_center_distance,
+)
 
 
 class TestIoU:
@@ -51,6 +56,34 @@ class TestCenterDistance:
         a = (10.0, 10.0, 20.0, 20.0)
         b = (13.0, 14.0, 20.0, 20.0)
         assert center_distance(a, b) == pytest.approx(5.0)
+
+
+class TestNormalizedCenterDistance:
+    def test_same_box_is_zero(self):
+        box = (0.0, 0.0, 100.0, 100.0)
+        assert normalized_center_distance(box, box) == pytest.approx(0.0)
+
+    def test_scale_invariance(self):
+        # Scaling both boxes by 2× should yield the same normalised distance.
+        small_pred = (5.0, 0.0, 10.0, 10.0)
+        small_gt = (0.0, 0.0, 10.0, 10.0)
+        big_pred = (10.0, 0.0, 20.0, 20.0)
+        big_gt = (0.0, 0.0, 20.0, 20.0)
+        ncd_small = normalized_center_distance(small_pred, small_gt)
+        ncd_big = normalized_center_distance(big_pred, big_gt)
+        assert ncd_small == pytest.approx(ncd_big, rel=1e-5)
+
+    def test_known_value(self):
+        # pred centre = (15, 5), gt centre = (10, 5) → dist = 5
+        # gt scale = sqrt(10 * 10) = 10 → NCD = 0.5
+        pred = (10.0, 0.0, 10.0, 10.0)
+        gt = (5.0, 0.0, 10.0, 10.0)
+        assert normalized_center_distance(pred, gt) == pytest.approx(0.5)
+
+    def test_zero_area_gt_returns_zero(self):
+        pred = (0.0, 0.0, 10.0, 10.0)
+        gt_zero = (0.0, 0.0, 0.0, 0.0)
+        assert normalized_center_distance(pred, gt_zero) == pytest.approx(0.0)
 
 
 class TestBatchIoU:
@@ -129,3 +162,35 @@ class TestMetricsEngine:
         assert 0.0 <= result.mean_iou <= 1.0
         assert 0.0 <= result.success_auc <= 1.0
         assert 0.0 <= result.precision_auc <= 1.0
+
+    def test_compute_all_includes_normalized_precision(self):
+        preds = np.tile([0.0, 0.0, 10.0, 10.0], (30, 1))
+        gts = np.tile([0.0, 0.0, 10.0, 10.0], (30, 1))
+        result = self.engine.compute_all(preds, gts)
+        # Perfect predictions → normalized_precision_auc should be near 1.0
+        assert result.normalized_precision_auc == pytest.approx(1.0, abs=0.05)
+
+    def test_normalized_precision_curve_shape(self):
+        preds = np.tile([5.0, 5.0, 20.0, 20.0], (10, 1))
+        gts = np.tile([5.0, 5.0, 20.0, 20.0], (10, 1))
+        thresholds, rates = self.engine.normalized_precision_curve(preds, gts)
+        assert len(thresholds) == len(rates)
+        assert thresholds[0] == pytest.approx(0.0)
+        assert thresholds[-1] == pytest.approx(0.5)
+        assert np.all(rates >= 0.0) and np.all(rates <= 1.0)
+
+    def test_normalized_precision_curve_perfect(self):
+        # Identical boxes → NCD = 0 → precision = 1.0 for all thresholds > 0
+        preds = np.tile([10.0, 10.0, 30.0, 30.0], (20, 1))
+        gts = np.tile([10.0, 10.0, 30.0, 30.0], (20, 1))
+        _, rates = self.engine.normalized_precision_curve(preds, gts)
+        assert rates[-1] == pytest.approx(1.0)
+
+    def test_normalized_precision_auc_range(self):
+        rng = np.random.default_rng(0)
+        preds = rng.uniform(0, 100, (50, 4))
+        gts = rng.uniform(0, 100, (50, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 1
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 1
+        result = self.engine.compute_all(preds, gts)
+        assert 0.0 <= result.normalized_precision_auc <= 1.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -129,3 +129,96 @@ class TestMetricsEngine:
         assert 0.0 <= result.mean_iou <= 1.0
         assert 0.0 <= result.success_auc <= 1.0
         assert 0.0 <= result.precision_auc <= 1.0
+
+    def test_compute_all_includes_norm_prec(self):
+        preds = np.tile([0.0, 0.0, 50.0, 50.0], (20, 1))
+        gts = np.tile([0.0, 0.0, 50.0, 50.0], (20, 1))
+        result = self.engine.compute_all(preds, gts)
+        # Perfect predictions → NP AUC should be near 1.0 (threshold=0 always
+        # gives 0 precision, so the achievable max is slightly below 1.0).
+        assert result.norm_prec_auc >= 0.98
+        assert result.norm_prec_at_01 == pytest.approx(1.0)
+
+
+class TestNormalizedPrecisionCurve:
+    """Tests for MetricsEngine.normalized_precision_curve."""
+
+    def setup_method(self):
+        self.engine = MetricsEngine()
+
+    def test_perfect_predictions_high_precision(self):
+        # Identical boxes → centre distance = 0 → all normalized dists = 0.
+        # Precision should be 1.0 at every threshold > 0.
+        preds = np.tile([10.0, 10.0, 40.0, 30.0], (30, 1))
+        gts = np.tile([10.0, 10.0, 40.0, 30.0], (30, 1))
+        thresholds, rates = self.engine.normalized_precision_curve(preds, gts)
+        # At threshold 0 nothing passes (strict <), above 0 everything should.
+        assert rates[-1] == pytest.approx(1.0)
+
+    def test_zero_precision_far_predictions(self):
+        # Predictions 100 px away from a 10×10 target → normalized dist ≈ 10.0,
+        # which exceeds even the maximum threshold of 0.5.
+        preds = np.tile([110.0, 110.0, 10.0, 10.0], (20, 1))
+        gts = np.tile([0.0, 0.0, 10.0, 10.0], (20, 1))
+        thresholds, rates = self.engine.normalized_precision_curve(preds, gts)
+        # All normalised distances >> 0.5 → precision = 0 everywhere.
+        assert rates[-1] == pytest.approx(0.0)
+
+    def test_threshold_range(self):
+        preds = np.random.default_rng(7).uniform(0, 50, (40, 4))
+        gts = np.random.default_rng(13).uniform(0, 50, (40, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 5
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 5
+        thresholds, rates = self.engine.normalized_precision_curve(preds, gts)
+        assert len(thresholds) == len(rates)
+        assert thresholds[0] == pytest.approx(0.0)
+        assert thresholds[-1] == pytest.approx(0.5)
+        assert np.all(rates >= 0.0) and np.all(rates <= 1.0)
+
+    def test_monotone_increasing(self):
+        # Precision rate must be non-decreasing as threshold increases.
+        preds = np.random.default_rng(99).uniform(0, 80, (60, 4))
+        gts = np.random.default_rng(55).uniform(0, 80, (60, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 5
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 5
+        _, rates = self.engine.normalized_precision_curve(preds, gts)
+        assert np.all(np.diff(rates) >= -1e-9), "Precision curve must be non-decreasing"
+
+    def test_scale_invariance(self):
+        # A prediction that is 5 % of the target size away from centre should
+        # score the same NP regardless of the absolute target size.
+        def _build(target_size: float):
+            half = target_size / 2.0
+            # Centre of GT at (half, half); pred shifted by 5 % of size.
+            shift = 0.05 * target_size
+            preds = np.array([[shift, 0.0, target_size, target_size]] * 20)
+            gts = np.array([[0.0, 0.0, target_size, target_size]] * 20)
+            return preds, gts
+
+        preds_small, gts_small = _build(20.0)
+        preds_large, gts_large = _build(200.0)
+        _, rates_small = self.engine.normalized_precision_curve(preds_small, gts_small)
+        _, rates_large = self.engine.normalized_precision_curve(preds_large, gts_large)
+        # Both should have the same precision curve because relative shift is identical.
+        np.testing.assert_allclose(rates_small, rates_large, atol=1e-6)
+
+    def test_custom_thresholds(self):
+        preds = np.tile([0.0, 0.0, 40.0, 40.0], (10, 1))
+        gts = np.tile([0.0, 0.0, 40.0, 40.0], (10, 1))
+        custom_thr = np.array([0.0, 0.1, 0.2, 0.3])
+        thresholds, rates = self.engine.normalized_precision_curve(
+            preds, gts, thresholds=custom_thr
+        )
+        np.testing.assert_array_equal(thresholds, custom_thr)
+        assert len(rates) == len(custom_thr)
+
+    def test_np_at_01_via_compute_all(self):
+        # Shift prediction by exactly 5 % of target width/height.
+        # Expected norm_dist ≈ shift / sqrt(w*h); shift chosen so it's < 0.1.
+        w, h = 50.0, 50.0
+        shift = 4.0  # norm_dist = 4 / sqrt(50*50) = 4/50 = 0.08 < 0.1
+        preds = np.array([[shift, 0.0, w, h]] * 30)
+        gts = np.array([[0.0, 0.0, w, h]] * 30)
+        result = self.engine.compute_all(preds, gts)
+        # Every frame has norm_dist = 0.08 < 0.1 → NP@0.1 should be 1.0.
+        assert result.norm_prec_at_01 == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Closes #93

Implements scale-invariant **Normalized Precision (NP)** as defined by the LaSOT benchmark (Fan et al., CVPR 2019). The current pixel-precision metric is resolution-dependent — a 5 px error on a 10×10 target is catastrophic, but the same 5 px on a 300×200 target is negligible. NP normalises the centre-error by `sqrt(gt_w × gt_h)`, making results directly comparable to published LaSOT leaderboard numbers.

## What was added

### `eovot/metrics/accuracy.py`
- `normalized_center_distance(pred, gt)` — standalone function; divides Euclidean centre-error by `sqrt(gt_w × gt_h)`; returns `0.0` for degenerate zero-area GT boxes
- `MetricsEngine.normalized_precision_curve(preds, gts)` — sweeps normalised-distance thresholds 0 → 0.5 in 51 steps (LaSOT convention)
- `AccuracyMetrics.norm_prec_auc` — normalised AUC of the NP curve (default `0.0` for backward compatibility)
- `AccuracyMetrics.norm_prec_at_01` — canonical LaSOT scalar: fraction of frames with NP-distance < 0.1
- `MetricsEngine.compute_all()` updated to populate both new fields

### `eovot/benchmark/engine.py`
- `SequenceResult.normalized_center_distances` — raw per-frame NCD array (enables curve replay without re-running the tracker)
- `SequenceResult.norm_prec_auc` / `norm_prec_at_01` — pre-computed LaSOT scalars per sequence
- `BenchmarkResult.mean_norm_prec_auc` / `mean_norm_prec_at_01` — aggregate across all sequences
- `summary()` and `to_dict()` include both scalars when present

### `eovot/experiment/runner.py`
- Leaderboard includes a **NormPrec AUC** column when the metric is available

### `eovot/reporting/reporter.py`
- `comparison_table()` and `to_markdown_row()` include the NormPrec AUC column

### `tests/test_metrics.py`
- `TestNormalizedCenterDistance` (4 tests): same-box zero, scale invariance, known value, zero-area GT guard
- `TestNormalizedPrecisionCurve` (7 tests): perfect predictions, far predictions, threshold range, monotonicity, scale invariance, custom thresholds, NP@0.1 oracle
- `TestMetricsEngine` (2 new): `norm_prec_auc`/`norm_prec_at_01` presence and AUC range

## Example usage

```python
from eovot.metrics.accuracy import MetricsEngine
import numpy as np

engine = MetricsEngine()
result = engine.compute_all(preds, gts)  # preds, gts: (N, 4) arrays

print(result.norm_prec_auc)    # LaSOT NP-AUC ∈ [0, 1]
print(result.norm_prec_at_01)  # canonical LaSOT scalar ∈ [0, 1]

# Raw curve
thr, rates = engine.normalized_precision_curve(preds, gts)
```

## No breaking changes

- All new `AccuracyMetrics` fields default to `0.0`
- All new `SequenceResult` fields are `Optional` with `None` defaults
- Existing callers of `compute_all()` and the benchmark engine continue to work unchanged
