### PR TITLE
[feat] Normalized precision metric + extended latency profiling

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -115,7 +115,10 @@ class BenchmarkResult:
                 "sequence_name": r.sequence_name,
                 "mean_iou": round(r.mean_iou, 4),
                 "fps": round(r.profiling.fps, 2),
+                "fps_std": round(r.profiling.fps_std, 2),
                 "mean_latency_ms": round(r.profiling.latency_mean_ms, 3),
+                "latency_p95_ms": round(r.profiling.latency_p95_ms, 3),
+                "latency_p99_ms": round(r.profiling.latency_p99_ms, 3),
                 "peak_memory_mb": round(r.profiling.peak_memory_mb, 2),
             }
             if r.energy is not None:

--- a/eovot/metrics/accuracy.py
+++ b/eovot/metrics/accuracy.py
@@ -79,12 +79,22 @@ class AccuracyMetrics:
     precision_auc: float
     """Normalised AUC of the Precision Curve (distance thresholds 0 → 50 px)."""
 
+    normalized_precision_auc: float = 0.0
+    """Normalised AUC of the Normalized Precision Curve (TrackingNet/GOT-10k style).
+
+    The normalized precision divides the centre-distance by the square root of
+    the ground-truth box area before sweeping thresholds in ``[0, 0.5]``.
+    This makes the metric invariant to target scale, enabling fair comparison
+    across sequences with differently sized objects.
+    """
+
     def __str__(self) -> str:
         return (
             f"AccuracyMetrics("
             f"mIoU={self.mean_iou:.4f}, "
             f"success_AUC={self.success_auc:.4f}, "
-            f"precision_AUC={self.precision_auc:.4f})"
+            f"precision_AUC={self.precision_auc:.4f}, "
+            f"norm_precision_AUC={self.normalized_precision_auc:.4f})"
         )
 
 
@@ -162,6 +172,42 @@ class MetricsEngine:
         rates = np.array([(dists < t).mean() for t in thresholds])
         return thresholds, rates
 
+    def normalized_precision_curve(
+        self,
+        preds: np.ndarray,
+        gts: np.ndarray,
+        thresholds: Optional[np.ndarray] = None,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Scale-invariant normalized precision curve (TrackingNet / GOT-10k style).
+
+        The centre-distance between predicted and ground-truth box is divided by
+        ``sqrt(gt_w * gt_h)`` before thresholding, making the metric independent
+        of the absolute target size.  This allows fair comparison across
+        sequences that contain vastly different-sized objects.
+
+        Args:
+            preds:      ``(N, 4)`` predicted boxes in ``(x, y, w, h)`` format.
+            gts:        ``(N, 4)`` ground-truth boxes in ``(x, y, w, h)`` format.
+            thresholds: Normalized-distance thresholds to sweep.  Defaults to
+                        50 evenly spaced values in ``[0, 0.5]`` (canonical range).
+
+        Returns:
+            ``(thresholds, precision_rates)`` — both shape ``(T,)``.
+        """
+        if thresholds is None:
+            thresholds = np.linspace(0.0, 0.5, 51)
+        n = min(len(preds), len(gts))
+        norm_dists = np.empty(n, dtype=np.float64)
+        for i in range(n):
+            px, py, pw, ph = preds[i]
+            gx, gy, gw, gh = gts[i]
+            scale = float(np.sqrt(gw * gh)) if gw > 0 and gh > 0 else 1.0
+            dx = (px + pw / 2.0) - (gx + gw / 2.0)
+            dy = (py + ph / 2.0) - (gy + gh / 2.0)
+            norm_dists[i] = float(np.sqrt(dx * dx + dy * dy)) / max(scale, 1e-6)
+        rates = np.array([(norm_dists < t).mean() for t in thresholds])
+        return thresholds, rates
+
     def compute_all(
         self,
         preds: np.ndarray,
@@ -191,8 +237,12 @@ class MetricsEngine:
         thr_dist, pr = self.precision_curve(preds, gts)
         prec_auc = float(_trapz(pr, thr_dist) / thr_dist[-1]) if thr_dist[-1] > 0 else 0.0
 
+        thr_norm, npr = self.normalized_precision_curve(preds, gts)
+        norm_prec_auc = float(_trapz(npr, thr_norm) / thr_norm[-1]) if thr_norm[-1] > 0 else 0.0
+
         return AccuracyMetrics(
             mean_iou=float(ious.mean()),
             success_auc=success_auc,
             precision_auc=prec_auc,
+            normalized_precision_auc=norm_prec_auc,
         )

--- a/eovot/profiling/profiler.py
+++ b/eovot/profiling/profiler.py
@@ -22,13 +22,17 @@ class ProfilingResult:
     latency_std_ms: float
     latency_p95_ms: float
     peak_memory_mb: float
+    latency_p99_ms: float = 0.0
+    """99th-percentile per-frame latency (ms) — tail latency indicator."""
+    fps_std: float = 0.0
+    """Standard deviation of per-frame FPS — measures throughput stability."""
 
     def __str__(self) -> str:
         return (
             f"ProfilingResult[{self.tracker_name}] "
-            f"FPS={self.fps:.1f}  "
+            f"FPS={self.fps:.1f}±{self.fps_std:.1f}  "
             f"latency={self.latency_mean_ms:.2f}±{self.latency_std_ms:.2f} ms  "
-            f"p95={self.latency_p95_ms:.2f} ms  "
+            f"p95={self.latency_p95_ms:.2f} ms  p99={self.latency_p99_ms:.2f} ms  "
             f"mem={self.peak_memory_mb:.1f} MiB  "
             f"frames={self.frame_count}"
         )
@@ -64,6 +68,7 @@ class Profiler:
             raise ValueError("No frames profiled.")
         arr = np.array(self._latencies)
         mean_ms = float(arr.mean())
+        per_frame_fps = np.where(arr > 0, 1_000.0 / arr, 0.0)
         return ProfilingResult(
             tracker_name=tracker_name,
             frame_count=len(arr),
@@ -72,6 +77,8 @@ class Profiler:
             latency_std_ms=float(arr.std()),
             latency_p95_ms=float(np.percentile(arr, 95)),
             peak_memory_mb=self._peak_memory_mb,
+            latency_p99_ms=float(np.percentile(arr, 99)),
+            fps_std=float(per_frame_fps.std()),
         )
 
     def reset(self) -> None:

--- a/tests/test_normalized_precision.py
+++ b/tests/test_normalized_precision.py
@@ -1,0 +1,173 @@
+"""Unit tests for normalized precision metric and extended profiling fields."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from eovot.metrics.accuracy import AccuracyMetrics, MetricsEngine
+from eovot.profiling.profiler import Profiler, ProfilingResult
+
+
+class TestNormalizedPrecisionCurve:
+    def setup_method(self):
+        self.engine = MetricsEngine()
+
+    def test_perfect_prediction_max_rate(self):
+        # Identical boxes → norm distance = 0 → rate = 1.0 at every threshold > 0
+        boxes = np.tile([10.0, 10.0, 40.0, 40.0], (20, 1))
+        thresholds, rates = self.engine.normalized_precision_curve(boxes, boxes)
+        assert rates[-1] == pytest.approx(1.0)
+
+    def test_far_prediction_zero_rate(self):
+        # GT: small 4×4 box, pred: far away → norm dist >> 0.5 → rate at 0.5 ≈ 0
+        gt = np.tile([0.0, 0.0, 4.0, 4.0], (10, 1))
+        pred = np.tile([1000.0, 1000.0, 4.0, 4.0], (10, 1))
+        thresholds, rates = self.engine.normalized_precision_curve(pred, gt)
+        assert rates[-1] == pytest.approx(0.0)
+
+    def test_output_shapes(self):
+        boxes = np.random.default_rng(0).uniform(1, 100, (30, 4))
+        boxes[:, 2:] = np.abs(boxes[:, 2:]) + 1.0
+        thresholds, rates = self.engine.normalized_precision_curve(boxes, boxes)
+        assert thresholds.shape == rates.shape
+        assert len(thresholds) == 51  # default 51 points
+
+    def test_rates_in_unit_interval(self):
+        rng = np.random.default_rng(7)
+        preds = rng.uniform(0, 200, (50, 4))
+        gts = rng.uniform(0, 200, (50, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 1.0
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 1.0
+        _, rates = self.engine.normalized_precision_curve(preds, gts)
+        assert np.all(rates >= 0.0) and np.all(rates <= 1.0)
+
+    def test_monotone_non_decreasing(self):
+        # Larger threshold → at least as many frames qualify → rate non-decreasing
+        rng = np.random.default_rng(13)
+        preds = rng.uniform(0, 100, (40, 4))
+        gts = rng.uniform(0, 100, (40, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 1.0
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 1.0
+        _, rates = self.engine.normalized_precision_curve(preds, gts)
+        assert np.all(np.diff(rates) >= -1e-9)
+
+    def test_scale_invariance(self):
+        # Scale gt box by 4× while keeping relative displacement constant →
+        # normalized distance stays the same → same AUC.
+        rng = np.random.default_rng(99)
+        n = 30
+        gt_small = rng.uniform(10, 50, (n, 4))
+        gt_small[:, 2:] = 10.0  # 10×10 boxes
+        gt_large = gt_small.copy()
+        gt_large[:, 2:] = 40.0  # 40×40 boxes — 4× bigger
+
+        # Displacement equal to 10% of target size for each
+        disp_small = 1.0   # 10% of 10
+        disp_large = 4.0   # 10% of 40
+
+        pred_small = gt_small.copy()
+        pred_small[:, 0] += disp_small
+        pred_large = gt_large.copy()
+        pred_large[:, 0] += disp_large
+
+        _, rates_small = self.engine.normalized_precision_curve(pred_small, gt_small)
+        _, rates_large = self.engine.normalized_precision_curve(pred_large, gt_large)
+        np.testing.assert_allclose(rates_small, rates_large, atol=1e-9)
+
+    def test_custom_thresholds(self):
+        boxes = np.tile([0.0, 0.0, 20.0, 20.0], (5, 1))
+        custom_thr = np.array([0.0, 0.1, 0.2, 0.3])
+        thr_out, rates = self.engine.normalized_precision_curve(boxes, boxes,
+                                                                thresholds=custom_thr)
+        np.testing.assert_array_equal(thr_out, custom_thr)
+        assert len(rates) == len(custom_thr)
+
+
+class TestComputeAllIncludesNormPrecision:
+    def setup_method(self):
+        self.engine = MetricsEngine()
+
+    def test_perfect_prediction_norm_prec_close_to_one(self):
+        boxes = np.tile([5.0, 5.0, 30.0, 30.0], (20, 1))
+        result = self.engine.compute_all(boxes, boxes)
+        assert result.normalized_precision_auc == pytest.approx(1.0, abs=0.05)
+
+    def test_returns_accuracy_metrics_instance(self):
+        boxes = np.tile([0.0, 0.0, 10.0, 10.0], (10, 1))
+        result = self.engine.compute_all(boxes, boxes)
+        assert isinstance(result, AccuracyMetrics)
+        assert hasattr(result, "normalized_precision_auc")
+
+    def test_norm_prec_in_unit_interval(self):
+        rng = np.random.default_rng(5)
+        preds = rng.uniform(0, 100, (40, 4))
+        gts = rng.uniform(0, 100, (40, 4))
+        preds[:, 2:] = np.abs(preds[:, 2:]) + 1.0
+        gts[:, 2:] = np.abs(gts[:, 2:]) + 1.0
+        result = self.engine.compute_all(preds, gts)
+        assert 0.0 <= result.normalized_precision_auc <= 1.0
+
+    def test_str_includes_norm_precision(self):
+        boxes = np.tile([0.0, 0.0, 10.0, 10.0], (5, 1))
+        result = self.engine.compute_all(boxes, boxes)
+        assert "norm_precision" in str(result)
+
+
+class TestAccuracyMetricsBackwardCompat:
+    """Ensure old code that omits normalized_precision_auc still works."""
+
+    def test_default_zero(self):
+        m = AccuracyMetrics(mean_iou=0.5, success_auc=0.4, precision_auc=0.3)
+        assert m.normalized_precision_auc == 0.0
+
+    def test_explicit_value(self):
+        m = AccuracyMetrics(mean_iou=0.5, success_auc=0.4, precision_auc=0.3,
+                            normalized_precision_auc=0.75)
+        assert m.normalized_precision_auc == pytest.approx(0.75)
+
+
+class TestExtendedProfilingFields:
+    def setup_method(self):
+        self.profiler = Profiler()
+
+    def _run(self, n: int = 10) -> ProfilingResult:
+        for _ in range(n):
+            self.profiler.start_frame()
+            time.sleep(0.002)
+            self.profiler.end_frame()
+        return self.profiler.summary("test")
+
+    def test_latency_p99_present(self):
+        result = self._run(10)
+        assert hasattr(result, "latency_p99_ms")
+        assert result.latency_p99_ms > 0.0
+
+    def test_p99_ge_p95(self):
+        result = self._run(20)
+        assert result.latency_p99_ms >= result.latency_p95_ms - 1e-9
+
+    def test_fps_std_present(self):
+        result = self._run(10)
+        assert hasattr(result, "fps_std")
+        assert result.fps_std >= 0.0
+
+    def test_str_includes_fps_std(self):
+        result = self._run(5)
+        assert "±" in str(result)
+
+    def test_backward_compat_default_values(self):
+        # ProfilingResult can still be built without new fields (they have defaults)
+        pr = ProfilingResult(
+            tracker_name="t",
+            frame_count=5,
+            fps=100.0,
+            latency_mean_ms=10.0,
+            latency_std_ms=1.0,
+            latency_p95_ms=12.0,
+            peak_memory_mb=50.0,
+        )
+        assert pr.latency_p99_ms == 0.0
+        assert pr.fps_std == 0.0


### PR DESCRIPTION
## What was added

### 1. Normalized Precision Metric (`eovot/metrics/accuracy.py`)

Adds a scale-invariant precision curve used by TrackingNet and GOT-10k benchmarks.

**Problem with standard precision:** Centre-distance in pixels is meaningless when comparing across sequences — a 10 px error tracking a 20×20 pedestrian is a disaster, but perfectly acceptable for a 200×200 vehicle.

**Solution:** Normalize the centre-distance by `sqrt(gt_w * gt_h)` before thresholding. This makes the metric invariant to target size, enabling fair cross-sequence comparison.

```python
from eovot.metrics.accuracy import MetricsEngine
import numpy as np

engine = MetricsEngine()
preds = np.array([[10., 10., 50., 50.], [15., 12., 48., 52.]])
gts   = np.array([[10., 10., 50., 50.], [13., 11., 50., 50.]])

# Scale-invariant precision curve (threshold range [0, 0.5])
thresholds, rates = engine.normalized_precision_curve(preds, gts)

# All metrics in one call — now includes normalized_precision_auc
result = engine.compute_all(preds, gts)
print(result.normalized_precision_auc)  # e.g. 0.94
```

`AccuracyMetrics` gains `normalized_precision_auc` with `default=0.0` — fully backward-compatible.

### 2. Extended Latency Profiling (`eovot/profiling/profiler.py`)

Two new fields on `ProfilingResult`:

| Field | Purpose |
|---|---|
| `latency_p99_ms` | 99th-percentile per-frame latency — captures tail latency spikes that p95 misses. Critical for real-time edge systems where the worst 1% of frames can cause dropped tracking. |
| `fps_std` | Standard deviation of per-frame FPS — measures throughput *stability*, not just mean speed. A tracker with FPS=60 ± 40 is much riskier than one with FPS=50 ± 2. |

```python
from eovot.profiling.profiler import Profiler

profiler = Profiler()
# ... run tracking frames ...
result = profiler.summary("MyTracker")
print(result)
# ProfilingResult[MyTracker] FPS=312.4±8.1  latency=3.20±0.09 ms
#   p95=3.31 ms  p99=3.45 ms  mem=128.3 MiB  frames=500
```

Both fields default to `0.0` — backward-compatible with existing code that constructs `ProfilingResult` directly.

### 3. Richer `BenchmarkResult.to_dict()` (`eovot/benchmark/engine.py`)

Per-sequence JSON output now includes `fps_std`, `latency_p95_ms`, and `latency_p99_ms` alongside the existing `fps` and `mean_latency_ms` fields.

### 4. Tests (`tests/test_normalized_precision.py`)

18 unit tests covering:
- Scale invariance (core correctness property)
- Monotonicity of the precision curve
- Perfect and worst-case edge cases
- Backward compatibility of both `AccuracyMetrics` and `ProfilingResult`
- Integration with `MetricsEngine.compute_all()`

## Why it matters for edge deployment

Standard benchmarks (OTB, VOT) only report centre-distance precision in pixels, which is resolution- and scale-dependent. Edge devices often run on lower-resolution feeds or track objects at very different scales (drones vs. autonomous vehicles). Normalized precision closes this gap.

Tail latency (p99) and throughput jitter (`fps_std`) are critical for real-time systems. A tracker that is fast on average but spikes on complex frames causes tracking failures in real deployments. These two metrics surface problems that mean FPS and p95 latency hide.

## No breaking changes

All new fields carry backward-compatible defaults. Existing experiments, result JSON files, and tests are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCASW9ymH9HPmy2tRMy8mi)_