### PR TITLE
feat(metrics): GOT-10k evaluation protocol (AO, SR50, SR75) + fix dataset loader

### DIFF
--- a/eovot/datasets/got10k.py
+++ b/eovot/datasets/got10k.py
@@ -109,7 +109,7 @@ class GOT10kDataset(BaseDataset):
         self._seq_names = names
         return self._seq_names
 
-    def _load_sequence(self, seq_name: str) -> Sequence:
+    def load_sequence(self, seq_name: str) -> Sequence:
         """Load a single GOT-10k sequence by name.
 
         Frames are referenced by path (lazy I/O) rather than pre-loaded,
@@ -161,8 +161,6 @@ class GOT10kDataset(BaseDataset):
     @property
     def name(self) -> str:
         return f"GOT-10k-{self.split}"
-
-        return Sequence(name=seq_name, frame_paths=frame_paths_str, ground_truth=gt_array)
 
     @staticmethod
     def _load_groundtruth(gt_file: Path) -> List[BBox]:

--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -7,6 +7,13 @@ from .accuracy import (
     MetricsEngine,
 )
 from .robustness import RobustnessAnalyzer, RobustnessResult
+from .got10k_eval import (
+    compute_ao,
+    compute_sr,
+    GOT10kSequenceResult,
+    GOT10kReport,
+    GOT10kEvaluator,
+)
 
 __all__ = [
     "iou",
@@ -15,4 +22,9 @@ __all__ = [
     "MetricsEngine",
     "RobustnessAnalyzer",
     "RobustnessResult",
+    "compute_ao",
+    "compute_sr",
+    "GOT10kSequenceResult",
+    "GOT10kReport",
+    "GOT10kEvaluator",
 ]

--- a/eovot/metrics/got10k_eval.py
+++ b/eovot/metrics/got10k_eval.py
@@ -1,0 +1,317 @@
+"""GOT-10k evaluation protocol for EOVOT.
+
+Implements the official GOT-10k evaluation metrics defined in:
+
+    Huang et al., "GOT-10k: A Large High-Diversity Benchmark for Generic
+    Object Tracking in the Wild." IEEE TPAMI 2021.
+
+Metrics
+-------
+* **AO** (Average Overlap): mean IoU across all non-initialisation frames
+  (frame 0 is excluded — it is the init frame and trivially has IoU = 1).
+* **SR₅₀** (Success Rate at τ = 0.5): fraction of non-init frames with
+  IoU ≥ 0.5.  Required by the official leaderboard.
+* **SR₇₅** (Success Rate at τ = 0.75): fraction of non-init frames with
+  IoU ≥ 0.75.  Discriminates high-accuracy trackers.
+
+The evaluator also exports predictions in the official GOT-10k submission
+format (one TXT file per sequence, starting from frame 2) for upload to
+the evaluation server at http://got-10k.aitestunion.com/
+
+Typical usage::
+
+    from eovot.benchmark.engine import BenchmarkEngine
+    from eovot.metrics.got10k_eval import GOT10kEvaluator
+
+    engine = BenchmarkEngine()
+    result = engine.run(tracker, got10k_val_dataset, dataset_name="GOT-10k-val")
+
+    evaluator = GOT10kEvaluator(split="val")
+    report = evaluator.evaluate(result)
+    print(report)
+    # GOT-10k [MOSSE / val] AO=0.3421  SR50=0.3012  SR75=0.0987  (180 sequences)
+
+    # Export for submission to the evaluation server
+    evaluator.export_submission(report, result, output_dir="submissions/")
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+
+@dataclass
+class GOT10kSequenceResult:
+    """Per-sequence GOT-10k evaluation result."""
+
+    sequence_name: str
+    ao: float
+    """Average Overlap — mean IoU over all non-init frames."""
+    sr50: float
+    """Success Rate at IoU ≥ 0.5."""
+    sr75: float
+    """Success Rate at IoU ≥ 0.75."""
+    num_frames: int
+    """Total frame count including the initialisation frame."""
+
+    def __str__(self) -> str:
+        return (
+            f"{self.sequence_name}: AO={self.ao:.4f}  "
+            f"SR50={self.sr50:.4f}  SR75={self.sr75:.4f}  "
+            f"frames={self.num_frames}"
+        )
+
+    def to_dict(self) -> Dict:
+        return {
+            "name": self.sequence_name,
+            "ao": round(self.ao, 4),
+            "sr50": round(self.sr50, 4),
+            "sr75": round(self.sr75, 4),
+            "frames": self.num_frames,
+        }
+
+
+@dataclass
+class GOT10kReport:
+    """Aggregate GOT-10k evaluation report across all sequences.
+
+    Attributes:
+        tracker_name:  Identifier of the evaluated tracker.
+        dataset_split: Dataset split (``"val"`` or ``"test"``).
+        ao:            Mean AO across sequences — primary leaderboard metric.
+        sr50:          Mean SR₅₀ across sequences.
+        sr75:          Mean SR₇₅ across sequences.
+        num_sequences: Number of sequences evaluated.
+        per_sequence:  Per-sequence breakdown.
+    """
+
+    tracker_name: str
+    dataset_split: str
+    ao: float
+    sr50: float
+    sr75: float
+    num_sequences: int
+    per_sequence: List[GOT10kSequenceResult] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return (
+            f"GOT-10k [{self.tracker_name} / {self.dataset_split}] "
+            f"AO={self.ao:.4f}  SR50={self.sr50:.4f}  SR75={self.sr75:.4f}  "
+            f"({self.num_sequences} sequences)"
+        )
+
+    def to_dict(self) -> Dict:
+        return {
+            "tracker": self.tracker_name,
+            "split": self.dataset_split,
+            "ao": round(self.ao, 4),
+            "sr50": round(self.sr50, 4),
+            "sr75": round(self.sr75, 4),
+            "num_sequences": self.num_sequences,
+            "per_sequence": [s.to_dict() for s in self.per_sequence],
+        }
+
+
+def compute_ao(ious: np.ndarray) -> float:
+    """Compute Average Overlap (AO) following the GOT-10k protocol.
+
+    The initialisation frame (index 0) is excluded; it is trivially
+    IoU = 1.0 by construction and would inflate the score.
+
+    Args:
+        ious: Per-frame IoU array of shape ``(N,)`` where ``N`` is the
+            total sequence length including the init frame.
+
+    Returns:
+        Mean IoU over frames ``1 … N-1``, or ``0.0`` for sequences
+        shorter than 2 frames.
+    """
+    if len(ious) < 2:
+        return 0.0
+    return float(np.mean(ious[1:]))
+
+
+def compute_sr(ious: np.ndarray, threshold: float = 0.5) -> float:
+    """Compute Success Rate (SR) at a given IoU threshold.
+
+    Args:
+        ious:      Per-frame IoU array of shape ``(N,)``.
+        threshold: IoU threshold in ``[0, 1]``.  Default: ``0.5`` (SR₅₀).
+
+    Returns:
+        Fraction of non-init frames with IoU ≥ ``threshold``, or ``0.0``
+        for sequences shorter than 2 frames.
+    """
+    if len(ious) < 2:
+        return 0.0
+    return float(np.mean(ious[1:] >= threshold))
+
+
+class GOT10kEvaluator:
+    """Evaluate tracker results using the official GOT-10k protocol.
+
+    Computes AO, SR₅₀, and SR₇₅ from
+    :class:`~eovot.benchmark.engine.BenchmarkResult` objects and optionally
+    exports results in the official submission format.
+
+    Args:
+        split: Dataset split being evaluated — used for report labelling only.
+            Default: ``"val"``.
+
+    Example::
+
+        evaluator = GOT10kEvaluator(split="val")
+        report = evaluator.evaluate(benchmark_result)
+        print(report)
+
+        # Save JSON report + submission TXT files
+        evaluator.export_submission(report, benchmark_result, output_dir="submit/")
+
+        # Compare multiple trackers
+        reports = [evaluator.evaluate(r) for r in results]
+        print(evaluator.to_markdown_table(reports))
+    """
+
+    def __init__(self, split: str = "val") -> None:
+        self.split = split
+
+    # ------------------------------------------------------------------
+    # Core evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate(self, result) -> GOT10kReport:
+        """Compute GOT-10k metrics from a :class:`~eovot.benchmark.engine.BenchmarkResult`.
+
+        Args:
+            result: Output of :meth:`~eovot.benchmark.engine.BenchmarkEngine.run`.
+
+        Returns:
+            :class:`GOT10kReport` with aggregate and per-sequence statistics.
+        """
+        per_seq: List[GOT10kSequenceResult] = []
+
+        for sr in result.sequence_results:
+            ious = np.asarray(sr.ious, dtype=np.float64)
+            per_seq.append(
+                GOT10kSequenceResult(
+                    sequence_name=sr.sequence_name,
+                    ao=compute_ao(ious),
+                    sr50=compute_sr(ious, 0.5),
+                    sr75=compute_sr(ious, 0.75),
+                    num_frames=len(ious),
+                )
+            )
+
+        n = len(per_seq)
+        mean_ao = float(np.mean([s.ao for s in per_seq])) if n else 0.0
+        mean_sr50 = float(np.mean([s.sr50 for s in per_seq])) if n else 0.0
+        mean_sr75 = float(np.mean([s.sr75 for s in per_seq])) if n else 0.0
+
+        return GOT10kReport(
+            tracker_name=result.tracker_name,
+            dataset_split=self.split,
+            ao=mean_ao,
+            sr50=mean_sr50,
+            sr75=mean_sr75,
+            num_sequences=n,
+            per_sequence=per_seq,
+        )
+
+    # ------------------------------------------------------------------
+    # Submission format export
+    # ------------------------------------------------------------------
+
+    def export_submission(
+        self,
+        report: GOT10kReport,
+        result,
+        output_dir: str,
+    ) -> Path:
+        """Export results in the GOT-10k official submission format.
+
+        The official server expects a directory named ``<tracker_name>``
+        containing one TXT file per sequence.  Each file holds predicted
+        bounding boxes from frame 2 onwards (frame 1 is the init frame),
+        one ``x,y,w,h`` box per line (comma-separated, three decimal places).
+
+        A JSON summary of AO / SR₅₀ / SR₇₅ is also written alongside
+        the per-sequence files for local record-keeping.
+
+        Args:
+            report:     :class:`GOT10kReport` returned by :meth:`evaluate`.
+            result:     Original
+                :class:`~eovot.benchmark.engine.BenchmarkResult` — needed
+                for the raw per-frame predictions.
+            output_dir: Root directory.  A ``<tracker_name>/`` subdirectory
+                is created inside it.
+
+        Returns:
+            Path to the tracker submission directory.
+        """
+        submit_dir = Path(output_dir) / report.tracker_name
+        submit_dir.mkdir(parents=True, exist_ok=True)
+
+        for sr in result.sequence_results:
+            if sr.predictions is None or len(sr.predictions) < 2:
+                continue
+            pred_txt = submit_dir / f"{sr.sequence_name}.txt"
+            with open(pred_txt, "w") as fh:
+                for box in sr.predictions[1:]:
+                    fh.write(
+                        f"{box[0]:.3f},{box[1]:.3f},{box[2]:.3f},{box[3]:.3f}\n"
+                    )
+
+        report_path = submit_dir / "got10k_report.json"
+        with open(report_path, "w") as fh:
+            json.dump(report.to_dict(), fh, indent=2)
+
+        return submit_dir
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+
+    def to_markdown_table(self, reports: List[GOT10kReport]) -> str:
+        """Format a list of GOT-10k reports as a Markdown comparison table.
+
+        Trackers are ranked by AO (descending).
+
+        Args:
+            reports: One :class:`GOT10kReport` per tracker.
+
+        Returns:
+            Multi-line Markdown string ready for pasting into a README or paper.
+        """
+        ranked = sorted(reports, key=lambda r: r.ao, reverse=True)
+        lines = [
+            "| Rank | Tracker | AO | SR₅₀ | SR₇₅ | Sequences |",
+            "|------|---------|---:|-----:|-----:|----------:|",
+        ]
+        for rank, r in enumerate(ranked, 1):
+            lines.append(
+                f"| {rank} | {r.tracker_name} | {r.ao:.4f} "
+                f"| {r.sr50:.4f} | {r.sr75:.4f} | {r.num_sequences} |"
+            )
+        return "\n".join(lines)
+
+    def save_report(self, report: GOT10kReport, output_dir: str) -> Path:
+        """Save a :class:`GOT10kReport` as a JSON file.
+
+        Args:
+            report:     Report to save.
+            output_dir: Destination directory (created if absent).
+
+        Returns:
+            Path to the written JSON file.
+        """
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        path = out / f"got10k_{report.tracker_name}_{report.dataset_split}.json"
+        with open(path, "w") as fh:
+            json.dump(report.to_dict(), fh, indent=2)
+        return path

--- a/tests/test_got10k_eval.py
+++ b/tests/test_got10k_eval.py
@@ -1,0 +1,368 @@
+"""Tests for eovot.metrics.got10k_eval and eovot.datasets.got10k (bug fix)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Iterator, List
+
+import cv2
+import numpy as np
+import pytest
+
+from eovot.metrics.got10k_eval import (
+    GOT10kEvaluator,
+    GOT10kReport,
+    GOT10kSequenceResult,
+    compute_ao,
+    compute_sr,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic BenchmarkResult-like objects
+# ---------------------------------------------------------------------------
+
+class _FakeSequenceResult:
+    def __init__(self, name: str, ious, predictions=None):
+        self.sequence_name = name
+        self.ious = np.asarray(ious, dtype=np.float64)
+        self.predictions = (
+            np.array(predictions, dtype=np.float64)
+            if predictions is not None
+            else None
+        )
+
+
+class _FakeBenchmarkResult:
+    def __init__(self, tracker_name: str, seq_results):
+        self.tracker_name = tracker_name
+        self.sequence_results = seq_results
+
+
+def _make_result(tracker_name, seq_ious_map, with_predictions=True):
+    seq_results = []
+    for name, ious in seq_ious_map.items():
+        n = len(ious)
+        preds = np.tile([10.0, 10.0, 50.0, 50.0], (n, 1)) if with_predictions else None
+        seq_results.append(_FakeSequenceResult(name, ious, preds))
+    return _FakeBenchmarkResult(tracker_name, seq_results)
+
+
+# ---------------------------------------------------------------------------
+# compute_ao
+# ---------------------------------------------------------------------------
+
+class TestComputeAO:
+    def test_perfect_tracking_excludes_init(self):
+        # All frames including init are 1.0 — AO should still be 1.0
+        ious = np.ones(10)
+        assert compute_ao(ious) == pytest.approx(1.0)
+
+    def test_zero_tracking(self):
+        ious = np.zeros(10)
+        assert compute_ao(ious) == pytest.approx(0.0)
+
+    def test_init_frame_excluded(self):
+        # Init frame (index 0) = 1.0, rest = 0.0 → AO should be 0.0
+        ious = np.array([1.0, 0.0, 0.0, 0.0, 0.0])
+        assert compute_ao(ious) == pytest.approx(0.0)
+
+    def test_known_mean(self):
+        ious = np.array([1.0, 0.2, 0.4, 0.6, 0.8])
+        expected = np.mean([0.2, 0.4, 0.6, 0.8])
+        assert compute_ao(ious) == pytest.approx(expected)
+
+    def test_single_frame_returns_zero(self):
+        assert compute_ao(np.array([1.0])) == pytest.approx(0.0)
+
+    def test_empty_returns_zero(self):
+        assert compute_ao(np.array([])) == pytest.approx(0.0)
+
+    def test_two_frames(self):
+        # Only one non-init frame
+        ious = np.array([1.0, 0.6])
+        assert compute_ao(ious) == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# compute_sr
+# ---------------------------------------------------------------------------
+
+class TestComputeSR:
+    def test_sr50_all_above(self):
+        ious = np.array([1.0, 0.6, 0.7, 0.8, 0.9])
+        assert compute_sr(ious, 0.5) == pytest.approx(1.0)
+
+    def test_sr50_none_above(self):
+        ious = np.array([1.0, 0.1, 0.2, 0.3, 0.4])
+        assert compute_sr(ious, 0.5) == pytest.approx(0.0)
+
+    def test_sr50_half(self):
+        ious = np.array([1.0, 0.6, 0.4, 0.6, 0.4])
+        assert compute_sr(ious, 0.5) == pytest.approx(0.5)
+
+    def test_sr75_stricter(self):
+        ious = np.array([1.0, 0.8, 0.6, 0.8, 0.6])
+        sr50 = compute_sr(ious, 0.5)
+        sr75 = compute_sr(ious, 0.75)
+        assert sr75 <= sr50
+
+    def test_exact_threshold_included(self):
+        # IoU == threshold qualifies (≥)
+        ious = np.array([1.0, 0.5, 0.5])
+        assert compute_sr(ious, 0.5) == pytest.approx(1.0)
+
+    def test_single_frame_returns_zero(self):
+        assert compute_sr(np.array([1.0]), 0.5) == pytest.approx(0.0)
+
+    def test_empty_returns_zero(self):
+        assert compute_sr(np.array([]), 0.5) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# GOT10kEvaluator.evaluate
+# ---------------------------------------------------------------------------
+
+class TestGOT10kEvaluator:
+    def setup_method(self):
+        self.evaluator = GOT10kEvaluator(split="val")
+
+    def test_returns_report_type(self):
+        result = _make_result("MOSSE", {"seq1": np.ones(10)})
+        report = self.evaluator.evaluate(result)
+        assert isinstance(report, GOT10kReport)
+
+    def test_tracker_name_preserved(self):
+        result = _make_result("KCF", {"seq1": np.ones(5)})
+        report = self.evaluator.evaluate(result)
+        assert report.tracker_name == "KCF"
+
+    def test_split_preserved(self):
+        ev = GOT10kEvaluator(split="test")
+        result = _make_result("MOSSE", {"seq1": np.ones(5)})
+        report = ev.evaluate(result)
+        assert report.dataset_split == "test"
+
+    def test_num_sequences(self):
+        result = _make_result("T", {"s1": np.ones(5), "s2": np.ones(5), "s3": np.ones(5)})
+        report = self.evaluator.evaluate(result)
+        assert report.num_sequences == 3
+
+    def test_perfect_tracker_ao_one(self):
+        result = _make_result("T", {"s1": np.ones(20), "s2": np.ones(15)})
+        report = self.evaluator.evaluate(result)
+        assert report.ao == pytest.approx(1.0)
+
+    def test_perfect_tracker_sr50_one(self):
+        result = _make_result("T", {"s1": np.ones(20)})
+        report = self.evaluator.evaluate(result)
+        assert report.sr50 == pytest.approx(1.0)
+
+    def test_perfect_tracker_sr75_one(self):
+        result = _make_result("T", {"s1": np.ones(20)})
+        report = self.evaluator.evaluate(result)
+        assert report.sr75 == pytest.approx(1.0)
+
+    def test_zero_tracker_all_zeros(self):
+        # All non-init frames are 0 → AO=SR50=SR75=0
+        ious = np.array([1.0] + [0.0] * 9)
+        result = _make_result("T", {"s1": ious})
+        report = self.evaluator.evaluate(result)
+        assert report.ao == pytest.approx(0.0)
+        assert report.sr50 == pytest.approx(0.0)
+        assert report.sr75 == pytest.approx(0.0)
+
+    def test_sr75_leq_sr50(self):
+        ious = np.array([1.0, 0.8, 0.6, 0.4, 0.9, 0.7])
+        result = _make_result("T", {"s1": ious})
+        report = self.evaluator.evaluate(result)
+        assert report.sr75 <= report.sr50
+
+    def test_per_sequence_count(self):
+        result = _make_result("T", {"s1": np.ones(5), "s2": np.ones(5)})
+        report = self.evaluator.evaluate(result)
+        assert len(report.per_sequence) == 2
+
+    def test_per_sequence_ao_correct(self):
+        ious = np.array([1.0, 0.4, 0.6, 0.8])
+        result = _make_result("T", {"only": ious})
+        report = self.evaluator.evaluate(result)
+        expected_ao = np.mean([0.4, 0.6, 0.8])
+        assert report.per_sequence[0].ao == pytest.approx(expected_ao)
+
+    def test_empty_result(self):
+        result = _FakeBenchmarkResult("T", [])
+        report = self.evaluator.evaluate(result)
+        assert report.num_sequences == 0
+        assert report.ao == pytest.approx(0.0)
+
+    def test_str_representation(self):
+        result = _make_result("MOSSE", {"s1": np.ones(10)})
+        report = self.evaluator.evaluate(result)
+        s = str(report)
+        assert "MOSSE" in s
+        assert "AO" in s
+        assert "SR50" in s
+
+    def test_to_dict_keys(self):
+        result = _make_result("T", {"s1": np.ones(8)})
+        report = self.evaluator.evaluate(result)
+        d = report.to_dict()
+        for key in ("tracker", "split", "ao", "sr50", "sr75", "num_sequences", "per_sequence"):
+            assert key in d
+
+
+# ---------------------------------------------------------------------------
+# export_submission
+# ---------------------------------------------------------------------------
+
+class TestExportSubmission:
+    def setup_method(self):
+        self.evaluator = GOT10kEvaluator(split="val")
+
+    def test_creates_tracker_directory(self, tmp_path):
+        preds = np.tile([10.0, 10.0, 50.0, 50.0], (5, 1))
+        seq = _FakeSequenceResult("GOT-10k_Val_000001", np.ones(5), preds)
+        result = _FakeBenchmarkResult("MOSSE", [seq])
+        report = self.evaluator.evaluate(result)
+        submit_dir = self.evaluator.export_submission(report, result, str(tmp_path))
+        assert submit_dir.is_dir()
+        assert submit_dir.name == "MOSSE"
+
+    def test_creates_per_sequence_txt(self, tmp_path):
+        preds = np.tile([10.0, 10.0, 50.0, 50.0], (5, 1))
+        seq = _FakeSequenceResult("seq_001", np.ones(5), preds)
+        result = _FakeBenchmarkResult("KCF", [seq])
+        report = self.evaluator.evaluate(result)
+        submit_dir = self.evaluator.export_submission(report, result, str(tmp_path))
+        assert (submit_dir / "seq_001.txt").exists()
+
+    def test_txt_skips_init_frame(self, tmp_path):
+        preds = np.tile([1.0, 2.0, 10.0, 10.0], (4, 1))
+        seq = _FakeSequenceResult("s1", np.ones(4), preds)
+        result = _FakeBenchmarkResult("T", [seq])
+        report = self.evaluator.evaluate(result)
+        submit_dir = self.evaluator.export_submission(report, result, str(tmp_path))
+        lines = (submit_dir / "s1.txt").read_text().strip().splitlines()
+        # 4 frames → init excluded → 3 lines
+        assert len(lines) == 3
+
+    def test_txt_format_comma_separated(self, tmp_path):
+        preds = np.array([[10.0, 20.0, 30.0, 40.0]] * 3)
+        seq = _FakeSequenceResult("s1", np.ones(3), preds)
+        result = _FakeBenchmarkResult("T", [seq])
+        report = self.evaluator.evaluate(result)
+        submit_dir = self.evaluator.export_submission(report, result, str(tmp_path))
+        first_line = (submit_dir / "s1.txt").read_text().strip().splitlines()[0]
+        parts = first_line.split(",")
+        assert len(parts) == 4
+        assert float(parts[0]) == pytest.approx(10.0, abs=0.01)
+
+    def test_creates_json_report(self, tmp_path):
+        preds = np.ones((3, 4))
+        seq = _FakeSequenceResult("s1", np.ones(3), preds)
+        result = _FakeBenchmarkResult("T", [seq])
+        report = self.evaluator.evaluate(result)
+        submit_dir = self.evaluator.export_submission(report, result, str(tmp_path))
+        assert (submit_dir / "got10k_report.json").exists()
+
+    def test_skips_sequence_without_predictions(self, tmp_path):
+        seq = _FakeSequenceResult("s1", np.ones(5), predictions=None)
+        result = _FakeBenchmarkResult("T", [seq])
+        report = self.evaluator.evaluate(result)
+        submit_dir = self.evaluator.export_submission(report, result, str(tmp_path))
+        assert not (submit_dir / "s1.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# to_markdown_table
+# ---------------------------------------------------------------------------
+
+class TestMarkdownTable:
+    def setup_method(self):
+        self.evaluator = GOT10kEvaluator()
+
+    def _report(self, name, ao, sr50, sr75):
+        return GOT10kReport(
+            tracker_name=name,
+            dataset_split="val",
+            ao=ao, sr50=sr50, sr75=sr75,
+            num_sequences=5,
+        )
+
+    def test_contains_tracker_names(self):
+        reports = [self._report("MOSSE", 0.35, 0.30, 0.10),
+                   self._report("KCF",   0.42, 0.38, 0.15)]
+        table = self.evaluator.to_markdown_table(reports)
+        assert "MOSSE" in table
+        assert "KCF" in table
+
+    def test_ranked_by_ao(self):
+        reports = [self._report("TrackerLow", 0.20, 0.15, 0.05),
+                   self._report("TrackerHigh", 0.45, 0.40, 0.20)]
+        table = self.evaluator.to_markdown_table(reports)
+        # TrackerHigh has higher AO → must appear before TrackerLow
+        assert table.index("TrackerHigh") < table.index("TrackerLow")
+
+    def test_empty_reports(self):
+        table = self.evaluator.to_markdown_table([])
+        assert "|" in table  # header row still present
+
+    def test_single_report(self):
+        table = self.evaluator.to_markdown_table([self._report("X", 0.3, 0.25, 0.08)])
+        assert "X" in table
+
+
+# ---------------------------------------------------------------------------
+# GOT10kDataset bug regression: load_sequence is public (not _load_sequence)
+# ---------------------------------------------------------------------------
+
+class TestGOT10kDatasetLoadSequencePublic:
+    """Regression test ensuring __getitem__ can call load_sequence (public)."""
+
+    def test_load_sequence_method_exists(self):
+        from eovot.datasets.got10k import GOT10kDataset
+        assert hasattr(GOT10kDataset, "load_sequence"), (
+            "GOT10kDataset must expose a public load_sequence() method "
+            "(was previously _load_sequence, causing __getitem__ to fail)"
+        )
+
+    def test_private_method_gone(self):
+        from eovot.datasets.got10k import GOT10kDataset
+        assert not hasattr(GOT10kDataset, "_load_sequence"), (
+            "_load_sequence should be removed after renaming to load_sequence"
+        )
+
+    def test_getitem_calls_load_sequence(self, tmp_path):
+        """__getitem__ should succeed with a synthetic GOT-10k structure."""
+        from eovot.datasets.got10k import GOT10kDataset
+
+        # Build minimal GOT-10k val structure
+        val_dir = tmp_path / "val"
+        seq_dir = val_dir / "GOT-10k_Val_000001"
+        img_dir = seq_dir / "img"
+        img_dir.mkdir(parents=True)
+
+        # Write 3 synthetic frames
+        for i in range(3):
+            frame = np.zeros((60, 80, 3), dtype=np.uint8)
+            cv2.imwrite(str(img_dir / f"{i + 1:08d}.jpg"), frame)
+
+        # Write groundtruth.txt
+        (seq_dir / "groundtruth.txt").write_text(
+            "10,20,50,40\n11,20,50,40\n12,20,50,40\n"
+        )
+
+        # list.txt
+        (val_dir / "list.txt").write_text("GOT-10k_Val_000001\n")
+
+        ds = GOT10kDataset(root=str(tmp_path), split="val")
+        assert len(ds) == 1
+
+        # This used to raise AttributeError before the bug fix
+        seq = ds[0]
+        assert seq.name == "GOT-10k_Val_000001"
+        assert len(seq) == 3
+        assert seq.ground_truth.shape == (3, 4)


### PR DESCRIPTION
Closes #100

## What was added

### Bug fix — `GOT10kDataset.load_sequence`
`__getitem__` was calling `self.load_sequence()` but the method was defined as `_load_sequence()`. This caused `AttributeError` whenever the dataset was actually iterated in a benchmark run. Renamed to `load_sequence` (public API) and removed the unreachable dead-code block after the `name` property.

### `eovot/metrics/got10k_eval.py` — GOT-10k evaluation protocol

Implements the official GOT-10k metrics needed for publishable comparisons:

| Metric | Description |
|--------|-------------|
| **AO** | Average Overlap — mean IoU over all non-initialisation frames |
| **SR₅₀** | Success Rate at IoU ≥ 0.5 — primary leaderboard threshold |
| **SR₇₅** | Success Rate at IoU ≥ 0.75 — discriminates high-accuracy trackers |

Key classes:
- `GOT10kEvaluator.evaluate(result)` — computes AO/SR50/SR75 from a `BenchmarkResult`
- `GOT10kEvaluator.export_submission(...)` — exports per-sequence TXT files in the official GOT-10k server format
- `GOT10kEvaluator.to_markdown_table(reports)` — publication-ready comparison table ranked by AO

### Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.metrics.got10k_eval import GOT10kEvaluator
from eovot.datasets.got10k import GOT10kDataset
from eovot.trackers.kcf import KCFTracker

dataset = GOT10kDataset("/data/GOT-10k", split="val")
engine  = BenchmarkEngine()
result  = engine.run(KCFTracker(), dataset, dataset_name="GOT-10k-val")

evaluator = GOT10kEvaluator(split="val")
report    = evaluator.evaluate(result)
print(report)
# GOT-10k [KCF / val] AO=0.4123  SR50=0.3891  SR75=0.1540  (180 sequences)

# Export for the official evaluation server
evaluator.export_submission(report, result, output_dir="submissions/")
```

## Files changed

| File | Change |
|------|--------|
| `eovot/datasets/got10k.py` | Fix: `_load_sequence → load_sequence`, remove dead code |
| `eovot/metrics/got10k_eval.py` | New: GOT-10k evaluation protocol module |
| `eovot/metrics/__init__.py` | Export `GOT10kEvaluator`, `GOT10kReport`, `compute_ao`, `compute_sr` |
| `tests/test_got10k_eval.py` | New: 41 unit tests |

## Test results

```
41 passed in 0.23s
```

Covers: `compute_ao`, `compute_sr`, `GOT10kEvaluator.evaluate`, submission export, markdown table, and the `load_sequence` bug regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSerG5kowKLRN8aJW7s9TS)_