### PR TITLE
[feat] AttributeAnalyzer — per-challenge tracker performance breakdown module

### DIFF
--- a/eovot/__init__.py
+++ b/eovot/__init__.py
@@ -2,6 +2,6 @@
 
 __version__ = "0.1.0"
 
-from eovot import benchmark, datasets, metrics, profiling, reporting, trackers
+from eovot import analysis, benchmark, datasets, metrics, profiling, reporting, trackers
 
-__all__ = ["benchmark", "datasets", "metrics", "profiling", "reporting", "trackers"]
+__all__ = ["analysis", "benchmark", "datasets", "metrics", "profiling", "reporting", "trackers"]

--- a/eovot/analysis/__init__.py
+++ b/eovot/analysis/__init__.py
@@ -1,0 +1,13 @@
+"""Analysis sub-package — per-attribute and cross-experiment tracker evaluation."""
+
+from .attribute_analyzer import (
+    AttributeStats,
+    AttributeReport,
+    AttributeAnalyzer,
+)
+
+__all__ = [
+    "AttributeStats",
+    "AttributeReport",
+    "AttributeAnalyzer",
+]

--- a/eovot/analysis/attribute_analyzer.py
+++ b/eovot/analysis/attribute_analyzer.py
@@ -1,0 +1,446 @@
+"""Attribute-based tracker performance analysis for OTB-style benchmarks.
+
+Visual tracking benchmarks annotate sequences with challenge attributes such as
+Occlusion, Fast Motion, and Scale Variation.  Grouping per-sequence results by
+these attributes exposes *why* a tracker succeeds or fails — information that
+aggregate mIoU scores completely hide.
+
+This module provides :class:`AttributeAnalyzer`, which accepts benchmark results
+(from :class:`~eovot.benchmark.engine.BenchmarkResult`) and a mapping of sequence
+names to their challenge attributes, then produces:
+
+- Per-attribute mean IoU and failure statistics for each tracker
+- A tracker × attribute comparison matrix (research-grade table)
+- Identification of the *hardest* attribute per tracker
+- Identification of the *best* tracker per attribute
+- A self-contained Markdown report suitable for inclusion in papers
+
+The analyzer is dataset-agnostic: any ``Dict[str, Collection[str]]`` mapping
+sequence names to attribute codes works — not just OTB.  The
+:meth:`~eovot.datasets.otb.OTBDataset.attribute_map` method on ``OTBDataset``
+returns exactly this format.
+
+Typical usage::
+
+    from eovot.analysis import AttributeAnalyzer
+    from eovot.datasets.otb import OTBDataset
+
+    dataset = OTBDataset("/data/OTB100")
+    attr_map = dataset.attribute_map()
+
+    # Assume benchmark_results is a list of BenchmarkResult objects,
+    # one per tracker, obtained from BenchmarkEngine.
+    analyzer = AttributeAnalyzer(attr_map)
+    report = analyzer.generate_report(benchmark_results)
+    print(report.to_markdown())
+
+    # Save to file
+    with open("attribute_analysis.md", "w") as f:
+        f.write(report.to_markdown())
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Collection, Dict, FrozenSet, List, Optional, Tuple, TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..benchmark.engine import BenchmarkResult
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AttributeStats:
+    """Per-attribute performance statistics for a single tracker.
+
+    Attributes:
+        tracker_name: Human-readable tracker identifier.
+        attribute: Attribute code (e.g. ``"FM"``).
+        attribute_name: Full attribute name (e.g. ``"Fast Motion"``).
+        n_sequences: Number of sequences in the dataset that carry this attribute.
+        mean_iou: Mean IoU across all frames in those sequences.
+        std_iou: Standard deviation of per-sequence mean IoU values.
+        min_iou: Worst per-sequence mean IoU (most difficult sequence for this attribute).
+        max_iou: Best per-sequence mean IoU.
+        sequence_names: Sequence names included in this attribute group.
+    """
+
+    tracker_name: str
+    attribute: str
+    attribute_name: str
+    n_sequences: int
+    mean_iou: float
+    std_iou: float
+    min_iou: float
+    max_iou: float
+    sequence_names: List[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return (
+            f"AttributeStats({self.tracker_name} | {self.attribute} | "
+            f"n={self.n_sequences} | mIoU={self.mean_iou:.4f} ± {self.std_iou:.4f})"
+        )
+
+
+@dataclass
+class AttributeReport:
+    """Full attribute-analysis report for one or more trackers.
+
+    Attributes:
+        tracker_names: Ordered list of tracker names in this report.
+        attributes: Ordered list of attribute codes covered.
+        attribute_names: Full names corresponding to each code in ``attributes``.
+        stats: Nested mapping ``tracker_name → attribute → AttributeStats``.
+        dataset_name: Optional dataset label for the report header.
+    """
+
+    tracker_names: List[str]
+    attributes: List[str]
+    attribute_names: List[str]
+    stats: Dict[str, Dict[str, AttributeStats]]
+    dataset_name: str = ""
+
+    # ------------------------------------------------------------------
+    # Derived metrics
+    # ------------------------------------------------------------------
+
+    def iou_matrix(self) -> np.ndarray:
+        """Return a (n_trackers × n_attributes) mean-IoU matrix.
+
+        Rows correspond to ``tracker_names``; columns to ``attributes``.
+        Missing cells (attribute not present for a tracker) are filled with
+        ``np.nan``.
+        """
+        mat = np.full((len(self.tracker_names), len(self.attributes)), np.nan)
+        for i, tracker in enumerate(self.tracker_names):
+            for j, attr in enumerate(self.attributes):
+                entry = self.stats.get(tracker, {}).get(attr)
+                if entry is not None:
+                    mat[i, j] = entry.mean_iou
+        return mat
+
+    def hardest_attribute(self, tracker_name: str) -> Optional[Tuple[str, float]]:
+        """Return ``(attribute_code, mean_iou)`` for the tracker's weakest attribute.
+
+        Returns ``None`` if the tracker has no attribute stats.
+        """
+        tracker_stats = self.stats.get(tracker_name, {})
+        if not tracker_stats:
+            return None
+        worst = min(tracker_stats.values(), key=lambda s: s.mean_iou)
+        return worst.attribute, worst.mean_iou
+
+    def best_tracker_per_attribute(self) -> Dict[str, Tuple[str, float]]:
+        """Return ``{attribute: (best_tracker_name, mean_iou)}`` for all attributes."""
+        best: Dict[str, Tuple[str, float]] = {}
+        for attr in self.attributes:
+            candidates = [
+                (tracker, self.stats[tracker][attr].mean_iou)
+                for tracker in self.tracker_names
+                if attr in self.stats.get(tracker, {})
+            ]
+            if candidates:
+                best[attr] = max(candidates, key=lambda x: x[1])
+        return best
+
+    # ------------------------------------------------------------------
+    # Report serialisation
+    # ------------------------------------------------------------------
+
+    def to_markdown(self) -> str:
+        """Render a complete Markdown analysis report.
+
+        The report contains:
+        1. Header with dataset name and date context
+        2. Tracker × attribute mean-IoU table
+        3. Per-tracker hardest attribute summary
+        4. Best tracker per attribute table
+        5. Methodology note
+        """
+        lines: List[str] = []
+
+        # --- Header ---
+        header = f"# Attribute-Based Tracker Performance Analysis"
+        if self.dataset_name:
+            header += f" — {self.dataset_name}"
+        lines.append(header)
+        lines.append("")
+        lines.append(
+            "Mean IoU grouped by OTB challenge attribute.  "
+            "Each cell shows the average IoU over all sequences that carry the given "
+            "attribute.  **Bold** marks the best tracker per column."
+        )
+        lines.append("")
+
+        # --- Tracker × attribute matrix ---
+        mat = self.iou_matrix()
+        best_per_col = np.nanargmax(mat, axis=0)
+
+        # Build header row
+        col_labels = [f"{a}<br>({n})" for a, n in zip(self.attributes, self.attribute_names)]
+        header_row = "| Tracker | " + " | ".join(col_labels) + " |"
+        sep_row = "|---------|" + "|".join(["------:"] * len(self.attributes)) + "|"
+        lines.append(header_row)
+        lines.append(sep_row)
+
+        for i, tracker in enumerate(self.tracker_names):
+            cells = []
+            for j, attr in enumerate(self.attributes):
+                val = mat[i, j]
+                if math.isnan(val):
+                    cells.append(" — ")
+                else:
+                    formatted = f"{val:.3f}"
+                    if best_per_col[j] == i:
+                        formatted = f"**{formatted}**"
+                    cells.append(formatted)
+            lines.append(f"| {tracker} | " + " | ".join(cells) + " |")
+
+        lines.append("")
+
+        # --- Coverage row (how many sequences per attribute) ---
+        lines.append("*Sequence counts per attribute:*")
+        lines.append("")
+        # Use stats from the first tracker to get sequence counts
+        first_tracker = self.tracker_names[0] if self.tracker_names else ""
+        count_parts = []
+        for attr in self.attributes:
+            entry = self.stats.get(first_tracker, {}).get(attr)
+            n = entry.n_sequences if entry else "?"
+            count_parts.append(f"{attr}: {n}")
+        lines.append("  " + ",  ".join(count_parts))
+        lines.append("")
+
+        # --- Per-tracker hardest attribute ---
+        lines.append("## Hardest Attribute per Tracker")
+        lines.append("")
+        lines.append("| Tracker | Hardest Attribute | mIoU on that Attribute |")
+        lines.append("|---------|-------------------|------------------------|")
+        for tracker in self.tracker_names:
+            result = self.hardest_attribute(tracker)
+            if result:
+                attr_code, miou = result
+                attr_full = self.attribute_names[self.attributes.index(attr_code)]
+                lines.append(f"| {tracker} | {attr_code} ({attr_full}) | {miou:.4f} |")
+        lines.append("")
+
+        # --- Best tracker per attribute ---
+        lines.append("## Best Tracker per Attribute")
+        lines.append("")
+        lines.append("| Attribute | Best Tracker | mIoU |")
+        lines.append("|-----------|-------------|------|")
+        best_per_attr = self.best_tracker_per_attribute()
+        for attr, attr_name in zip(self.attributes, self.attribute_names):
+            if attr in best_per_attr:
+                tracker, miou = best_per_attr[attr]
+                lines.append(f"| {attr} ({attr_name}) | {tracker} | {miou:.4f} |")
+        lines.append("")
+
+        # --- Methodology ---
+        lines.append("## Methodology")
+        lines.append("")
+        lines.append(
+            "Attribute membership follows the annotations from "
+            "*Wu et al., \"Object Tracking Benchmark\", IEEE TPAMI 2015*. "
+            "A sequence may carry multiple attributes; it is included in the "
+            "computation for each attribute it carries.  Mean IoU is computed "
+            "over all frames in the matched sequences, weighted equally per "
+            "sequence."
+        )
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        """Serialise the report to a JSON-compatible dict."""
+        return {
+            "dataset": self.dataset_name,
+            "trackers": self.tracker_names,
+            "attributes": self.attributes,
+            "stats": {
+                tracker: {
+                    attr: {
+                        "n_sequences": s.n_sequences,
+                        "mean_iou": round(s.mean_iou, 6),
+                        "std_iou": round(s.std_iou, 6),
+                        "min_iou": round(s.min_iou, 6),
+                        "max_iou": round(s.max_iou, 6),
+                        "sequences": s.sequence_names,
+                    }
+                    for attr, s in attr_map.items()
+                }
+                for tracker, attr_map in self.stats.items()
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Analyzer
+# ---------------------------------------------------------------------------
+
+class AttributeAnalyzer:
+    """Compute per-attribute tracker performance from benchmark results.
+
+    The analyzer is intentionally dataset-agnostic: it accepts any mapping
+    ``{sequence_name: set_of_attribute_codes}`` so it works with OTB, custom
+    datasets, or any benchmark with sequence-level annotations.
+
+    Args:
+        attribute_map: Mapping from sequence name to a collection of attribute
+            codes.  Use :meth:`~eovot.datasets.otb.OTBDataset.attribute_map`
+            to obtain this from an ``OTBDataset``, or build it manually.
+        attribute_names: Optional mapping from attribute code to full name for
+            richer report output.  Defaults to using the code itself when absent.
+        dataset_name: Optional string used as the report title.
+
+    Example::
+
+        from eovot.analysis import AttributeAnalyzer
+        from eovot.datasets.otb import OTBDataset, OTB_ATTRIBUTE_NAMES
+
+        dataset = OTBDataset("/data/OTB100")
+        analyzer = AttributeAnalyzer(
+            attribute_map=dataset.attribute_map(),
+            attribute_names=OTB_ATTRIBUTE_NAMES,
+            dataset_name="OTB-100",
+        )
+        report = analyzer.generate_report(benchmark_results)
+        print(report.to_markdown())
+    """
+
+    def __init__(
+        self,
+        attribute_map: Dict[str, Collection[str]],
+        attribute_names: Optional[Dict[str, str]] = None,
+        dataset_name: str = "",
+    ) -> None:
+        if not attribute_map:
+            raise ValueError("attribute_map must not be empty.")
+        self._attr_map: Dict[str, FrozenSet[str]] = {
+            seq: frozenset(attrs) for seq, attrs in attribute_map.items()
+        }
+        self._attr_names: Dict[str, str] = attribute_names or {}
+        self.dataset_name = dataset_name
+
+        # Collect all unique attributes across the map, sorted for reproducibility.
+        all_attrs: set = set()
+        for attrs in self._attr_map.values():
+            all_attrs.update(attrs)
+        self._all_attributes: List[str] = sorted(all_attrs)
+
+    @property
+    def attributes(self) -> List[str]:
+        """Sorted list of all attribute codes present in the attribute map."""
+        return list(self._all_attributes)
+
+    def sequences_for_attribute(self, attribute: str) -> List[str]:
+        """Return sequence names annotated with *attribute*, sorted."""
+        return sorted(
+            seq for seq, attrs in self._attr_map.items() if attribute in attrs
+        )
+
+    def compute_stats(
+        self,
+        result: "BenchmarkResult",
+    ) -> Dict[str, AttributeStats]:
+        """Compute per-attribute :class:`AttributeStats` for one tracker result.
+
+        Only sequences present in both *result* and the attribute map contribute
+        to the statistics.  Sequences in the result that are not in the attribute
+        map are ignored (they were not annotated and cannot be grouped).
+
+        Args:
+            result: :class:`~eovot.benchmark.engine.BenchmarkResult` from a
+                single tracker evaluated on the benchmark dataset.
+
+        Returns:
+            Mapping ``{attribute_code: AttributeStats}`` containing one entry
+            per attribute that has at least one matching sequence.
+        """
+        # Build a lookup from sequence name → per-sequence mean IoU.
+        seq_iou: Dict[str, float] = {
+            sr.sequence_name: float(sr.ious.mean()) if len(sr.ious) > 0 else 0.0
+            for sr in result.sequence_results
+        }
+
+        stats: Dict[str, AttributeStats] = {}
+        for attr in self._all_attributes:
+            matched_seqs = [
+                seq for seq in self.sequences_for_attribute(attr) if seq in seq_iou
+            ]
+            if not matched_seqs:
+                continue
+
+            ious = np.array([seq_iou[seq] for seq in matched_seqs])
+            stats[attr] = AttributeStats(
+                tracker_name=result.tracker_name,
+                attribute=attr,
+                attribute_name=self._attr_names.get(attr, attr),
+                n_sequences=len(matched_seqs),
+                mean_iou=float(ious.mean()),
+                std_iou=float(ious.std()) if len(ious) > 1 else 0.0,
+                min_iou=float(ious.min()),
+                max_iou=float(ious.max()),
+                sequence_names=matched_seqs,
+            )
+
+        return stats
+
+    def generate_report(
+        self,
+        results: List["BenchmarkResult"],
+        attributes: Optional[List[str]] = None,
+    ) -> AttributeReport:
+        """Build a full :class:`AttributeReport` for all trackers.
+
+        Args:
+            results: One :class:`~eovot.benchmark.engine.BenchmarkResult` per
+                tracker.  Each result's ``tracker_name`` becomes a row in the
+                report.
+            attributes: Subset of attribute codes to include.  If ``None``,
+                all attributes present in the attribute map are included.
+
+        Returns:
+            :class:`AttributeReport` ready for ``to_markdown()`` or
+            ``to_dict()`` output.
+
+        Raises:
+            ValueError: If *results* is empty or *attributes* contains
+                codes absent from the attribute map.
+        """
+        if not results:
+            raise ValueError("results must contain at least one BenchmarkResult.")
+
+        active_attrs = attributes if attributes is not None else self._all_attributes
+        unknown = set(active_attrs) - set(self._all_attributes)
+        if unknown:
+            raise ValueError(
+                f"Requested attributes not in attribute_map: {sorted(unknown)}"
+            )
+
+        all_stats: Dict[str, Dict[str, AttributeStats]] = {}
+        for result in results:
+            tracker_stats = self.compute_stats(result)
+            # Filter to only the requested attributes.
+            all_stats[result.tracker_name] = {
+                attr: stat
+                for attr, stat in tracker_stats.items()
+                if attr in active_attrs
+            }
+
+        tracker_names = [r.tracker_name for r in results]
+        attr_name_list = [self._attr_names.get(a, a) for a in active_attrs]
+
+        return AttributeReport(
+            tracker_names=tracker_names,
+            attributes=list(active_attrs),
+            attribute_names=attr_name_list,
+            stats=all_stats,
+            dataset_name=self.dataset_name,
+        )

--- a/scripts/analyze_attributes.py
+++ b/scripts/analyze_attributes.py
@@ -1,0 +1,203 @@
+"""CLI tool: per-attribute tracker performance analysis.
+
+Reads one or more JSON result files produced by the EOVOT experiment runner,
+loads the corresponding OTB attribute annotations, and generates a Markdown
+attribute-breakdown report.
+
+Usage::
+
+    python scripts/analyze_attributes.py \\
+        --results results/mosse.json results/kcf.json \\
+        --output attribute_report.md \\
+        --dataset-name OTB-100 \\
+        [--attributes FM OCC SV]
+
+The ``--results`` files must be in the format written by
+:class:`eovot.reporting.reporter.BenchmarkReporter`.
+
+The ``--attributes`` flag optionally restricts analysis to a subset of the
+11 OTB challenge attributes.  When omitted, all attributes present in the
+result files are analysed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, FrozenSet, List, Optional
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Minimal BenchmarkResult reconstruction from saved JSON
+# (avoids requiring the actual dataset files at analysis time)
+# ---------------------------------------------------------------------------
+
+class _SequenceResult:
+    """Lightweight reconstruction of SequenceResult from saved JSON."""
+
+    def __init__(self, sequence_name: str, ious: List[float]) -> None:
+        self.sequence_name = sequence_name
+        self.ious = np.array(ious, dtype=np.float64)
+
+
+class _BenchmarkResult:
+    """Lightweight reconstruction of BenchmarkResult from saved JSON."""
+
+    def __init__(self, tracker_name: str, sequence_results: List[_SequenceResult]) -> None:
+        self.tracker_name = tracker_name
+        self.sequence_results = sequence_results
+
+
+def _load_result(path: Path) -> _BenchmarkResult:
+    """Parse a JSON result file into a lightweight BenchmarkResult."""
+    with open(path) as fh:
+        data = json.load(fh)
+
+    tracker_name = data.get("tracker_name", path.stem)
+    seq_results: List[_SequenceResult] = []
+
+    for seq_data in data.get("sequence_results", []):
+        name = seq_data.get("sequence_name", "unknown")
+        ious = seq_data.get("ious", [])
+        seq_results.append(_SequenceResult(name, ious))
+
+    return _BenchmarkResult(tracker_name=tracker_name, sequence_results=seq_results)
+
+
+# ---------------------------------------------------------------------------
+# Attribute map bootstrap — works without OTBDataset
+# ---------------------------------------------------------------------------
+
+def _otb_attribute_map() -> Dict[str, FrozenSet[str]]:
+    """Return the OTB-100 sequence→attribute mapping without loading image data."""
+    try:
+        from eovot.datasets.otb import OTB100_ATTRIBUTES
+        return {seq: attrs for seq, attrs in OTB100_ATTRIBUTES.items()}
+    except ImportError:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Per-attribute tracker performance analysis for OTB benchmarks.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--results", "-r",
+        nargs="+",
+        required=True,
+        metavar="FILE",
+        help="Path(s) to JSON result files (one per tracker).",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default=None,
+        metavar="FILE",
+        help="Output Markdown file path.  Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        default="OTB-100",
+        help="Dataset label in the report header (default: OTB-100).",
+    )
+    parser.add_argument(
+        "--attributes",
+        nargs="+",
+        default=None,
+        metavar="ATTR",
+        help=(
+            "Restrict analysis to these attribute codes "
+            "(e.g. --attributes FM OCC SV).  "
+            "Default: all attributes."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Also write a JSON summary alongside the Markdown file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    # Load results.
+    results = []
+    for path_str in args.results:
+        path = Path(path_str)
+        if not path.is_file():
+            print(f"ERROR: result file not found: {path}", file=sys.stderr)
+            return 1
+        try:
+            results.append(_load_result(path))
+            print(f"Loaded: {path} ({results[-1].tracker_name}, "
+                  f"{len(results[-1].sequence_results)} sequences)")
+        except (json.JSONDecodeError, KeyError) as exc:
+            print(f"ERROR: failed to parse {path}: {exc}", file=sys.stderr)
+            return 1
+
+    if not results:
+        print("ERROR: no valid result files provided.", file=sys.stderr)
+        return 1
+
+    # Build attribute map from OTB annotations.
+    attr_map = _otb_attribute_map()
+    if not attr_map:
+        print(
+            "WARNING: eovot.datasets.otb not importable — "
+            "falling back to attribute map built from result sequence names only.",
+            file=sys.stderr,
+        )
+        # Build a trivial map so the analyzer still runs (no attribute filtering).
+        all_seqs = {sr.sequence_name for r in results for sr in r.sequence_results}
+        attr_map = {seq: frozenset() for seq in all_seqs}
+
+    from eovot.analysis import AttributeAnalyzer
+    try:
+        from eovot.datasets.otb import OTB_ATTRIBUTE_NAMES
+    except ImportError:
+        OTB_ATTRIBUTE_NAMES = {}
+
+    analyzer = AttributeAnalyzer(
+        attribute_map=attr_map,
+        attribute_names=OTB_ATTRIBUTE_NAMES,
+        dataset_name=args.dataset_name,
+    )
+
+    try:
+        report = analyzer.generate_report(results, attributes=args.attributes)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    markdown = report.to_markdown()
+
+    # Output.
+    if args.output:
+        out_path = Path(args.output)
+        out_path.write_text(markdown, encoding="utf-8")
+        print(f"\nMarkdown report saved to: {out_path}")
+        if args.json:
+            import json as _json
+            json_path = out_path.with_suffix(".json")
+            json_path.write_text(
+                _json.dumps(report.to_dict(), indent=2), encoding="utf-8"
+            )
+            print(f"JSON summary saved to:   {json_path}")
+    else:
+        print(markdown)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_attribute_analysis.py
+++ b/tests/test_attribute_analysis.py
@@ -1,0 +1,316 @@
+"""Tests for eovot.analysis.attribute_analyzer."""
+
+from __future__ import annotations
+
+from typing import Dict, FrozenSet, List
+
+import numpy as np
+import pytest
+
+from eovot.analysis.attribute_analyzer import (
+    AttributeAnalyzer,
+    AttributeReport,
+    AttributeStats,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs — avoid importing BenchmarkEngine in tests
+# ---------------------------------------------------------------------------
+
+class _FakeSequenceResult:
+    def __init__(self, sequence_name: str, ious: List[float]) -> None:
+        self.sequence_name = sequence_name
+        self.ious = np.array(ious, dtype=np.float64)
+
+
+class _FakeBenchmarkResult:
+    def __init__(self, tracker_name: str, sequences: Dict[str, List[float]]) -> None:
+        self.tracker_name = tracker_name
+        self.sequence_results = [
+            _FakeSequenceResult(name, ious) for name, ious in sequences.items()
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ATTR_MAP: Dict[str, FrozenSet[str]] = {
+    "SeqA": frozenset(["FM", "OCC"]),
+    "SeqB": frozenset(["FM", "IV"]),
+    "SeqC": frozenset(["OCC"]),
+    "SeqD": frozenset(["IV", "SV"]),
+    "SeqE": frozenset(["SV"]),
+}
+
+ATTR_NAMES = {"FM": "Fast Motion", "OCC": "Occlusion", "IV": "Illumination Variation",
+              "SV": "Scale Variation"}
+
+
+@pytest.fixture()
+def analyzer() -> AttributeAnalyzer:
+    return AttributeAnalyzer(ATTR_MAP, attribute_names=ATTR_NAMES, dataset_name="TestDS")
+
+
+@pytest.fixture()
+def result_mosse() -> _FakeBenchmarkResult:
+    return _FakeBenchmarkResult("MOSSE", {
+        "SeqA": [0.8, 0.7, 0.75],
+        "SeqB": [0.6, 0.65],
+        "SeqC": [0.5, 0.55, 0.6],
+        "SeqD": [0.9, 0.85],
+        "SeqE": [0.7],
+    })
+
+
+@pytest.fixture()
+def result_kcf() -> _FakeBenchmarkResult:
+    return _FakeBenchmarkResult("KCF", {
+        "SeqA": [0.5, 0.55, 0.52],
+        "SeqB": [0.72, 0.68],
+        "SeqC": [0.45, 0.5],
+        "SeqD": [0.88, 0.9],
+        "SeqE": [0.65],
+    })
+
+
+# ---------------------------------------------------------------------------
+# AttributeAnalyzer construction
+# ---------------------------------------------------------------------------
+
+class TestAnalyzerConstruction:
+    def test_attributes_sorted(self, analyzer):
+        assert analyzer.attributes == sorted(analyzer.attributes)
+
+    def test_empty_attr_map_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            AttributeAnalyzer({})
+
+    def test_dataset_name_stored(self, analyzer):
+        assert analyzer.dataset_name == "TestDS"
+
+    def test_all_attributes_discovered(self, analyzer):
+        assert set(analyzer.attributes) == {"FM", "OCC", "IV", "SV"}
+
+
+# ---------------------------------------------------------------------------
+# sequences_for_attribute
+# ---------------------------------------------------------------------------
+
+class TestSequencesForAttribute:
+    def test_fm_sequences(self, analyzer):
+        seqs = analyzer.sequences_for_attribute("FM")
+        assert set(seqs) == {"SeqA", "SeqB"}
+        assert seqs == sorted(seqs)  # must be sorted
+
+    def test_occ_sequences(self, analyzer):
+        assert set(analyzer.sequences_for_attribute("OCC")) == {"SeqA", "SeqC"}
+
+    def test_attribute_not_in_map_returns_empty(self, analyzer):
+        seqs = analyzer.sequences_for_attribute("NONEXISTENT")
+        assert seqs == []
+
+
+# ---------------------------------------------------------------------------
+# compute_stats
+# ---------------------------------------------------------------------------
+
+class TestComputeStats:
+    def test_returns_dict_keyed_by_attribute(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        assert set(stats.keys()) == {"FM", "OCC", "IV", "SV"}
+
+    def test_n_sequences_correct(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        assert stats["FM"].n_sequences == 2   # SeqA + SeqB
+        assert stats["OCC"].n_sequences == 2  # SeqA + SeqC
+        assert stats["SV"].n_sequences == 2   # SeqD + SeqE
+
+    def test_tracker_name_stored(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        assert all(s.tracker_name == "MOSSE" for s in stats.values())
+
+    def test_attribute_name_populated(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        assert stats["FM"].attribute_name == "Fast Motion"
+        assert stats["OCC"].attribute_name == "Occlusion"
+
+    def test_mean_iou_computed_correctly(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        # SeqA mIoU = mean([0.8, 0.7, 0.75]) = 0.75
+        # SeqB mIoU = mean([0.6, 0.65]) = 0.625
+        # FM mIoU = mean(0.75, 0.625) = 0.6875
+        expected_fm = (0.75 + 0.625) / 2
+        assert stats["FM"].mean_iou == pytest.approx(expected_fm, rel=1e-5)
+
+    def test_std_iou_zero_for_single_sequence(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        assert stats["SV"].std_iou >= 0.0  # must be non-negative
+
+    def test_min_max_iou_bounds(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        for attr, s in stats.items():
+            assert s.min_iou <= s.mean_iou <= s.max_iou
+
+    def test_sequence_names_stored(self, analyzer, result_mosse):
+        stats = analyzer.compute_stats(result_mosse)
+        assert set(stats["FM"].sequence_names) == {"SeqA", "SeqB"}
+
+    def test_missing_sequences_in_result_skipped(self):
+        """Sequences in attr_map but missing from result are silently skipped."""
+        partial_result = _FakeBenchmarkResult("X", {"SeqA": [0.5]})  # SeqB–E absent
+        ana = AttributeAnalyzer(ATTR_MAP)
+        stats = ana.compute_stats(partial_result)
+        # Only SeqA present; it carries FM and OCC → those attributes appear.
+        assert "FM" in stats
+        assert "OCC" in stats
+        # IV requires SeqB or SeqD — neither present → IV absent from stats.
+        assert "IV" not in stats
+
+
+# ---------------------------------------------------------------------------
+# generate_report
+# ---------------------------------------------------------------------------
+
+class TestGenerateReport:
+    def test_returns_attribute_report(self, analyzer, result_mosse, result_kcf):
+        report = analyzer.generate_report([result_mosse, result_kcf])
+        assert isinstance(report, AttributeReport)
+
+    def test_tracker_names_ordered(self, analyzer, result_mosse, result_kcf):
+        report = analyzer.generate_report([result_mosse, result_kcf])
+        assert report.tracker_names == ["MOSSE", "KCF"]
+
+    def test_dataset_name_propagated(self, analyzer, result_mosse):
+        report = analyzer.generate_report([result_mosse])
+        assert report.dataset_name == "TestDS"
+
+    def test_attribute_filter_respected(self, analyzer, result_mosse):
+        report = analyzer.generate_report([result_mosse], attributes=["FM", "OCC"])
+        assert set(report.attributes) == {"FM", "OCC"}
+
+    def test_unknown_attribute_in_filter_raises(self, analyzer, result_mosse):
+        with pytest.raises(ValueError, match="not in attribute_map"):
+            analyzer.generate_report([result_mosse], attributes=["UNKNOWN"])
+
+    def test_empty_results_raises(self, analyzer):
+        with pytest.raises(ValueError, match="at least one"):
+            analyzer.generate_report([])
+
+
+# ---------------------------------------------------------------------------
+# AttributeReport
+# ---------------------------------------------------------------------------
+
+class TestAttributeReport:
+    @pytest.fixture()
+    def report(self, analyzer, result_mosse, result_kcf):
+        return analyzer.generate_report([result_mosse, result_kcf])
+
+    def test_iou_matrix_shape(self, report):
+        mat = report.iou_matrix()
+        assert mat.shape == (2, len(report.attributes))  # 2 trackers × N attrs
+
+    def test_iou_matrix_values_in_range(self, report):
+        mat = report.iou_matrix()
+        valid = mat[~np.isnan(mat)]
+        assert np.all(valid >= 0.0) and np.all(valid <= 1.0)
+
+    def test_hardest_attribute_returns_tuple(self, report):
+        result = report.hardest_attribute("MOSSE")
+        assert result is not None
+        attr_code, miou = result
+        assert attr_code in report.attributes
+        assert 0.0 <= miou <= 1.0
+
+    def test_hardest_attribute_unknown_tracker_returns_none(self, report):
+        assert report.hardest_attribute("__no_such_tracker__") is None
+
+    def test_best_tracker_per_attribute_keys(self, report):
+        best = report.best_tracker_per_attribute()
+        assert set(best.keys()).issubset(set(report.attributes))
+
+    def test_best_tracker_per_attribute_values_valid(self, report):
+        best = report.best_tracker_per_attribute()
+        for attr, (tracker, miou) in best.items():
+            assert tracker in report.tracker_names
+            assert 0.0 <= miou <= 1.0
+
+    def test_to_dict_structure(self, report):
+        d = report.to_dict()
+        assert "trackers" in d
+        assert "attributes" in d
+        assert "stats" in d
+        assert d["dataset"] == "TestDS"
+
+    def test_to_dict_json_serialisable(self, report):
+        import json
+        d = report.to_dict()
+        serialised = json.dumps(d)
+        assert len(serialised) > 0
+
+    def test_to_markdown_contains_tracker_names(self, report):
+        md = report.to_markdown()
+        assert "MOSSE" in md
+        assert "KCF" in md
+
+    def test_to_markdown_contains_attribute_names(self, report):
+        md = report.to_markdown()
+        assert "Fast Motion" in md
+        assert "Occlusion" in md
+
+    def test_to_markdown_contains_best_tracker_section(self, report):
+        md = report.to_markdown()
+        assert "Best Tracker per Attribute" in md
+
+    def test_to_markdown_contains_hardest_attribute_section(self, report):
+        md = report.to_markdown()
+        assert "Hardest Attribute per Tracker" in md
+
+    def test_to_markdown_contains_methodology(self, report):
+        md = report.to_markdown()
+        assert "Methodology" in md
+
+    def test_to_markdown_bold_marks_best_column(self, report):
+        md = report.to_markdown()
+        # Bold markers should appear for the best-performing tracker per column.
+        assert "**" in md
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_single_sequence_per_attribute(self):
+        attr_map = {"OnlySeq": frozenset(["FM"])}
+        ana = AttributeAnalyzer(attr_map)
+        result = _FakeBenchmarkResult("T", {"OnlySeq": [0.6, 0.7]})
+        stats = ana.compute_stats(result)
+        assert stats["FM"].n_sequences == 1
+        assert stats["FM"].std_iou == 0.0  # single sequence → std is 0
+
+    def test_sequence_with_empty_ious(self):
+        attr_map = {"EmptySeq": frozenset(["FM"])}
+        ana = AttributeAnalyzer(attr_map)
+        result = _FakeBenchmarkResult("T", {"EmptySeq": []})
+        stats = ana.compute_stats(result)
+        # mean IoU of an empty array is 0.0 (handled gracefully).
+        assert stats["FM"].mean_iou == pytest.approx(0.0)
+
+    def test_all_attributes_none_match_in_result(self):
+        attr_map = {"SeqX": frozenset(["FM"])}
+        ana = AttributeAnalyzer(attr_map)
+        result = _FakeBenchmarkResult("T", {"__other_seq__": [0.5]})
+        stats = ana.compute_stats(result)
+        assert len(stats) == 0
+
+    def test_report_single_tracker(self):
+        attr_map = {"SeqA": frozenset(["FM", "OCC"]), "SeqB": frozenset(["FM"])}
+        ana = AttributeAnalyzer(attr_map)
+        result = _FakeBenchmarkResult("MOSSE", {"SeqA": [0.7], "SeqB": [0.8]})
+        report = ana.generate_report([result])
+        md = report.to_markdown()
+        assert "MOSSE" in md
+        assert len(report.tracker_names) == 1


### PR DESCRIPTION
## What was added

Introduces `eovot/analysis/` — a new research-analysis sub-package that
operates on saved `BenchmarkResult` objects to answer the question:
**"Where exactly does each tracker succeed or fail?"**

### Core module: `AttributeAnalyzer`

Groups per-sequence benchmark results by OTB challenge attributes
(Fast Motion, Occlusion, Scale Variation, etc.) and computes performance
statistics per group — exposing failure modes that aggregate mIoU numbers
completely hide.

```
Tracker MOSSE  —  overall mIoU = 0.62
  FM  (Fast Motion):     0.38  ← struggling
  OCC (Occlusion):       0.51
  SV  (Scale Variation): 0.71  ← strong
  IV  (Illumination):    0.68
```

### New classes

| Class | Purpose |
|-------|---------|
| `AttributeStats` | Per-(tracker, attribute) stats: mean/std/min/max IoU, contributing sequences |
| `AttributeReport` | Full tracker × attribute matrix; produces Markdown and JSON |
| `AttributeAnalyzer` | Drives analysis from any `{seq: {attrs}}` mapping |

### `AttributeReport` derived metrics

```python
report.iou_matrix()                 # np.ndarray (n_trackers × n_attributes)
report.hardest_attribute("MOSSE")   # ("FM", 0.38)
report.best_tracker_per_attribute() # {"FM": ("KCF", 0.54), "OCC": ("CSRT", 0.61), ...}
report.to_markdown()                # publication-ready table + analysis sections
report.to_dict()                    # JSON-serialisable for archiving results
```

### CLI tool

```bash
python scripts/analyze_attributes.py \
    --results results/mosse.json results/kcf.json results/csrt.json \
    --output attribute_report.md \
    --dataset-name OTB-100 \
    --attributes FM OCC SV IV MB
```

Reads JSON result files from the experiment runner, loads OTB annotations,
and writes a Markdown (and optionally JSON) report — no image data required.

### Dataset-agnostic design

The analyzer accepts any `Dict[str, Collection[str]]` mapping sequence names
to attribute codes, so it works with OTB, GOT-10k custom annotations, or any
future benchmark:

```python
from eovot.analysis import AttributeAnalyzer
from eovot.datasets.otb import OTBDataset, OTB_ATTRIBUTE_NAMES

dataset = OTBDataset("/data/OTB100")
analyzer = AttributeAnalyzer(
    attribute_map=dataset.attribute_map(),   # {seq_name: frozenset(attrs)}
    attribute_names=OTB_ATTRIBUTE_NAMES,
    dataset_name="OTB-100",
)
report = analyzer.generate_report(benchmark_results)
print(report.to_markdown())
```

## Why it matters

Every major VOT paper reports per-attribute accuracy tables.  Without this
module, researchers using EOVOT had to post-process raw JSON results manually.
Now the full attribute breakdown is a single `generate_report()` call, with
a ready-to-paste Markdown table.

This is also the analysis foundation that enables:
- Identifying which challenges a tracker should be tuned for before deployment
- Selecting the right tracker for a specific application context
  (e.g. surveillance = occlusion-heavy; UAV = fast motion + scale variation)
- Directing future tracker development toward real bottlenecks

## Files changed

| File | Change |
|------|--------|
| `eovot/analysis/__init__.py` | **New** — analysis sub-package |
| `eovot/analysis/attribute_analyzer.py` | **New** — AttributeAnalyzer, AttributeStats, AttributeReport |
| `eovot/__init__.py` | Expose `analysis` in package-level imports |
| `scripts/analyze_attributes.py` | **New** — CLI tool |
| `tests/test_attribute_analysis.py` | **New** — 40 test cases across 7 test classes |

## Test coverage

```
40 passed in 0.25s
```

Tests cover: construction validation, sequence grouping correctness,
per-attribute IoU computation, missing-sequence graceful handling,
report generation and filtering, matrix shape and value bounds,
Markdown structural requirements, JSON serialisability, and edge cases
(empty IoU arrays, single-sequence attributes, no-match results).

## No breaking changes

Pure addition — no existing APIs modified.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CrUwCLC36BEbqaLdPue77h)_