### PR TITLE
[feat] Add configurable multi-criteria tracker ranking engine

### DIFF
--- a/eovot/metrics/__init__.py
+++ b/eovot/metrics/__init__.py
@@ -15,6 +15,7 @@ from .statistical import (
     PairwiseSummary,
     StatisticalTestEngine,
 )
+from .ranking import RankingWeights, TrackerRank, RankingEngine
 
 __all__ = [
     "iou",
@@ -31,4 +32,7 @@ __all__ = [
     "WilcoxonResult",
     "PairwiseSummary",
     "StatisticalTestEngine",
+    "RankingWeights",
+    "TrackerRank",
+    "RankingEngine",
 ]

--- a/eovot/metrics/ranking.py
+++ b/eovot/metrics/ranking.py
@@ -1,0 +1,377 @@
+"""Configurable multi-criteria tracker ranking for EOVOT.
+
+Extends the fixed Edge Efficiency Score with a weighted composite ranking
+that simultaneously incorporates accuracy, throughput, memory, energy, and
+robustness metrics.  Preset weight configurations model common deployment
+scenarios so researchers can reproduce apples-to-apples comparisons.
+
+Composite Score
+~~~~~~~~~~~~~~~
+Each metric is independently min-max normalised across the tracker set so
+that all dimensions live in ``[0, 1]``.  The composite score is the
+weighted sum of normalised values::
+
+    score = w_accuracy    * norm(success_auc)
+          + w_fps         * norm(fps)
+          + w_memory      * (1 - norm(peak_memory_mb))   # lower is better
+          + w_energy      * (1 - norm(energy_mj_frame))  # lower is better
+          + w_robustness  * norm(mean_iou)
+
+Weights must be non-negative but need not sum to 1 — they are re-normalised
+internally, so only the *relative* magnitudes matter.
+
+Preset configurations
+~~~~~~~~~~~~~~~~~~~~~
+Four named presets are provided as class methods on :class:`RankingWeights`
+so researchers can report results under standardised scenarios:
+
+- ``accuracy_first()`` — maximise tracking quality, ignore efficiency
+- ``edge_balanced()``  — equal weight to accuracy, speed, and memory
+- ``battery_saver()``  — heavy penalty on energy and memory
+- ``throughput_max()`` — optimise for raw FPS on constrained devices
+
+Example::
+
+    from eovot.metrics.ranking import RankingEngine, RankingWeights
+
+    weights = RankingWeights.edge_balanced()
+    engine  = RankingEngine(weights)
+    ranking = engine.rank(benchmark_results)
+
+    print(engine.to_markdown_table(ranking))
+    # Or as JSON-serialisable dicts:
+    print(engine.to_summary_dict(ranking))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..benchmark.engine import BenchmarkResult
+
+
+# ---------------------------------------------------------------------------
+# Weight configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RankingWeights:
+    """Relative importance weights for the five ranking dimensions.
+
+    All weights must be non-negative.  They are normalised internally so only
+    their relative magnitudes matter — ``(0.5, 0.5)`` is identical to
+    ``(1.0, 1.0)`` for a two-metric run.
+
+    Attributes:
+        accuracy:   Weight for tracking accuracy (success AUC, falling back to
+                    mean IoU when AUC is unavailable).
+        fps:        Weight for throughput (frames per second). Higher is better.
+        memory:     Weight for memory efficiency. Lower peak memory is better.
+        energy:     Weight for energy efficiency. Lower mJ/frame is better.
+        robustness: Weight for mean IoU as a robustness proxy when both
+                    success AUC *and* mean IoU are available together, this
+                    captures a slightly different quality dimension.
+        label:      Human-readable name for the weight configuration, used
+                    in reports and table headings.
+    """
+
+    accuracy: float = 1.0
+    fps: float = 1.0
+    memory: float = 1.0
+    energy: float = 0.0
+    robustness: float = 0.0
+    label: str = "custom"
+
+    def __post_init__(self) -> None:
+        for name, val in self._weight_values().items():
+            if val < 0:
+                raise ValueError(f"Weight '{name}' must be non-negative, got {val}.")
+
+    def _weight_values(self) -> dict:
+        return {
+            "accuracy": self.accuracy,
+            "fps": self.fps,
+            "memory": self.memory,
+            "energy": self.energy,
+            "robustness": self.robustness,
+        }
+
+    def total(self) -> float:
+        return sum(self._weight_values().values())
+
+    # ------------------------------------------------------------------
+    # Named presets
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def accuracy_first(cls) -> "RankingWeights":
+        """Maximise tracking quality; treat efficiency as secondary."""
+        return cls(accuracy=5.0, fps=0.5, memory=0.5, energy=0.0, robustness=2.0,
+                   label="accuracy_first")
+
+    @classmethod
+    def edge_balanced(cls) -> "RankingWeights":
+        """Equal weight to accuracy, speed, and memory — typical edge scenario."""
+        return cls(accuracy=1.0, fps=1.0, memory=1.0, energy=0.5, robustness=0.5,
+                   label="edge_balanced")
+
+    @classmethod
+    def battery_saver(cls) -> "RankingWeights":
+        """Penalise energy and memory; optimise for battery-constrained IoT."""
+        return cls(accuracy=1.0, fps=0.5, memory=2.0, energy=3.0, robustness=0.0,
+                   label="battery_saver")
+
+    @classmethod
+    def throughput_max(cls) -> "RankingWeights":
+        """Optimise raw FPS for hard real-time edge applications."""
+        return cls(accuracy=0.5, fps=4.0, memory=1.0, energy=0.5, robustness=0.0,
+                   label="throughput_max")
+
+
+# ---------------------------------------------------------------------------
+# Per-tracker ranking result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrackerRank:
+    """Ranking result for one tracker.
+
+    Attributes:
+        rank:              1-based position in the ranked list (1 = best).
+        tracker_name:      Tracker identifier.
+        dataset_name:      Dataset on which the tracker was evaluated.
+        composite_score:   Weighted composite score in ``[0, 1]``.
+        norm_accuracy:     Normalised accuracy score.
+        norm_fps:          Normalised FPS score (higher is better).
+        norm_memory:       Normalised memory score (higher = less memory used).
+        norm_energy:       Normalised energy score (higher = less energy used).
+        norm_robustness:   Normalised robustness score.
+        raw_accuracy:      Raw success AUC (or mean IoU if AUC unavailable).
+        raw_fps:           Raw mean FPS.
+        raw_memory_mb:     Raw peak memory in MB.
+        raw_energy_mj:     Raw energy per frame in mJ, or ``None``.
+        raw_mean_iou:      Raw mean IoU.
+        weights_label:     Label of the :class:`RankingWeights` preset used.
+    """
+
+    rank: int
+    tracker_name: str
+    dataset_name: str
+    composite_score: float
+    norm_accuracy: float
+    norm_fps: float
+    norm_memory: float
+    norm_energy: float
+    norm_robustness: float
+    raw_accuracy: float
+    raw_fps: float
+    raw_memory_mb: float
+    raw_energy_mj: Optional[float]
+    raw_mean_iou: float
+    weights_label: str = "custom"
+
+    def __str__(self) -> str:
+        return (
+            f"[#{self.rank}] {self.tracker_name:<18s}  "
+            f"score={self.composite_score:.4f}  "
+            f"acc={self.raw_accuracy:.4f}  "
+            f"fps={self.raw_fps:.1f}  "
+            f"mem={self.raw_memory_mb:.1f} MB"
+        )
+
+    def to_dict(self) -> dict:
+        d = {
+            "rank": self.rank,
+            "tracker": self.tracker_name,
+            "dataset": self.dataset_name,
+            "composite_score": round(self.composite_score, 6),
+            "norm_accuracy": round(self.norm_accuracy, 4),
+            "norm_fps": round(self.norm_fps, 4),
+            "norm_memory": round(self.norm_memory, 4),
+            "norm_energy": round(self.norm_energy, 4),
+            "norm_robustness": round(self.norm_robustness, 4),
+            "raw_accuracy": round(self.raw_accuracy, 4),
+            "raw_fps": round(self.raw_fps, 2),
+            "raw_memory_mb": round(self.raw_memory_mb, 2),
+            "raw_mean_iou": round(self.raw_mean_iou, 4),
+            "weights_label": self.weights_label,
+        }
+        if self.raw_energy_mj is not None:
+            d["raw_energy_mj"] = round(self.raw_energy_mj, 4)
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Ranking engine
+# ---------------------------------------------------------------------------
+
+class RankingEngine:
+    """Rank trackers across multiple evaluation dimensions with configurable weights.
+
+    Args:
+        weights: :class:`RankingWeights` controlling the importance of each
+                 dimension. Defaults to the ``edge_balanced`` preset.
+
+    Example::
+
+        from eovot.metrics.ranking import RankingEngine, RankingWeights
+
+        engine = RankingEngine(RankingWeights.battery_saver())
+        ranking = engine.rank(benchmark_results)
+        print(engine.to_markdown_table(ranking))
+    """
+
+    def __init__(self, weights: Optional[RankingWeights] = None) -> None:
+        self.weights = weights if weights is not None else RankingWeights.edge_balanced()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def rank(self, results: List["BenchmarkResult"]) -> List[TrackerRank]:
+        """Rank a collection of :class:`~eovot.benchmark.engine.BenchmarkResult` objects.
+
+        Args:
+            results: One result per tracker / dataset combination.  At minimum
+                each result must contain at least one :class:`~eovot.benchmark.engine.SequenceResult`.
+
+        Returns:
+            List of :class:`TrackerRank`, sorted by composite score (highest first),
+            with ``rank`` fields assigned starting from 1.
+
+        Raises:
+            ValueError: If *results* is empty.
+        """
+        if not results:
+            raise ValueError("Cannot rank an empty list of BenchmarkResults.")
+
+        raw = self._extract_raw(results)
+        norms = self._normalise(raw)
+        scores = self._score(norms)
+
+        ranked: List[TrackerRank] = []
+        for i, result in enumerate(results):
+            ranked.append(TrackerRank(
+                rank=0,  # assigned below
+                tracker_name=result.tracker_name,
+                dataset_name=result.dataset_name,
+                composite_score=scores[i],
+                norm_accuracy=norms["accuracy"][i],
+                norm_fps=norms["fps"][i],
+                norm_memory=norms["memory"][i],
+                norm_energy=norms["energy"][i],
+                norm_robustness=norms["robustness"][i],
+                raw_accuracy=raw["accuracy"][i],
+                raw_fps=raw["fps"][i],
+                raw_memory_mb=raw["memory"][i],
+                raw_energy_mj=raw["energy"][i] if raw["energy"][i] >= 0 else None,
+                raw_mean_iou=raw["iou"][i],
+                weights_label=self.weights.label,
+            ))
+
+        ranked.sort(key=lambda r: r.composite_score, reverse=True)
+        for pos, entry in enumerate(ranked, start=1):
+            entry.rank = pos
+        return ranked
+
+    def to_markdown_table(self, ranking: List[TrackerRank]) -> str:
+        """Format the ranking as a Markdown table.
+
+        Args:
+            ranking: Output of :meth:`rank`.
+
+        Returns:
+            Multi-line Markdown string ready for README or paper appendix.
+        """
+        label = ranking[0].weights_label if ranking else "custom"
+        header = (
+            f"**Tracker Ranking — weights: `{label}`**\n\n"
+            "| Rank | Tracker | Dataset | Score | Acc | FPS | Mem (MB) | Energy (mJ) |\n"
+            "|------|---------|---------|------:|----:|----:|---------:|------------:|"
+        )
+        rows = []
+        for r in ranking:
+            energy_str = f"{r.raw_energy_mj:.3f}" if r.raw_energy_mj is not None else "—"
+            rows.append(
+                f"| {r.rank} | {r.tracker_name} | {r.dataset_name} "
+                f"| {r.composite_score:.4f} "
+                f"| {r.raw_accuracy:.4f} "
+                f"| {r.raw_fps:.1f} "
+                f"| {r.raw_memory_mb:.1f} "
+                f"| {energy_str} |"
+            )
+        return header + "\n" + "\n".join(rows)
+
+    def to_summary_dict(self, ranking: List[TrackerRank]) -> List[dict]:
+        """Return ranking as a list of plain dicts suitable for JSON serialisation."""
+        return [r.to_dict() for r in ranking]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _extract_raw(self, results: List["BenchmarkResult"]) -> dict:
+        """Pull raw metric values from each BenchmarkResult."""
+        accuracy, fps, memory, energy, iou = [], [], [], [], []
+        for r in results:
+            # Prefer success AUC as the primary accuracy signal.
+            acc = r.mean_success_auc if r.mean_success_auc is not None else r.mean_iou
+            accuracy.append(acc)
+            fps.append(r.mean_fps)
+            memory.append(r.peak_memory_mb)
+            iou.append(r.mean_iou)
+            epf = r.mean_energy_per_frame_mj
+            energy.append(epf if epf is not None else -1.0)  # sentinel for missing
+        return {"accuracy": accuracy, "fps": fps, "memory": memory,
+                "energy": energy, "iou": iou}
+
+    @staticmethod
+    def _minmax(values: list, invert: bool = False) -> list:
+        """Min-max normalise a list to [0, 1]; optionally invert (lower=better)."""
+        arr = np.array(values, dtype=float)
+        # Replace sentinels (-1) with NaN so they don't distort the range.
+        arr_clean = np.where(arr < 0, np.nan, arr)
+        valid = arr_clean[~np.isnan(arr_clean)]
+        if valid.size == 0:
+            # All values are sentinels (missing); assign neutral score.
+            return [0.5] * len(values)
+        lo, hi = float(valid.min()), float(valid.max())
+        if hi == lo:
+            normed = np.where(np.isnan(arr_clean), 0.5, 0.5)
+        else:
+            normed = (arr_clean - lo) / (hi - lo)
+            normed = np.where(np.isnan(normed), 0.5, normed)
+        if invert:
+            normed = 1.0 - normed
+        return normed.tolist()
+
+    def _normalise(self, raw: dict) -> dict:
+        return {
+            "accuracy":   self._minmax(raw["accuracy"]),
+            "fps":        self._minmax(raw["fps"]),
+            "memory":     self._minmax(raw["memory"], invert=True),   # less = better
+            "energy":     self._minmax(raw["energy"], invert=True),   # less = better
+            "robustness": self._minmax(raw["iou"]),
+        }
+
+    def _score(self, norms: dict) -> list:
+        w = self.weights
+        total_w = w.total()
+        if total_w == 0:
+            raise ValueError("All weights are zero — cannot compute a composite score.")
+        scores = []
+        n = len(norms["accuracy"])
+        for i in range(n):
+            s = (
+                w.accuracy   * norms["accuracy"][i]
+                + w.fps      * norms["fps"][i]
+                + w.memory   * norms["memory"][i]
+                + w.energy   * norms["energy"][i]
+                + w.robustness * norms["robustness"][i]
+            ) / total_w
+            scores.append(s)
+        return scores

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,255 @@
+"""Tests for eovot.metrics.ranking — weighted multi-criteria tracker ranking."""
+
+from __future__ import annotations
+
+import math
+from typing import List
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from eovot.metrics.ranking import RankingEngine, RankingWeights, TrackerRank
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build minimal BenchmarkResult mocks
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    tracker: str,
+    dataset: str = "synthetic",
+    mean_iou: float = 0.5,
+    mean_fps: float = 100.0,
+    peak_memory_mb: float = 200.0,
+    success_auc: float | None = None,
+    energy_mj: float | None = None,
+) -> MagicMock:
+    r = MagicMock()
+    r.tracker_name = tracker
+    r.dataset_name = dataset
+    r.mean_iou = mean_iou
+    r.mean_fps = mean_fps
+    r.peak_memory_mb = peak_memory_mb
+    r.mean_success_auc = success_auc
+    r.mean_energy_per_frame_mj = energy_mj
+    return r
+
+
+# ---------------------------------------------------------------------------
+# RankingWeights
+# ---------------------------------------------------------------------------
+
+class TestRankingWeights:
+    def test_default_weights_non_negative(self) -> None:
+        w = RankingWeights()
+        assert w.accuracy >= 0
+        assert w.fps >= 0
+        assert w.memory >= 0
+        assert w.energy >= 0
+        assert w.robustness >= 0
+
+    def test_negative_weight_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            RankingWeights(accuracy=-1.0)
+
+    def test_total_is_sum(self) -> None:
+        w = RankingWeights(accuracy=2.0, fps=3.0, memory=1.0, energy=0.0, robustness=0.0)
+        assert w.total() == pytest.approx(6.0)
+
+    def test_preset_edge_balanced(self) -> None:
+        w = RankingWeights.edge_balanced()
+        assert w.label == "edge_balanced"
+        assert w.accuracy > 0 and w.fps > 0 and w.memory > 0
+
+    def test_preset_accuracy_first(self) -> None:
+        w = RankingWeights.accuracy_first()
+        assert w.accuracy > w.fps
+
+    def test_preset_battery_saver(self) -> None:
+        w = RankingWeights.battery_saver()
+        assert w.energy > w.fps
+
+    def test_preset_throughput_max(self) -> None:
+        w = RankingWeights.throughput_max()
+        assert w.fps > w.accuracy
+
+
+# ---------------------------------------------------------------------------
+# RankingEngine — basic contract
+# ---------------------------------------------------------------------------
+
+class TestRankingEngineBasic:
+    def test_empty_results_raises(self) -> None:
+        engine = RankingEngine()
+        with pytest.raises(ValueError, match="empty"):
+            engine.rank([])
+
+    def test_single_tracker_scores_half(self) -> None:
+        """With one tracker, all min-max normalised values are 0.5 (tie)."""
+        engine = RankingEngine()
+        r = _make_result("MOSSE", mean_iou=0.6, mean_fps=300.0, peak_memory_mb=50.0)
+        ranking = engine.rank([r])
+        assert len(ranking) == 1
+        assert ranking[0].rank == 1
+        assert ranking[0].composite_score == pytest.approx(0.5, abs=1e-9)
+
+    def test_rank_ordering(self) -> None:
+        """Higher composite score → lower (better) rank number."""
+        engine = RankingEngine(RankingWeights(accuracy=1.0, fps=0.0, memory=0.0))
+        fast = _make_result("Fast", mean_iou=0.8, mean_fps=100.0, peak_memory_mb=100.0, success_auc=0.8)
+        slow = _make_result("Slow", mean_iou=0.3, mean_fps=100.0, peak_memory_mb=100.0, success_auc=0.3)
+        ranking = engine.rank([fast, slow])
+        assert ranking[0].tracker_name == "Fast"
+        assert ranking[0].rank == 1
+        assert ranking[1].rank == 2
+
+    def test_rank_fields_populated(self) -> None:
+        results = [
+            _make_result("A", mean_iou=0.6, mean_fps=200.0, peak_memory_mb=100.0),
+            _make_result("B", mean_iou=0.4, mean_fps=400.0, peak_memory_mb=80.0),
+        ]
+        engine = RankingEngine(RankingWeights.edge_balanced())
+        ranking = engine.rank(results)
+        for r in ranking:
+            assert r.tracker_name in ("A", "B")
+            assert 0.0 <= r.composite_score <= 1.0
+            assert r.raw_fps > 0
+            assert r.raw_memory_mb > 0
+
+    def test_success_auc_preferred_over_iou(self) -> None:
+        """When success_auc is available it should be used as raw_accuracy."""
+        engine = RankingEngine(RankingWeights(accuracy=1.0, fps=0.0, memory=0.0))
+        r = _make_result("T", mean_iou=0.5, success_auc=0.9)
+        ranking = engine.rank([r])
+        assert ranking[0].raw_accuracy == pytest.approx(0.9)
+
+    def test_iou_fallback_when_no_auc(self) -> None:
+        engine = RankingEngine(RankingWeights(accuracy=1.0, fps=0.0, memory=0.0))
+        r = _make_result("T", mean_iou=0.55, success_auc=None)
+        ranking = engine.rank([r])
+        assert ranking[0].raw_accuracy == pytest.approx(0.55)
+
+    def test_energy_none_handled(self) -> None:
+        """Missing energy should not raise and norm_energy should default to 0.5."""
+        engine = RankingEngine()
+        r = _make_result("T", energy_mj=None)
+        ranking = engine.rank([r])
+        assert ranking[0].raw_energy_mj is None
+        assert ranking[0].norm_energy == pytest.approx(0.5, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# RankingEngine — normalisation properties
+# ---------------------------------------------------------------------------
+
+class TestNormalisation:
+    def test_best_tracker_norm_values_near_one(self) -> None:
+        """The tracker with best accuracy/fps should have norm ≈ 1.0 on those dims."""
+        engine = RankingEngine()
+        best = _make_result("Best", mean_iou=0.9, mean_fps=500.0, peak_memory_mb=50.0)
+        worst = _make_result("Worst", mean_iou=0.2, mean_fps=10.0, peak_memory_mb=900.0)
+        ranking = engine.rank([best, worst])
+        best_entry = next(r for r in ranking if r.tracker_name == "Best")
+        assert best_entry.norm_accuracy == pytest.approx(1.0, abs=1e-9)
+        assert best_entry.norm_fps == pytest.approx(1.0, abs=1e-9)
+        assert best_entry.norm_memory == pytest.approx(1.0, abs=1e-9)
+
+    def test_identical_trackers_get_same_score(self) -> None:
+        """Two identical trackers should receive the same composite score."""
+        engine = RankingEngine()
+        r1 = _make_result("A", mean_iou=0.5, mean_fps=100.0, peak_memory_mb=200.0)
+        r2 = _make_result("B", mean_iou=0.5, mean_fps=100.0, peak_memory_mb=200.0)
+        ranking = engine.rank([r1, r2])
+        assert ranking[0].composite_score == pytest.approx(ranking[1].composite_score, abs=1e-9)
+
+    def test_all_zero_weights_raises(self) -> None:
+        engine = RankingEngine(RankingWeights(accuracy=0.0, fps=0.0, memory=0.0,
+                                              energy=0.0, robustness=0.0))
+        r = _make_result("T")
+        with pytest.raises(ValueError, match="zero"):
+            engine.rank([r])
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+class TestOutputFormatting:
+    def _two_tracker_ranking(self) -> List[TrackerRank]:
+        engine = RankingEngine(RankingWeights.edge_balanced())
+        results = [
+            _make_result("MOSSE", mean_iou=0.6, mean_fps=300.0, peak_memory_mb=80.0),
+            _make_result("KCF",   mean_iou=0.65, mean_fps=150.0, peak_memory_mb=90.0),
+        ]
+        return engine.rank(results)
+
+    def test_markdown_table_has_header(self) -> None:
+        engine = RankingEngine(RankingWeights.edge_balanced())
+        ranking = self._two_tracker_ranking()
+        table = engine.to_markdown_table(ranking)
+        assert "Rank" in table
+        assert "Tracker" in table
+        assert "Score" in table
+
+    def test_markdown_table_has_both_trackers(self) -> None:
+        ranking = self._two_tracker_ranking()
+        table = RankingEngine().to_markdown_table(ranking)
+        assert "MOSSE" in table or "KCF" in table  # at least one appears
+
+    def test_summary_dict_length(self) -> None:
+        engine = RankingEngine()
+        ranking = self._two_tracker_ranking()
+        summary = engine.to_summary_dict(ranking)
+        assert len(summary) == 2
+
+    def test_summary_dict_keys(self) -> None:
+        engine = RankingEngine()
+        ranking = self._two_tracker_ranking()
+        d = engine.to_summary_dict(ranking)[0]
+        for key in ("rank", "tracker", "dataset", "composite_score",
+                    "raw_accuracy", "raw_fps", "raw_memory_mb"):
+            assert key in d
+
+    def test_tracker_rank_str(self) -> None:
+        engine = RankingEngine()
+        ranking = self._two_tracker_ranking()
+        s = str(ranking[0])
+        assert "#1" in s
+
+
+# ---------------------------------------------------------------------------
+# Preset differentiation
+# ---------------------------------------------------------------------------
+
+class TestPresetDifferentiation:
+    """Verify that different presets produce different orderings when expected."""
+
+    def test_accuracy_first_vs_throughput_max(self) -> None:
+        """
+        Tracker A: high accuracy, low FPS.
+        Tracker B: low accuracy, high FPS.
+        accuracy_first should prefer A; throughput_max should prefer B.
+        """
+        accurate = _make_result("Accurate", mean_iou=0.85, mean_fps=20.0,
+                                peak_memory_mb=150.0, success_auc=0.85)
+        fast = _make_result("Fast", mean_iou=0.30, mean_fps=500.0,
+                            peak_memory_mb=60.0, success_auc=0.30)
+
+        acc_engine = RankingEngine(RankingWeights.accuracy_first())
+        acc_ranking = acc_engine.rank([accurate, fast])
+        assert acc_ranking[0].tracker_name == "Accurate"
+
+        fps_engine = RankingEngine(RankingWeights.throughput_max())
+        fps_ranking = fps_engine.rank([accurate, fast])
+        assert fps_ranking[0].tracker_name == "Fast"
+
+    def test_battery_saver_penalises_high_energy(self) -> None:
+        """Tracker with lower energy should rank first under battery_saver."""
+        efficient = _make_result("Efficient", mean_iou=0.5, mean_fps=100.0,
+                                 peak_memory_mb=100.0, energy_mj=0.5)
+        hungry = _make_result("Hungry", mean_iou=0.5, mean_fps=100.0,
+                              peak_memory_mb=100.0, energy_mj=10.0)
+        engine = RankingEngine(RankingWeights.battery_saver())
+        ranking = engine.rank([efficient, hungry])
+        assert ranking[0].tracker_name == "Efficient"


### PR DESCRIPTION
## What was added

A new `RankingEngine` in `eovot/metrics/ranking.py` that scores and ranks trackers across **five evaluation dimensions simultaneously** using configurable weights:

| Dimension | Direction | Source |
|-----------|-----------|--------|
| Accuracy | higher is better | `success_auc` (falls back to `mean_iou`) |
| FPS | higher is better | `mean_fps` |
| Memory | lower is better | `peak_memory_mb` |
| Energy | lower is better | `mean_energy_per_frame_mj` |
| Robustness | higher is better | `mean_iou` |

Each dimension is **min-max normalised** across the tracker set before weighted aggregation, so all five axes are on equal footing regardless of their raw units.

## Why it matters

The existing `EfficiencyMetricsEngine` uses a fixed EES formula (`IoU × log(FPS) / memory_penalty`). That formula is useful but encodes a single implicit trade-off. Researchers and practitioners need to ask different questions:

- *"Which tracker has the best raw accuracy, regardless of speed?"* → `accuracy_first` preset
- *"Which tracker fits a Raspberry Pi 4 with limited battery?"* → `battery_saver` preset
- *"Which tracker meets a hard 60 FPS constraint?"* → `throughput_max` preset

`RankingEngine` makes these trade-offs explicit, reproducible, and configurable.

## Four named presets

```python
RankingWeights.accuracy_first()   # maximise quality, treat efficiency as secondary
RankingWeights.edge_balanced()    # equal weight to accuracy, speed, memory
RankingWeights.battery_saver()    # heavy penalty on energy + memory (IoT)
RankingWeights.throughput_max()   # optimise raw FPS for hard real-time edge
```

## Example usage

```python
from eovot.metrics.ranking import RankingEngine, RankingWeights
from eovot.benchmark.engine import BenchmarkEngine

# Run benchmarks as usual
engine = BenchmarkEngine(tdp_watts=10.0)
results = [engine.run(t, dataset) for t in trackers]

# Rank under three scenarios side by side
for weights in [RankingWeights.accuracy_first(),
                RankingWeights.edge_balanced(),
                RankingWeights.battery_saver()]:
    ranker = RankingEngine(weights)
    ranking = ranker.rank(results)
    print(ranker.to_markdown_table(ranking))

# Export to JSON for downstream analysis
import json
print(json.dumps(ranker.to_summary_dict(ranking), indent=2))
```

## Files changed

| File | Change |
|------|--------|
| `eovot/metrics/ranking.py` | New module: `RankingWeights`, `TrackerRank`, `RankingEngine` |
| `eovot/metrics/__init__.py` | Export three new symbols |
| `tests/test_ranking.py` | 24 tests covering normalisation, presets, edge cases, formatting |

## Test coverage

```
24 passed in 0.17s
```

- Weight validation (negative weights raise, zero-total raises)
- Single-tracker normalisation (`score == 0.5` for tie)
- Ordering correctness across 2+ trackers
- `success_auc` preferred over `mean_iou` when available
- Missing energy handled gracefully (defaults to neutral `0.5`)
- Preset differentiation: `accuracy_first` vs `throughput_max` invert the order on a deliberately skewed tracker pair

## How it fits the project

This sits cleanly alongside the existing `EfficiencyMetricsEngine` — they answer complementary questions:
- `EfficiencyMetricsEngine.rank_trackers()` → "What is the EES Pareto front?"
- `RankingEngine.rank()` → "Under my specific deployment constraints, who wins?"

No existing APIs are modified. The module is a pure addition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLAEukWiyFxMhpJ671yJyb)_