### PR TITLE
[feat] Add FrameSkipTracker for edge deployment ablation studies

### DIFF
--- a/eovot/trackers/__init__.py
+++ b/eovot/trackers/__init__.py
@@ -3,6 +3,7 @@ from .mosse import MOSSETracker
 from .kcf import KCFTracker
 from .csrt import CSRTTracker
 from .median_flow import MedianFlowTracker
+from .adaptive import FrameSkipTracker
 
 __all__ = [
     "BaseTracker",
@@ -11,4 +12,5 @@ __all__ = [
     "KCFTracker",
     "CSRTTracker",
     "MedianFlowTracker",
+    "FrameSkipTracker",
 ]

--- a/eovot/trackers/adaptive.py
+++ b/eovot/trackers/adaptive.py
@@ -1,0 +1,250 @@
+"""Adaptive frame-skip tracker wrapper for edge deployment.
+
+Wraps any :class:`~eovot.trackers.base.BaseTracker` and skips tracker
+updates on a configurable fraction of frames, propagating the bounding box
+using simple extrapolation.  This enables systematic ablation studies of the
+accuracy-vs-throughput trade-off that is central to edge VOT deployment.
+
+Background
+~~~~~~~~~~
+On resource-constrained hardware (Raspberry Pi, Jetson Nano) even lightweight
+trackers like MOSSE and KCF may fall below real-time frame rates (≥25 FPS)
+when combined with image capture and post-processing.  A principled response
+is *frame skipping*: run the tracker once every N frames and extrapolate the
+target location in between.  The EOVOT benchmarking goal is to quantify the
+accuracy penalty incurred at each skip rate so that practitioners can select
+the Pareto-optimal operating point for their deployment.
+
+Two extrapolation strategies are provided:
+
+``"constant"``
+    The last confirmed bounding box is repeated unchanged for all skipped
+    frames.  Fast, robust to scale changes, but accumulates position error
+    for moving targets.
+
+``"linear"``
+    The centre and size of the bounding box are extrapolated along the
+    velocity vector estimated from the two most recent tracker updates.
+    Reduces centre-distance error for objects with approximately constant
+    velocity.  Bounding box coordinates are clamped to the image boundary
+    when the frame shape is known.
+
+Usage
+~~~~~
+::
+
+    from eovot.trackers.mosse import MOSSETracker
+    from eovot.trackers.adaptive import FrameSkipTracker
+
+    base = MOSSETracker()
+    tracker = FrameSkipTracker(base, skip_rate=3, extrapolation="linear")
+
+    # Drop-in replacement inside BenchmarkEngine:
+    from eovot.benchmark.engine import BenchmarkEngine
+    engine = BenchmarkEngine()
+    result = engine.run(tracker, dataset, "OTB100")
+
+    # Inspect skip statistics after the run:
+    print(f"Tracked {tracker.frames_tracked} / {tracker.total_frames} frames "
+          f"(skipped {tracker.skip_ratio*100:.1f}%)")
+
+Ablation study pattern
+~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+    skip_rates = [0, 1, 2, 3, 5, 9]
+    for rate in skip_rates:
+        t = FrameSkipTracker(MOSSETracker(), skip_rate=rate)
+        result = engine.run(t, dataset, "synthetic")
+        print(f"skip={rate}  mIoU={result.mean_iou:.3f}  FPS={result.mean_fps:.1f}")
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+
+from .base import BaseTracker, BBox
+
+
+class FrameSkipTracker(BaseTracker):
+    """A drop-in :class:`BaseTracker` that skips inner tracker updates periodically.
+
+    Args:
+        tracker:       Any :class:`BaseTracker` implementation to wrap.
+        skip_rate:     Number of frames to skip between tracker updates.
+                       ``0`` disables skipping (every frame is tracked).
+                       ``1`` runs the tracker every second frame.
+                       ``N`` runs the tracker every ``(N + 1)``-th frame.
+        extrapolation: How to fill in bounding boxes on skipped frames.
+                       ``"constant"`` repeats the last tracked bbox.
+                       ``"linear"`` extrapolates position and size using
+                       the velocity of the two most recent tracked frames.
+        name:          Optional override for the tracker name shown in reports.
+                       Defaults to ``"<inner_name>(skip=N)"``.
+
+    Attributes:
+        frames_tracked: Number of frames on which the inner tracker was called.
+        frames_skipped: Number of frames filled by extrapolation.
+        total_frames:   Total frames seen since :meth:`initialize`.
+        skip_ratio:     ``frames_skipped / total_frames`` (0.0 when no frames
+                        have been processed yet).
+    """
+
+    EXTRAPOLATION_MODES = ("constant", "linear")
+
+    def __init__(
+        self,
+        tracker: BaseTracker,
+        skip_rate: int = 1,
+        extrapolation: str = "constant",
+        name: Optional[str] = None,
+    ) -> None:
+        if skip_rate < 0:
+            raise ValueError(f"skip_rate must be >= 0, got {skip_rate}.")
+        if extrapolation not in self.EXTRAPOLATION_MODES:
+            raise ValueError(
+                f"extrapolation must be one of {self.EXTRAPOLATION_MODES}, "
+                f"got {extrapolation!r}."
+            )
+        derived_name = name or f"{tracker.name}(skip={skip_rate})"
+        super().__init__(derived_name)
+        self._inner = tracker
+        self.skip_rate = skip_rate
+        self.extrapolation = extrapolation
+
+        # State reset on each initialize() call.
+        self._last_bbox: Optional[BBox] = None
+        self._prev_bbox: Optional[BBox] = None      # two frames back, for velocity
+        self._frame_counter: int = 0                # frames since initialize
+        self._next_track_at: int = 0                # frame index for next inner update
+        self._frame_shape: Optional[Tuple[int, int]] = None  # (H, W) for clamping
+
+        self.frames_tracked: int = 0
+        self.frames_skipped: int = 0
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def total_frames(self) -> int:
+        return self.frames_tracked + self.frames_skipped
+
+    @property
+    def skip_ratio(self) -> float:
+        tot = self.total_frames
+        return self.frames_skipped / tot if tot > 0 else 0.0
+
+    @property
+    def inner_tracker(self) -> BaseTracker:
+        """The wrapped tracker instance."""
+        return self._inner
+
+    # ------------------------------------------------------------------
+    # BaseTracker interface
+    # ------------------------------------------------------------------
+
+    def initialize(self, frame: np.ndarray, bbox: BBox) -> None:
+        """Initialise both the wrapper and the inner tracker.
+
+        Args:
+            frame: BGR uint8 image, shape ``(H, W, 3)``.
+            bbox:  Ground-truth bounding box ``(x, y, w, h)``.
+        """
+        self._inner.initialize(frame, bbox)
+        self._last_bbox = bbox
+        self._prev_bbox = None
+        self._frame_counter = 0
+        self._next_track_at = self.skip_rate + 1  # first skip N frames, then track
+        self._frame_shape = (frame.shape[0], frame.shape[1])
+        self.frames_tracked = 0
+        self.frames_skipped = 0
+
+    def update(self, frame: np.ndarray) -> BBox:
+        """Return the predicted bounding box for *frame*.
+
+        Calls the inner tracker on scheduled frames; extrapolates on the rest.
+
+        Args:
+            frame: BGR uint8 image, shape ``(H, W, 3)``.
+
+        Returns:
+            Predicted bounding box ``(x, y, w, h)``.
+
+        Raises:
+            RuntimeError: If called before :meth:`initialize`.
+        """
+        if self._last_bbox is None:
+            raise RuntimeError("FrameSkipTracker.update() called before initialize().")
+
+        self._frame_counter += 1
+        self._frame_shape = (frame.shape[0], frame.shape[1])
+
+        if self.skip_rate == 0 or self._frame_counter >= self._next_track_at:
+            # Run the inner tracker on this frame.
+            bbox = self._inner.update(frame)
+            self._prev_bbox = self._last_bbox
+            self._last_bbox = bbox
+            self.frames_tracked += 1
+            # Schedule next tracker call.
+            self._next_track_at = self._frame_counter + self.skip_rate + 1
+        else:
+            # Extrapolate the bounding box without running the inner tracker.
+            bbox = self._extrapolate()
+            self.frames_skipped += 1
+
+        return bbox
+
+    # ------------------------------------------------------------------
+    # Extrapolation
+    # ------------------------------------------------------------------
+
+    def _extrapolate(self) -> BBox:
+        """Predict the bounding box for a skipped frame."""
+        if self.extrapolation == "linear" and self._prev_bbox is not None:
+            return self._linear_extrapolate()
+        return self._last_bbox  # type: ignore[return-value]
+
+    def _linear_extrapolate(self) -> BBox:
+        """Extrapolate centre and size linearly from the two most-recent bboxes.
+
+        Velocity is estimated as the per-component difference between the last
+        two *tracked* frames.  The extrapolated bbox is clamped to the image
+        boundary if ``_frame_shape`` is available.
+        """
+        ax, ay, aw, ah = self._last_bbox  # type: ignore[misc]
+        bx, by, bw, bh = self._prev_bbox  # type: ignore[misc]
+
+        # Velocity = (last - prev) per component; apply once per skipped frame.
+        vx = ax - bx
+        vy = ay - by
+        vw = aw - bw
+        vh = ah - bh
+
+        nx = ax + vx
+        ny = ay + vy
+        nw = max(1.0, aw + vw)
+        nh = max(1.0, ah + vh)
+
+        if self._frame_shape is not None:
+            H, W = self._frame_shape
+            nx = float(np.clip(nx, 0, W - 1))
+            ny = float(np.clip(ny, 0, H - 1))
+            nw = float(np.clip(nw, 1, W - nx))
+            nh = float(np.clip(nh, 1, H - ny))
+
+        return (nx, ny, nw, nh)
+
+    # ------------------------------------------------------------------
+    # Representation
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return (
+            f"FrameSkipTracker("
+            f"inner={self._inner!r}, "
+            f"skip_rate={self.skip_rate}, "
+            f"extrapolation={self.extrapolation!r})"
+        )

--- a/tests/test_adaptive_tracker.py
+++ b/tests/test_adaptive_tracker.py
@@ -1,0 +1,281 @@
+"""Tests for eovot.trackers.adaptive — FrameSkipTracker wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+import numpy as np
+import pytest
+
+from eovot.trackers.adaptive import FrameSkipTracker
+from eovot.trackers.base import BaseTracker, BBox
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_inner(name: str = "Mock") -> MagicMock:
+    """Build a mock BaseTracker that returns a simple bbox on update."""
+    inner = MagicMock(spec=BaseTracker)
+    inner.name = name
+    inner.update.return_value = (10.0, 20.0, 50.0, 40.0)
+    return inner
+
+
+def _frame(h: int = 240, w: int = 320) -> np.ndarray:
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+INIT_BBOX: BBox = (5.0, 5.0, 30.0, 30.0)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+class TestConstruction:
+    def test_default_name_derived(self) -> None:
+        inner = _make_inner("KCF")
+        t = FrameSkipTracker(inner, skip_rate=2)
+        assert "KCF" in t.name
+        assert "skip=2" in t.name
+
+    def test_custom_name_override(self) -> None:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=1, name="my_tracker")
+        assert t.name == "my_tracker"
+
+    def test_invalid_skip_rate_raises(self) -> None:
+        with pytest.raises(ValueError, match="skip_rate"):
+            FrameSkipTracker(_make_inner(), skip_rate=-1)
+
+    def test_invalid_extrapolation_raises(self) -> None:
+        with pytest.raises(ValueError, match="extrapolation"):
+            FrameSkipTracker(_make_inner(), extrapolation="cubic")
+
+    def test_inner_tracker_accessible(self) -> None:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=0)
+        assert t.inner_tracker is inner
+
+    def test_initial_stats_zero(self) -> None:
+        t = FrameSkipTracker(_make_inner(), skip_rate=1)
+        assert t.frames_tracked == 0
+        assert t.frames_skipped == 0
+        assert t.total_frames == 0
+        assert t.skip_ratio == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Initialize
+# ---------------------------------------------------------------------------
+
+class TestInitialize:
+    def test_delegates_to_inner(self) -> None:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=1)
+        f = _frame()
+        t.initialize(f, INIT_BBOX)
+        inner.initialize.assert_called_once_with(f, INIT_BBOX)
+
+    def test_update_before_init_raises(self) -> None:
+        t = FrameSkipTracker(_make_inner(), skip_rate=1)
+        with pytest.raises(RuntimeError, match="initialize"):
+            t.update(_frame())
+
+    def test_reinitialize_resets_stats(self) -> None:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=0)
+        t.initialize(_frame(), INIT_BBOX)
+        t.update(_frame())
+        t.update(_frame())
+        # Re-init should reset counters.
+        t.initialize(_frame(), INIT_BBOX)
+        assert t.frames_tracked == 0
+        assert t.frames_skipped == 0
+
+
+# ---------------------------------------------------------------------------
+# skip_rate=0: no skipping
+# ---------------------------------------------------------------------------
+
+class TestNoSkip:
+    def test_every_frame_tracked(self) -> None:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=0)
+        t.initialize(_frame(), INIT_BBOX)
+        for _ in range(5):
+            t.update(_frame())
+        assert t.frames_tracked == 5
+        assert t.frames_skipped == 0
+        assert inner.update.call_count == 5
+
+    def test_skip_ratio_zero(self) -> None:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=0)
+        t.initialize(_frame(), INIT_BBOX)
+        t.update(_frame())
+        assert t.skip_ratio == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# skip_rate=1: track every other frame
+# ---------------------------------------------------------------------------
+
+class TestSkipRateOne:
+    def _run(self, n_updates: int = 6) -> FrameSkipTracker:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=1)
+        t.initialize(_frame(), INIT_BBOX)
+        for _ in range(n_updates):
+            t.update(_frame())
+        return t
+
+    def test_tracked_vs_skipped_balance(self) -> None:
+        t = self._run(6)
+        # Frame schedule: track@1, skip@2, track@3, skip@4, track@5, skip@6
+        assert t.frames_tracked == 3
+        assert t.frames_skipped == 3
+
+    def test_total_frames(self) -> None:
+        t = self._run(6)
+        assert t.total_frames == 6
+
+    def test_skip_ratio(self) -> None:
+        t = self._run(6)
+        assert t.skip_ratio == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# skip_rate=3: track every 4th frame
+# ---------------------------------------------------------------------------
+
+class TestSkipRateThree:
+    def _run(self, n_updates: int = 8) -> FrameSkipTracker:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=3)
+        t.initialize(_frame(), INIT_BBOX)
+        for _ in range(n_updates):
+            t.update(_frame())
+        return t
+
+    def test_inner_call_count(self) -> None:
+        t = self._run(8)
+        # Track at frame 4 and 8 (counter=4,8); so 2 tracker calls.
+        assert t.frames_tracked == 2
+
+    def test_skipped_count(self) -> None:
+        t = self._run(8)
+        assert t.frames_skipped == 6
+
+
+# ---------------------------------------------------------------------------
+# Extrapolation: constant
+# ---------------------------------------------------------------------------
+
+class TestConstantExtrapolation:
+    def test_skipped_frame_returns_last_tracked_bbox(self) -> None:
+        tracked_bbox = (10.0, 20.0, 50.0, 40.0)
+        inner = _make_inner()
+        inner.update.return_value = tracked_bbox
+        t = FrameSkipTracker(inner, skip_rate=2, extrapolation="constant")
+        t.initialize(_frame(), INIT_BBOX)
+        # frame 1: skip, 2: skip, 3: track → returns tracked_bbox
+        b1 = t.update(_frame())  # skip
+        b2 = t.update(_frame())  # skip
+        b3 = t.update(_frame())  # track → inner called
+        # frames 4,5 are skips → should return b3
+        b4 = t.update(_frame())
+        b5 = t.update(_frame())
+        assert b4 == pytest.approx(b3)
+        assert b5 == pytest.approx(b3)
+
+
+# ---------------------------------------------------------------------------
+# Extrapolation: linear
+# ---------------------------------------------------------------------------
+
+class TestLinearExtrapolation:
+    def test_linear_predicts_motion(self) -> None:
+        """Inner tracker moves bbox by (+5, +5) each call; skip should extrapolate."""
+        call_num = [0]
+
+        def _moving_update(frame: np.ndarray) -> BBox:
+            call_num[0] += 1
+            x = 10.0 + call_num[0] * 5.0
+            return (x, 20.0, 50.0, 40.0)
+
+        inner = _make_inner()
+        inner.update.side_effect = _moving_update
+
+        t = FrameSkipTracker(inner, skip_rate=1, extrapolation="linear")
+        t.initialize(_frame(), (10.0, 20.0, 50.0, 40.0))
+
+        # update 1: skip (frame_counter=1, next_track=2)
+        b1 = t.update(_frame())      # skipped → constant (no prev yet)
+        assert b1 == pytest.approx((10.0, 20.0, 50.0, 40.0))
+
+        # update 2: track → inner returns (15, 20, 50, 40)
+        b2 = t.update(_frame())
+        assert b2 == pytest.approx((15.0, 20.0, 50.0, 40.0))
+
+        # update 3: skip → extrapolate from (10→15, Δ=5)
+        b3 = t.update(_frame())
+        assert b3[0] == pytest.approx(20.0)  # 15 + 5
+
+        # update 4: track → inner returns (20, 20, 50, 40)
+        b4 = t.update(_frame())
+        assert b4 == pytest.approx((20.0, 20.0, 50.0, 40.0))
+
+    def test_linear_clamps_to_image_boundary(self) -> None:
+        """Extrapolated bbox should not exceed the image dimensions."""
+        inner = _make_inner()
+        # Return a bbox near the right edge; velocity pushes it out of bounds.
+        inner.update.return_value = (300.0, 10.0, 10.0, 10.0)
+        t = FrameSkipTracker(inner, skip_rate=1, extrapolation="linear")
+        frame = _frame(h=240, w=320)
+        # Init with a bbox to the left so velocity = +100 on first skip
+        t.initialize(frame, (200.0, 10.0, 10.0, 10.0))
+
+        t.update(frame)  # skip
+        t.update(frame)  # track → moves to x=300
+        b = t.update(frame)  # skip → velocity ~= 100, would go to x=400 — clamped
+
+        x, y, w, h = b
+        assert x >= 0
+        assert y >= 0
+        assert x + w <= 320
+        assert y + h <= 240
+
+    def test_linear_fallback_when_no_prev(self) -> None:
+        """Before two tracker calls exist, linear mode should fall back to constant."""
+        inner = _make_inner()
+        inner.update.return_value = (10.0, 10.0, 20.0, 20.0)
+        t = FrameSkipTracker(inner, skip_rate=2, extrapolation="linear")
+        t.initialize(_frame(), INIT_BBOX)
+        b = t.update(_frame())  # skip (no prev_bbox yet)
+        # Should equal init bbox (constant fallback)
+        assert b == pytest.approx(INIT_BBOX)
+
+
+# ---------------------------------------------------------------------------
+# Stats and repr
+# ---------------------------------------------------------------------------
+
+class TestStats:
+    def test_skip_ratio_accumulates(self) -> None:
+        inner = _make_inner()
+        t = FrameSkipTracker(inner, skip_rate=4)
+        t.initialize(_frame(), INIT_BBOX)
+        for _ in range(10):
+            t.update(_frame())
+        # track at frames 5,10 → 2 tracked, 8 skipped
+        assert t.skip_ratio == pytest.approx(8 / 10)
+
+    def test_repr_contains_key_info(self) -> None:
+        inner = _make_inner("MOSSE")
+        t = FrameSkipTracker(inner, skip_rate=3, extrapolation="linear")
+        r = repr(t)
+        assert "skip_rate=3" in r
+        assert "linear" in r


### PR DESCRIPTION
## What was added

A new `FrameSkipTracker` wrapper in `eovot/trackers/adaptive.py` that wraps **any** `BaseTracker` and skips inner tracker updates on a configurable fraction of frames, filling in the gaps with bounding box extrapolation.

## Why it matters

On resource-constrained edge hardware (Raspberry Pi 4, Jetson Nano, Coral Dev Board) even lightweight trackers fall below real-time frame rates when combined with image acquisition and post-processing. The standard engineering response is **frame skipping**: run the tracker every N frames and propagate the target location in between.

EOVOT did not previously provide a principled way to:
1. Evaluate the accuracy penalty of each skip rate
2. Compare how different trackers tolerate skipping
3. Find the Pareto-optimal operating point per device budget

`FrameSkipTracker` is a drop-in `BaseTracker` that enables all three.

## Two extrapolation strategies

| Mode | Behaviour | Best for |
|------|-----------|----------|
| `"constant"` | Repeat the last confirmed bbox unchanged | Slow-moving or stationary targets |
| `"linear"` | Extrapolate center + size along the velocity vector from the two most recent tracked frames; clamps to image boundary | Fast-moving targets with approximately linear motion |

## Example: ablation study

```python
from eovot.trackers.mosse import MOSSETracker
from eovot.trackers.adaptive import FrameSkipTracker
from eovot.benchmark.engine import BenchmarkEngine
from eovot.datasets.synthetic import SyntheticDataset

engine = BenchmarkEngine()
dataset = SyntheticDataset(num_sequences=5, sequence_length=200)

results = []
for skip_rate in [0, 1, 2, 3, 5, 9]:
    tracker = FrameSkipTracker(MOSSETracker(), skip_rate=skip_rate, extrapolation="linear")
    r = engine.run(tracker, dataset, "synthetic")
    print(f"skip={skip_rate:2d}  mIoU={r.mean_iou:.3f}  FPS={r.mean_fps:.1f}  "
          f"skip_ratio={tracker.skip_ratio*100:.0f}%")
```

**Sample output (illustrative):**
```
skip= 0  mIoU=0.612  FPS=310.2  skip_ratio= 0%
skip= 1  mIoU=0.598  FPS=580.4  skip_ratio=50%
skip= 2  mIoU=0.571  FPS=820.1  skip_ratio=67%
skip= 3  mIoU=0.541  FPS=1090.3  skip_ratio=75%
skip= 9  mIoU=0.449  FPS=2700.8  skip_ratio=90%
```

This directly answers: *"At what skip rate does MOSSE on a Raspberry Pi stay above 25 FPS while keeping mIoU above 0.5?"*

## Statistics exposed after each run

```python
tracker.frames_tracked   # int: inner tracker calls
tracker.frames_skipped   # int: extrapolated frames
tracker.total_frames     # int: frames_tracked + frames_skipped
tracker.skip_ratio       # float in [0, 1]: fraction skipped
```

## Files changed

| File | Change |
|------|--------|
| `eovot/trackers/adaptive.py` | New module: `FrameSkipTracker` |
| `eovot/trackers/__init__.py` | Export `FrameSkipTracker` |
| `tests/test_adaptive_tracker.py` | 22 tests |

## Test coverage

```
22 passed in 0.19s
```

- Construction: name derivation, invalid args, inner tracker access
- `initialize()` delegation and stats reset on re-init
- `skip_rate=0`: every frame tracked, ratio = 0
- `skip_rate=1`: alternating schedule, ratio = 0.5
- `skip_rate=3`: correct duty cycle over 8 frames
- Constant extrapolation: skipped frames return last tracked bbox
- Linear extrapolation: correctly predicts motion for a moving target
- Boundary clamping: no bbox coordinate exceeds frame dimensions
- Linear fallback to constant when `prev_bbox` is not yet available

## No breaking changes

`FrameSkipTracker` is a pure addition implementing the existing `BaseTracker` interface. All existing tracker tests pass unmodified. The wrapper is transparent to `BenchmarkEngine`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLAEukWiyFxMhpJ671yJyb)_