### PR TITLE
[feat] Per-attribute performance analysis for VOT benchmarks

### DIFF
--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -7,6 +7,17 @@ from .accuracy import (
     MetricsEngine,
 )
 from .robustness import RobustnessAnalyzer, RobustnessResult
+from .attributes import (
+    AttributeAnalyzer,
+    AttributeAnalysis,
+    AttributeResult,
+    LASOT_ATTRIBUTES,
+    OTB_ATTRIBUTES,
+    AUTO_DERIVABLE_ATTRIBUTES,
+    derive_fast_motion_mask,
+    derive_scale_variation_mask,
+    derive_low_resolution_mask,
+)
 
 __all__ = [
     "iou",
@@ -15,4 +26,13 @@ __all__ = [
     "MetricsEngine",
     "RobustnessAnalyzer",
     "RobustnessResult",
+    "AttributeAnalyzer",
+    "AttributeAnalysis",
+    "AttributeResult",
+    "LASOT_ATTRIBUTES",
+    "OTB_ATTRIBUTES",
+    "AUTO_DERIVABLE_ATTRIBUTES",
+    "derive_fast_motion_mask",
+    "derive_scale_variation_mask",
+    "derive_low_resolution_mask",
 ]

--- a/eovot/metrics/attributes.py
+++ b/eovot/metrics/attributes.py
@@ -1,0 +1,430 @@
+"""Per-attribute performance analysis for VOT benchmarks.
+
+Standard benchmarks (LaSOT, OTB, GOT-10k) annotate sequences with challenging
+conditions such as occlusion, fast motion, and scale variation.  Reporting
+accuracy *per attribute* is required by most VOT challenge papers and reveals
+failure modes that a single scalar mIoU hides.
+
+This module provides:
+- :class:`AttributeAnalyzer` — compute per-attribute IoU / success / precision
+- :func:`derive_fast_motion_mask` — auto-derive fast-motion labels from GT boxes
+- :func:`derive_scale_variation_mask` — auto-derive scale-variation labels
+- :func:`derive_low_resolution_mask` — auto-derive low-resolution labels
+- :class:`AttributeResult` / :class:`AttributeAnalysis` — result containers
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .accuracy import AccuracyMetrics, MetricsEngine
+
+
+# ── Standard attribute vocabularies ──────────────────────────────────────────
+
+#: Attribute names used by the LaSOT benchmark (per-sequence level annotations).
+LASOT_ATTRIBUTES: Tuple[str, ...] = (
+    "illumination_variation",
+    "occlusion",
+    "deformation",
+    "motion_blur",
+    "fast_motion",
+    "in_plane_rotation",
+    "out_of_plane_rotation",
+    "out_of_view",
+    "background_clutter",
+    "low_resolution",
+)
+
+#: Attribute names used by the OTB benchmark (sequence-level tags).
+OTB_ATTRIBUTES: Tuple[str, ...] = (
+    "illumination_variation",
+    "scale_variation",
+    "occlusion",
+    "deformation",
+    "motion_blur",
+    "fast_motion",
+    "in_plane_rotation",
+    "out_of_plane_rotation",
+    "out_of_view",
+    "background_clutter",
+    "low_resolution",
+)
+
+#: Attribute names that can be auto-derived from ground-truth geometry alone.
+AUTO_DERIVABLE_ATTRIBUTES: Tuple[str, ...] = (
+    "fast_motion",
+    "scale_variation",
+    "low_resolution",
+)
+
+
+# ── Result containers ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class AttributeResult:
+    """Accuracy metrics for a single challenging attribute."""
+
+    attribute: str
+    num_frames: int
+    mean_iou: float
+    success_auc: float
+    precision_auc: float
+
+    def to_dict(self) -> dict:
+        return {
+            "attribute": self.attribute,
+            "num_frames": self.num_frames,
+            "mean_iou": round(self.mean_iou, 4),
+            "success_auc": round(self.success_auc, 4),
+            "precision_auc": round(self.precision_auc, 4),
+        }
+
+
+@dataclass
+class AttributeAnalysis:
+    """Aggregated per-attribute results for one tracker on a dataset.
+
+    Attributes:
+        per_attribute: Mapping from attribute name to its metrics.
+        overall: Aggregate metrics across all frames (attribute-agnostic).
+    """
+
+    per_attribute: Dict[str, AttributeResult] = field(default_factory=dict)
+    overall: Optional[AccuracyMetrics] = None
+
+    # ── Human-readable output ─────────────────────────────────────────────────
+
+    def summary_table(self) -> str:
+        """Return a Markdown table sorted descending by mIoU."""
+        if not self.per_attribute:
+            return "No attribute data available."
+
+        rows = sorted(
+            self.per_attribute.values(),
+            key=lambda r: r.mean_iou,
+            reverse=True,
+        )
+        header = (
+            "| Attribute | Frames | mIoU | Success AUC | Precision AUC |\n"
+            "|-----------|-------:|-----:|------------:|--------------:|\n"
+        )
+        lines = [
+            f"| {r.attribute} | {r.num_frames} | {r.mean_iou:.4f} "
+            f"| {r.success_auc:.4f} | {r.precision_auc:.4f} |"
+            for r in rows
+        ]
+        return header + "\n".join(lines)
+
+    def worst_attributes(self, n: int = 3) -> List[AttributeResult]:
+        """Return the *n* most challenging attributes (lowest mIoU)."""
+        return sorted(self.per_attribute.values(), key=lambda r: r.mean_iou)[:n]
+
+    def best_attributes(self, n: int = 3) -> List[AttributeResult]:
+        """Return the *n* easiest attributes (highest mIoU)."""
+        return sorted(
+            self.per_attribute.values(), key=lambda r: r.mean_iou, reverse=True
+        )[:n]
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "per_attribute": {k: v.to_dict() for k, v in self.per_attribute.items()}
+        }
+        if self.overall is not None:
+            d["overall"] = {
+                "mean_iou": round(self.overall.mean_iou, 4),
+                "success_auc": round(self.overall.success_auc, 4),
+                "precision_auc": round(self.overall.precision_auc, 4),
+            }
+        return d
+
+
+# ── Geometry-based mask derivation ───────────────────────────────────────────
+
+
+def derive_fast_motion_mask(
+    ground_truth: np.ndarray,
+    velocity_threshold: float = 20.0,
+) -> np.ndarray:
+    """Per-frame fast-motion binary mask derived from ground-truth box centres.
+
+    A frame is labelled fast-motion when the centre displacement from the
+    previous frame exceeds *velocity_threshold* pixels.  The first frame is
+    always ``False`` (no previous frame to compare against).
+
+    Args:
+        ground_truth: ``(N, 4)`` array of boxes in ``(x, y, w, h)`` format.
+        velocity_threshold: Displacement threshold in pixels.
+
+    Returns:
+        Boolean ``(N,)`` array.
+    """
+    gt = np.asarray(ground_truth, dtype=np.float64)
+    cx = gt[:, 0] + gt[:, 2] / 2.0
+    cy = gt[:, 1] + gt[:, 3] / 2.0
+    centers = np.stack([cx, cy], axis=1)
+    displacements = np.linalg.norm(np.diff(centers, axis=0), axis=1)
+    mask = np.concatenate([[False], displacements > velocity_threshold])
+    return mask.astype(bool)
+
+
+def derive_scale_variation_mask(
+    ground_truth: np.ndarray,
+    ratio_threshold: float = 0.25,
+) -> np.ndarray:
+    """Per-frame scale-variation binary mask derived from ground-truth box areas.
+
+    A frame is labelled scale-variation when the absolute relative change in
+    box area with respect to the initial frame exceeds *ratio_threshold*.
+
+    Args:
+        ground_truth: ``(N, 4)`` array of boxes in ``(x, y, w, h)`` format.
+        ratio_threshold: Relative area deviation threshold (e.g. 0.25 = 25 %).
+
+    Returns:
+        Boolean ``(N,)`` array.
+    """
+    gt = np.asarray(ground_truth, dtype=np.float64)
+    areas = gt[:, 2] * gt[:, 3]
+    init_area = float(areas[0]) if areas[0] > 0.0 else 1.0
+    ratios = np.abs(areas / init_area - 1.0)
+    return (ratios > ratio_threshold).astype(bool)
+
+
+def derive_low_resolution_mask(
+    ground_truth: np.ndarray,
+    area_threshold: float = 400.0,
+) -> np.ndarray:
+    """Per-frame low-resolution binary mask derived from ground-truth box areas.
+
+    A frame is labelled low-resolution when the bounding-box area is below
+    *area_threshold* pixels² (default 400 ≈ 20 × 20 pixels).
+
+    Args:
+        ground_truth: ``(N, 4)`` array of boxes in ``(x, y, w, h)`` format.
+        area_threshold: Area threshold in pixels².
+
+    Returns:
+        Boolean ``(N,)`` array.
+    """
+    gt = np.asarray(ground_truth, dtype=np.float64)
+    areas = gt[:, 2] * gt[:, 3]
+    return (areas < area_threshold).astype(bool)
+
+
+# ── Core analyzer ─────────────────────────────────────────────────────────────
+
+
+class AttributeAnalyzer:
+    """Compute per-attribute accuracy metrics for a single tracker.
+
+    Supports two complementary workflows:
+
+    **Explicit masks** — caller provides per-frame boolean masks for each
+    attribute (e.g. loaded from LaSOT annotation files or OTB metadata).
+
+    **Auto-derived masks** — when no attribute annotations are available,
+    :meth:`auto_derive_masks` generates geometry-based masks for
+    ``fast_motion``, ``scale_variation``, and ``low_resolution``.
+
+    Both workflows produce an :class:`AttributeAnalysis` that can be printed
+    as a Markdown table or serialised to JSON.
+
+    Example — explicit masks::
+
+        analyzer = AttributeAnalyzer()
+        masks = {
+            "occlusion": np.array([False, True, True, False, ...]),
+            "fast_motion": np.array([False, False, True, True, ...]),
+        }
+        analysis = analyzer.analyze_sequence(predictions, ground_truth, masks)
+        print(analysis.summary_table())
+
+    Example — auto-derived masks::
+
+        analyzer = AttributeAnalyzer()
+        masks = analyzer.auto_derive_masks(ground_truth)
+        analysis = analyzer.analyze_sequence(predictions, ground_truth, masks)
+        print(analysis.summary_table())
+    """
+
+    def __init__(self) -> None:
+        self._engine = MetricsEngine()
+
+    # ── Single-sequence API ───────────────────────────────────────────────────
+
+    def analyze_sequence(
+        self,
+        predictions: np.ndarray,
+        ground_truth: np.ndarray,
+        attribute_masks: Dict[str, np.ndarray],
+    ) -> AttributeAnalysis:
+        """Compute per-attribute metrics for a single sequence.
+
+        Args:
+            predictions: ``(N, 4)`` predicted bounding boxes ``(x, y, w, h)``.
+            ground_truth: ``(N, 4)`` ground-truth bounding boxes ``(x, y, w, h)``.
+            attribute_masks: Mapping from attribute name to boolean ``(N,)`` mask.
+
+        Returns:
+            :class:`AttributeAnalysis` with per-attribute and overall metrics.
+        """
+        predictions = np.asarray(predictions, dtype=np.float32)
+        ground_truth = np.asarray(ground_truth, dtype=np.float32)
+
+        n = min(len(predictions), len(ground_truth))
+        predictions = predictions[:n]
+        ground_truth = ground_truth[:n]
+
+        overall = self._engine.compute_all(predictions, ground_truth)
+        per_attr: Dict[str, AttributeResult] = {}
+
+        for attr_name, mask in attribute_masks.items():
+            mask = np.asarray(mask, dtype=bool)
+            if len(mask) > n:
+                mask = mask[:n]
+            n_frames = int(mask.sum())
+            if n_frames < 2:
+                continue
+
+            pred_sub = predictions[mask]
+            gt_sub = ground_truth[mask]
+            metrics = self._engine.compute_all(pred_sub, gt_sub)
+
+            per_attr[attr_name] = AttributeResult(
+                attribute=attr_name,
+                num_frames=n_frames,
+                mean_iou=metrics.mean_iou,
+                success_auc=metrics.success_auc,
+                precision_auc=metrics.precision_auc,
+            )
+
+        return AttributeAnalysis(per_attribute=per_attr, overall=overall)
+
+    # ── Multi-sequence (benchmark) API ────────────────────────────────────────
+
+    def analyze_benchmark(
+        self,
+        sequence_predictions: List[np.ndarray],
+        sequence_ground_truths: List[np.ndarray],
+        sequence_attribute_masks: List[Dict[str, np.ndarray]],
+    ) -> AttributeAnalysis:
+        """Aggregate per-attribute metrics across multiple sequences.
+
+        Frames for each attribute are *pooled* across all sequences, and then
+        metrics are recomputed on the combined pool.  This matches the standard
+        LaSOT / OTB evaluation protocol.
+
+        Args:
+            sequence_predictions: List of ``(N_i, 4)`` prediction arrays.
+            sequence_ground_truths: List of ``(N_i, 4)`` ground-truth arrays.
+            sequence_attribute_masks: Per-sequence attribute mask dicts.
+
+        Returns:
+            :class:`AttributeAnalysis` aggregated over all sequences.
+        """
+        pooled_pred: Dict[str, List[np.ndarray]] = {}
+        pooled_gt: Dict[str, List[np.ndarray]] = {}
+        all_pred_list: List[np.ndarray] = []
+        all_gt_list: List[np.ndarray] = []
+
+        for preds, gts, masks in zip(
+            sequence_predictions, sequence_ground_truths, sequence_attribute_masks
+        ):
+            preds = np.asarray(preds, dtype=np.float32)
+            gts = np.asarray(gts, dtype=np.float32)
+            n = min(len(preds), len(gts))
+            preds, gts = preds[:n], gts[:n]
+            all_pred_list.append(preds)
+            all_gt_list.append(gts)
+
+            for attr_name, mask in masks.items():
+                mask = np.asarray(mask, dtype=bool)
+                if len(mask) > n:
+                    mask = mask[:n]
+                if mask.sum() < 2:
+                    continue
+                pooled_pred.setdefault(attr_name, []).append(preds[mask])
+                pooled_gt.setdefault(attr_name, []).append(gts[mask])
+
+        overall_pred = np.concatenate(all_pred_list, axis=0)
+        overall_gt = np.concatenate(all_gt_list, axis=0)
+        overall = self._engine.compute_all(overall_pred, overall_gt)
+
+        per_attr: Dict[str, AttributeResult] = {}
+        for attr_name in pooled_pred:
+            combined_pred = np.concatenate(pooled_pred[attr_name], axis=0)
+            combined_gt = np.concatenate(pooled_gt[attr_name], axis=0)
+            metrics = self._engine.compute_all(combined_pred, combined_gt)
+            per_attr[attr_name] = AttributeResult(
+                attribute=attr_name,
+                num_frames=len(combined_pred),
+                mean_iou=metrics.mean_iou,
+                success_auc=metrics.success_auc,
+                precision_auc=metrics.precision_auc,
+            )
+
+        return AttributeAnalysis(per_attribute=per_attr, overall=overall)
+
+    # ── Mask derivation helpers ───────────────────────────────────────────────
+
+    def auto_derive_masks(
+        self,
+        ground_truth: np.ndarray,
+        fast_motion_threshold: float = 20.0,
+        scale_variation_threshold: float = 0.25,
+        low_resolution_threshold: float = 400.0,
+    ) -> Dict[str, np.ndarray]:
+        """Auto-derive per-frame attribute masks from ground-truth geometry.
+
+        Useful when explicit attribute annotations are unavailable.  Produces
+        three geometry-based masks:
+
+        - ``fast_motion`` — large inter-frame centre displacement
+        - ``scale_variation`` — significant area change from initial frame
+        - ``low_resolution`` — bounding box smaller than threshold
+
+        Args:
+            ground_truth: ``(N, 4)`` ground-truth boxes ``(x, y, w, h)``.
+            fast_motion_threshold: Centre displacement threshold (px).
+            scale_variation_threshold: Relative area deviation threshold.
+            low_resolution_threshold: Minimum box area (px²) for normal res.
+
+        Returns:
+            Dict mapping attribute name → boolean ``(N,)`` mask.
+        """
+        gt = np.asarray(ground_truth, dtype=np.float64)
+        return {
+            "fast_motion": derive_fast_motion_mask(gt, fast_motion_threshold),
+            "scale_variation": derive_scale_variation_mask(gt, scale_variation_threshold),
+            "low_resolution": derive_low_resolution_mask(gt, low_resolution_threshold),
+        }
+
+    def extract_otb_attributes(
+        self,
+        sequence_tags: List[str],
+        num_frames: int,
+    ) -> Dict[str, np.ndarray]:
+        """Convert OTB sequence-level attribute tags to per-frame boolean masks.
+
+        OTB annotates at the sequence level; this method broadcasts each tag
+        into an all-``True`` frame-level mask so it can be used with
+        :meth:`analyze_sequence`.
+
+        Args:
+            sequence_tags: OTB attribute strings, e.g. ``["occlusion", "fast_motion"]``.
+            num_frames: Total number of frames in the sequence.
+
+        Returns:
+            Dict mapping normalised attribute name → all-True ``(N,)`` mask.
+        """
+        masks: Dict[str, np.ndarray] = {}
+        for tag in sequence_tags:
+            normalised = tag.lower().replace(" ", "_")
+            masks[normalised] = np.ones(num_frames, dtype=bool)
+        return masks

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,327 @@
+"""Tests for eovot.metrics.attributes — per-attribute performance analysis."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.metrics.attributes import (
+    AttributeAnalyzer,
+    AttributeAnalysis,
+    AttributeResult,
+    LASOT_ATTRIBUTES,
+    OTB_ATTRIBUTES,
+    AUTO_DERIVABLE_ATTRIBUTES,
+    derive_fast_motion_mask,
+    derive_scale_variation_mask,
+    derive_low_resolution_mask,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _perfect_boxes(n: int = 50, x: float = 10.0, y: float = 10.0,
+                   w: float = 40.0, h: float = 30.0) -> np.ndarray:
+    """Return *n* identical ground-truth boxes (tracker sees perfect IoU=1)."""
+    return np.tile([x, y, w, h], (n, 1)).astype(np.float32)
+
+
+def _noisy_boxes(gt: np.ndarray, noise_std: float = 3.0,
+                 seed: int = 0) -> np.ndarray:
+    """Add Gaussian noise to boxes; IoU stays high but < 1."""
+    rng = np.random.default_rng(seed)
+    return (gt + rng.normal(0, noise_std, gt.shape)).astype(np.float32)
+
+
+# ── Mask derivation functions ─────────────────────────────────────────────────
+
+
+class TestDeriveFastMotionMask:
+    def test_stationary_target_no_fast_motion(self):
+        gt = _perfect_boxes(20)
+        mask = derive_fast_motion_mask(gt, velocity_threshold=20.0)
+        assert mask.shape == (20,)
+        assert not mask.any(), "Stationary target should never be fast-motion"
+
+    def test_fast_target_mostly_flagged(self):
+        # Target moves 50 px per frame
+        gt = np.column_stack([
+            np.arange(100) * 50.0,
+            np.zeros(100),
+            np.full(100, 40.0),
+            np.full(100, 30.0),
+        ])
+        mask = derive_fast_motion_mask(gt, velocity_threshold=20.0)
+        # Frame 0 is always False; frames 1..99 should all be True
+        assert not mask[0]
+        assert mask[1:].all()
+
+    def test_first_frame_always_false(self):
+        gt = np.random.rand(30, 4) * 100
+        mask = derive_fast_motion_mask(gt)
+        assert not mask[0], "First frame has no previous frame; must be False"
+
+    def test_output_dtype_is_bool(self):
+        gt = _perfect_boxes(10)
+        assert derive_fast_motion_mask(gt).dtype == bool
+
+
+class TestDeriveScaleVariationMask:
+    def test_constant_size_no_variation(self):
+        gt = _perfect_boxes(30)
+        mask = derive_scale_variation_mask(gt, ratio_threshold=0.25)
+        assert not mask.any()
+
+    def test_doubling_area_flagged(self):
+        gt = np.array([[0, 0, 40, 30]] * 30, dtype=np.float32)
+        # Double width and height starting at frame 10 → area ×4
+        gt[10:, 2] = 80.0
+        gt[10:, 3] = 60.0
+        mask = derive_scale_variation_mask(gt, ratio_threshold=0.25)
+        assert mask[10:].all(), "4× area should be scale-variation"
+        assert not mask[:10].any()
+
+    def test_output_dtype_is_bool(self):
+        gt = _perfect_boxes(10)
+        assert derive_scale_variation_mask(gt).dtype == bool
+
+
+class TestDeriveLowResolutionMask:
+    def test_large_boxes_not_low_res(self):
+        gt = _perfect_boxes(20, w=100.0, h=100.0)  # area = 10,000 px²
+        mask = derive_low_resolution_mask(gt, area_threshold=400.0)
+        assert not mask.any()
+
+    def test_tiny_boxes_all_low_res(self):
+        gt = _perfect_boxes(20, w=10.0, h=10.0)  # area = 100 px²
+        mask = derive_low_resolution_mask(gt, area_threshold=400.0)
+        assert mask.all()
+
+    def test_output_dtype_is_bool(self):
+        gt = _perfect_boxes(10)
+        assert derive_low_resolution_mask(gt).dtype == bool
+
+
+# ── AttributeAnalyzer: single-sequence ───────────────────────────────────────
+
+
+class TestAnalyzeSequence:
+    def setup_method(self):
+        self.analyzer = AttributeAnalyzer()
+
+    def _run(self, n: int = 50, noise: float = 2.0):
+        gt = _perfect_boxes(n)
+        pred = _noisy_boxes(gt, noise_std=noise)
+        masks = {
+            "occlusion": np.concatenate([np.zeros(n // 2), np.ones(n // 2)]).astype(bool),
+            "fast_motion": np.zeros(n, dtype=bool),
+        }
+        return self.analyzer.analyze_sequence(pred, gt, masks), pred, gt
+
+    def test_returns_attribute_analysis(self):
+        result, _, _ = self._run()
+        assert isinstance(result, AttributeAnalysis)
+
+    def test_per_attribute_keys_match_masks(self):
+        result, _, _ = self._run()
+        # "fast_motion" has 0 True frames → should be absent (< 2 frames)
+        assert "occlusion" in result.per_attribute
+        assert "fast_motion" not in result.per_attribute
+
+    def test_overall_metrics_populated(self):
+        result, _, _ = self._run()
+        assert result.overall is not None
+        assert 0.0 <= result.overall.mean_iou <= 1.0
+
+    def test_attribute_result_fields(self):
+        result, _, _ = self._run()
+        attr = result.per_attribute["occlusion"]
+        assert isinstance(attr, AttributeResult)
+        assert attr.attribute == "occlusion"
+        assert attr.num_frames == 25  # half of 50 frames
+        assert 0.0 <= attr.mean_iou <= 1.0
+        assert 0.0 <= attr.success_auc <= 1.0
+        assert 0.0 <= attr.precision_auc <= 1.0
+
+    def test_perfect_predictions_iou_one(self):
+        n = 40
+        gt = _perfect_boxes(n)
+        pred = gt.copy()
+        masks = {"all_frames": np.ones(n, dtype=bool)}
+        result = self.analyzer.analyze_sequence(pred, gt, masks)
+        assert result.per_attribute["all_frames"].mean_iou == pytest.approx(1.0)
+
+    def test_empty_mask_attribute_skipped(self):
+        n = 30
+        gt = _perfect_boxes(n)
+        pred = gt.copy()
+        masks = {"empty_attr": np.zeros(n, dtype=bool)}
+        result = self.analyzer.analyze_sequence(pred, gt, masks)
+        assert "empty_attr" not in result.per_attribute
+
+    def test_mask_longer_than_frames_is_clipped(self):
+        n = 20
+        gt = _perfect_boxes(n)
+        pred = gt.copy()
+        masks = {"long_mask": np.ones(n + 10, dtype=bool)}
+        # Should not raise
+        result = self.analyzer.analyze_sequence(pred, gt, masks)
+        assert "long_mask" in result.per_attribute
+
+
+# ── AttributeAnalyzer: benchmark (multi-sequence) ────────────────────────────
+
+
+class TestAnalyzeBenchmark:
+    def setup_method(self):
+        self.analyzer = AttributeAnalyzer()
+
+    def _make_seq(self, n: int = 30):
+        gt = _perfect_boxes(n)
+        pred = _noisy_boxes(gt, noise_std=1.0)
+        masks = {
+            "occlusion": (np.arange(n) % 2 == 0),
+            "fast_motion": np.zeros(n, dtype=bool),
+        }
+        return pred, gt, masks
+
+    def test_returns_attribute_analysis(self):
+        preds, gts, masks = zip(*[self._make_seq() for _ in range(3)])
+        result = self.analyzer.analyze_benchmark(
+            list(preds), list(gts), list(masks)
+        )
+        assert isinstance(result, AttributeAnalysis)
+
+    def test_pooled_frame_count_correct(self):
+        n = 30
+        preds, gts, masks = zip(*[self._make_seq(n) for _ in range(4)])
+        result = self.analyzer.analyze_benchmark(
+            list(preds), list(gts), list(masks)
+        )
+        occ = result.per_attribute.get("occlusion")
+        assert occ is not None
+        # Every other frame is occlusion → 15 per sequence × 4 = 60
+        assert occ.num_frames == 60
+
+    def test_overall_always_present(self):
+        preds, gts, masks = zip(*[self._make_seq() for _ in range(2)])
+        result = self.analyzer.analyze_benchmark(
+            list(preds), list(gts), list(masks)
+        )
+        assert result.overall is not None
+
+
+# ── Auto-derive masks ─────────────────────────────────────────────────────────
+
+
+class TestAutoDeriveMasks:
+    def setup_method(self):
+        self.analyzer = AttributeAnalyzer()
+
+    def test_returns_three_masks(self):
+        gt = _perfect_boxes(50)
+        masks = self.analyzer.auto_derive_masks(gt)
+        assert set(masks.keys()) == {"fast_motion", "scale_variation", "low_resolution"}
+
+    def test_mask_lengths_match_gt(self):
+        gt = _perfect_boxes(40)
+        masks = self.analyzer.auto_derive_masks(gt)
+        for name, mask in masks.items():
+            assert len(mask) == 40, f"{name} mask length mismatch"
+
+    def test_all_bool_arrays(self):
+        gt = _perfect_boxes(20)
+        masks = self.analyzer.auto_derive_masks(gt)
+        for mask in masks.values():
+            assert mask.dtype == bool
+
+
+# ── OTB attribute extraction ──────────────────────────────────────────────────
+
+
+class TestExtractOtbAttributes:
+    def setup_method(self):
+        self.analyzer = AttributeAnalyzer()
+
+    def test_tags_become_all_true_masks(self):
+        n = 50
+        masks = self.analyzer.extract_otb_attributes(["occlusion", "fast_motion"], n)
+        assert set(masks.keys()) == {"occlusion", "fast_motion"}
+        for mask in masks.values():
+            assert mask.all()
+            assert len(mask) == n
+
+    def test_tag_normalisation(self):
+        masks = self.analyzer.extract_otb_attributes(["Background Clutter"], 10)
+        assert "background_clutter" in masks
+
+    def test_empty_tags_returns_empty_dict(self):
+        masks = self.analyzer.extract_otb_attributes([], 20)
+        assert masks == {}
+
+
+# ── AttributeAnalysis formatting ─────────────────────────────────────────────
+
+
+class TestAttributeAnalysisFormatting:
+    def _build_analysis(self):
+        analyzer = AttributeAnalyzer()
+        n = 60
+        gt = _perfect_boxes(n)
+        pred = _noisy_boxes(gt, noise_std=3.0)
+        masks = {
+            "occlusion": np.concatenate([np.ones(30), np.zeros(30)]).astype(bool),
+            "fast_motion": np.concatenate([np.zeros(30), np.ones(30)]).astype(bool),
+        }
+        return analyzer.analyze_sequence(pred, gt, masks)
+
+    def test_summary_table_is_string(self):
+        analysis = self._build_analysis()
+        table = analysis.summary_table()
+        assert isinstance(table, str)
+        assert "mIoU" in table
+
+    def test_worst_attributes_returns_list(self):
+        analysis = self._build_analysis()
+        worst = analysis.worst_attributes(n=1)
+        assert len(worst) == 1
+        assert isinstance(worst[0], AttributeResult)
+
+    def test_best_attributes_sorted_descending(self):
+        analysis = self._build_analysis()
+        best = analysis.best_attributes(n=2)
+        assert len(best) <= 2
+        if len(best) == 2:
+            assert best[0].mean_iou >= best[1].mean_iou
+
+    def test_to_dict_serialisable(self):
+        analysis = self._build_analysis()
+        d = analysis.to_dict()
+        import json
+        json.dumps(d)  # should not raise
+
+    def test_empty_analysis_summary_table(self):
+        analysis = AttributeAnalysis()
+        assert "No attribute data" in analysis.summary_table()
+
+
+# ── Vocabulary constants ──────────────────────────────────────────────────────
+
+
+class TestVocabularyConstants:
+    def test_lasot_attributes_not_empty(self):
+        assert len(LASOT_ATTRIBUTES) > 0
+
+    def test_otb_attributes_not_empty(self):
+        assert len(OTB_ATTRIBUTES) > 0
+
+    def test_auto_derivable_subset(self):
+        for attr in AUTO_DERIVABLE_ATTRIBUTES:
+            assert isinstance(attr, str)
+
+    def test_no_duplicates_in_lasot(self):
+        assert len(LASOT_ATTRIBUTES) == len(set(LASOT_ATTRIBUTES))
+
+    def test_no_duplicates_in_otb(self):
+        assert len(OTB_ATTRIBUTES) == len(set(OTB_ATTRIBUTES))


### PR DESCRIPTION
## What was added

Introduces `AttributeAnalyzer` — a module that breaks down tracker accuracy by challenging conditions (occlusion, fast motion, scale variation, low resolution, etc.) following the standard LaSOT / OTB evaluation protocol.

### New files
| File | Description |
|------|-------------|
| `eovot/metrics/attributes.py` | Core module: `AttributeAnalyzer`, `AttributeResult`, `AttributeAnalysis`, geometry-based mask derivation, OTB tag conversion, attribute vocabulary constants |
| `eovot/metrics/__init__.py` | Updated to export all new symbols |
| `tests/test_attributes.py` | 36 passing tests |

### Key capabilities

**Explicit mask workflow** (LaSOT / sequence-level annotations):
```python
from eovot.metrics import AttributeAnalyzer

analyzer = AttributeAnalyzer()
masks = {
    "occlusion":   np.array([False, True, True, False, ...]),
    "fast_motion": np.array([True,  True, False, False, ...]),
}
analysis = analyzer.analyze_sequence(predictions, ground_truth, masks)
print(analysis.summary_table())
```

**Auto-derive workflow** (no annotations required):
```python
masks = analyzer.auto_derive_masks(ground_truth)  # fast_motion, scale_variation, low_resolution
analysis = analyzer.analyze_sequence(predictions, ground_truth, masks)
```

**Benchmark aggregation** (pool frames across sequences):
```python
analysis = analyzer.analyze_benchmark(
    sequence_predictions, sequence_ground_truths, sequence_attribute_masks
)
```

**Example output:**
```
| Attribute       | Frames | mIoU   | Success AUC | Precision AUC |
|-----------------|-------:|-------:|------------:|--------------:|
| fast_motion     |    342 | 0.3812 |      0.3541 |        0.5123 |
| scale_variation |    518 | 0.4210 |      0.3980 |        0.5887 |
| low_resolution  |     97 | 0.2934 |      0.2701 |        0.4310 |
```

## Why it matters

Every major VOT challenge paper (LaSOT, OTB, GOT-10k, TrackingNet) reports per-attribute performance. Without it, a single mIoU scalar hides:
- Which conditions cause tracker failure
- Whether improvements are attribute-specific or general
- How trackers compare under deployment-relevant conditions (occlusion, small targets)

This module makes EOVOT results directly comparable to published benchmarks.

## How it fits the project

- Slots into the existing `MetricsEngine` pipeline — no API breakage
- `AttributeAnalysis.to_dict()` produces JSON-serialisable output for the reporter
- `summary_table()` returns Markdown for direct inclusion in experiment reports
- Auto-derived masks work on any dataset (OTB, GOT-10k) without requiring attribute annotation files

## Tests
```
36 passed in 0.24s
```
Covers: mask derivation edge cases, single-sequence analysis, benchmark pooling, OTB tag normalisation, Markdown/JSON serialisation, empty-input handling.

---
_Generated by [Claude Code](https://claude.ai/code/session_016kdVt9oMBi7xGcZtiuUHuY)_