### PR TITLE
[feat] Scale-Adaptive MOSSE tracker with multi-scale search

### DIFF
--- a/configs/experiments/scale_adaptation_demo.yaml
+++ b/configs/experiments/scale_adaptation_demo.yaml
@@ -1,0 +1,45 @@
+# EOVOT Scale Adaptation Demo
+# ----------------------------
+# Compares the standard MOSSE tracker against Scale-Adaptive MOSSE on a
+# synthetic dataset to demonstrate the accuracy gain from multi-scale search.
+#
+# Run with:
+#   python scripts/run_experiment.py \
+#     --config configs/experiments/scale_adaptation_demo.yaml
+#
+# To observe scale adaptation effects, change the motion pattern to "circular"
+# or increase frame count to see targets growing / shrinking in the sequence.
+
+experiment:
+  name: "scale-adaptation-demo"
+  seed: 42
+  tdp_watts: null
+
+dataset:
+  loader: SyntheticDataset
+  name: Synthetic-Linear
+  motion: linear
+  num_sequences: 10
+  num_frames: 150
+  frame_size: [320, 240]
+  bbox_size: [40, 40]
+  seed: 42
+
+trackers:
+  - name: MOSSE
+    params:
+      learning_rate: 0.125
+      sigma: 2.0
+
+  - name: ScaleAdaptiveMOSSE
+    params:
+      learning_rate: 0.125
+      sigma: 2.0
+      n_scales: 7
+      scale_step: 1.03
+      scale_lr: 0.35
+
+  - name: KCF
+    params:
+      learning_rate: 0.075
+      padding: 1.5

--- a/eovot/experiment/runner.py
+++ b/eovot/experiment/runner.py
@@ -275,6 +275,7 @@ class ExperimentRunner:
         from ..trackers.median_flow import MedianFlowTracker
         from ..trackers.mil import MILTracker
         from ..trackers.mosse import MOSSETracker
+        from ..trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
 
         registry = {
             "MOSSE": MOSSETracker,
@@ -282,6 +283,7 @@ class ExperimentRunner:
             "CSRT": CSRTTracker,
             "MIL": MILTracker,
             "MedianFlow": MedianFlowTracker,
+            "ScaleAdaptiveMOSSE": ScaleAdaptiveMOSSETracker,
         }
         name = cfg["name"]
         if name not in registry:

--- a/eovot/trackers/__init__.py
+++ b/eovot/trackers/__init__.py
@@ -3,6 +3,7 @@ from .mosse import MOSSETracker
 from .kcf import KCFTracker
 from .csrt import CSRTTracker
 from .median_flow import MedianFlowTracker
+from .scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
 
 __all__ = [
     "BaseTracker",
@@ -11,4 +12,5 @@ __all__ = [
     "KCFTracker",
     "CSRTTracker",
     "MedianFlowTracker",
+    "ScaleAdaptiveMOSSETracker",
 ]

--- a/eovot/trackers/scale_adaptive_mosse.py
+++ b/eovot/trackers/scale_adaptive_mosse.py
@@ -1,0 +1,284 @@
+"""Scale-Adaptive MOSSE (SA-MOSSE) correlation filter tracker.
+
+Extends the standard MOSSE tracker with a discrete scale pool that searches
+for the best target scale at every frame.  The correlation filter is kept at
+a fixed template resolution; candidate patches are extracted at different
+physical sizes and resized to that resolution before correlation, so the
+filter itself never changes shape.
+
+Algorithm overview
+------------------
+1. **Translation** — same as MOSSE: compute the correlation response on a patch
+   extracted at the current (x, y, w, h) and locate the displacement peak.
+2. **Scale search** — after updating the translation, extract ``n_scales``
+   candidate patches whose physical size ranges from
+   ``scale_step ** (-(n_scales//2))`` to ``scale_step ** (n_scales//2)``
+   times the current dimensions.  Each candidate is resized to the fixed
+   template shape and correlated with the learned filter; the candidate with
+   the highest response peak is chosen.
+3. **Scale smoothing** — the raw scale candidate is blended with the previous
+   scale using an exponential moving average (``scale_lr``) to suppress
+   frame-to-frame jitter.
+4. **Filter update** — the filter is updated using the new scale patch (EMA
+   with ``learning_rate``), exactly as in standard MOSSE.
+
+References
+----------
+* Bolme et al., "Visual object tracking using adaptive correlation filters,"
+  CVPR 2010. (original MOSSE)
+* Li et al., "A Scale Adaptive Kernel Correlation Filter Tracker with Feature
+  Integration," ECCV Workshops 2014. (scale search motivation)
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import cv2
+import numpy as np
+
+from .base import BaseTracker, BBox
+
+
+class ScaleAdaptiveMOSSETracker(BaseTracker):
+    """MOSSE tracker extended with discrete-scale-pool search.
+
+    The tracker maintains a fixed-resolution correlation filter (initialised
+    from the first-frame bounding box) and performs a multi-scale patch search
+    at every subsequent frame.  Aspect ratio is always preserved.
+
+    Args:
+        learning_rate: EMA weight for online filter update (0 = frozen,
+            1 = full replacement).  Default ``0.125`` matches the original
+            MOSSE paper.
+        sigma: Standard deviation of the Gaussian target response used during
+            initialisation (pixels).  Default ``2.0``.
+        n_scales: Number of candidate scales to evaluate each frame.  Must be
+            a positive odd integer so the pool is symmetric around scale 1.
+            Default ``7`` (i.e. scale_step ** {-3, -2, -1, 0, +1, +2, +3}).
+        scale_step: Multiplicative step between consecutive scale candidates.
+            Default ``1.03`` (3 % increment per step).
+        scale_lr: EMA weight for the scale update.  Lower values produce
+            smoother but slower scale adaptation.  Default ``0.35``.
+
+    Example::
+
+        import cv2
+        from eovot.trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
+
+        tracker = ScaleAdaptiveMOSSETracker()
+        cap = cv2.VideoCapture("video.mp4")
+        ret, frame = cap.read()
+        tracker.initialize(frame, (100, 80, 60, 60))
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            bbox = tracker.update(frame)
+            print(bbox)
+    """
+
+    _MIN_DIM: int = 4  # minimum width / height in pixels
+
+    def __init__(
+        self,
+        learning_rate: float = 0.125,
+        sigma: float = 2.0,
+        n_scales: int = 7,
+        scale_step: float = 1.03,
+        scale_lr: float = 0.35,
+    ) -> None:
+        super().__init__(name="ScaleAdaptiveMOSSE")
+        if n_scales < 1:
+            raise ValueError("n_scales must be >= 1.")
+        if scale_step <= 1.0:
+            raise ValueError("scale_step must be > 1.0.")
+        if not (0.0 < learning_rate <= 1.0):
+            raise ValueError("learning_rate must be in (0, 1].")
+        if not (0.0 < scale_lr <= 1.0):
+            raise ValueError("scale_lr must be in (0, 1].")
+
+        self.learning_rate = learning_rate
+        self.sigma = sigma
+        self.n_scales = n_scales
+        self.scale_step = scale_step
+        self.scale_lr = scale_lr
+
+        # Build the symmetric scale pool once; reused every frame.
+        half = n_scales // 2
+        self._scale_pool: np.ndarray = np.array(
+            [scale_step ** k for k in range(-half, half + 1)], dtype=np.float64
+        )
+
+        # State initialised in initialize()
+        self._H_conj: Optional[np.ndarray] = None  # conjugate of learned filter
+        self._window: Optional[np.ndarray] = None   # Hann window (th, tw)
+        self._bbox: Optional[list] = None           # current [x, y, w, h]
+        self._template_size: Optional[Tuple[int, int]] = None  # (th, tw) fixed
+        self._init_w: int = 0                        # initial width (for scale calc)
+        self._init_h: int = 0                        # initial height (for scale calc)
+        self._current_scale: float = 1.0             # accumulated scale factor
+
+    # ------------------------------------------------------------------ #
+    # BaseTracker interface                                                #
+    # ------------------------------------------------------------------ #
+
+    def initialize(self, frame: np.ndarray, bbox: BBox) -> None:
+        """Initialise the scale-adaptive filter on the first frame.
+
+        Args:
+            frame: BGR or grayscale image ``(H, W[, C])``.
+            bbox:  Ground-truth bounding box ``(x, y, w, h)``.
+
+        Raises:
+            ValueError: If the bounding box yields an empty patch.
+        """
+        x, y, w, h = [int(round(v)) for v in bbox]
+        if w < self._MIN_DIM or h < self._MIN_DIM:
+            raise ValueError(
+                f"Bounding box {bbox} too small; minimum dimension is {self._MIN_DIM} px."
+            )
+
+        gray = _to_gray(frame)
+        self._bbox = [x, y, w, h]
+        self._init_w = w
+        self._init_h = h
+        self._current_scale = 1.0
+        self._template_size = (h, w)  # (th, tw) — fixed for the life of the track
+
+        self._window = np.outer(np.hanning(h), np.hanning(w)).astype(np.float32)
+
+        G = np.fft.fft2(_gaussian_response(h, w, self.sigma))
+        patch = _extract_and_resize(gray, x, y, w, h, w, h)
+        Fi = np.fft.fft2(self._preprocess(patch))
+        self._H_conj = (G * np.conj(Fi)) / (Fi * np.conj(Fi) + 1e-5)
+
+    def update(self, frame: np.ndarray) -> BBox:
+        """Localise the target in the next frame with scale adaptation.
+
+        Args:
+            frame: BGR or grayscale image ``(H, W[, C])``.
+
+        Returns:
+            Predicted bounding box ``(x, y, w, h)``.
+
+        Raises:
+            RuntimeError: If :meth:`initialize` has not been called.
+        """
+        if self._H_conj is None or self._bbox is None:
+            raise RuntimeError(
+                "Tracker not initialised — call initialize() before update()."
+            )
+
+        x, y, w, h = self._bbox
+        th, tw = self._template_size  # type: ignore[misc]
+        gray = _to_gray(frame)
+
+        # ---- Step 1: Translation estimation --------------------------------
+        patch = _extract_and_resize(gray, x, y, w, h, tw, th)
+        Fi = np.fft.fft2(self._preprocess(patch))
+        response = np.real(np.fft.ifft2(self._H_conj * Fi))
+
+        ky, kx = np.unravel_index(response.argmax(), response.shape)
+        # Wrap-around: peaks beyond the half-size encode negative displacements.
+        dy_tmpl = ky if ky < th // 2 else ky - th
+        dx_tmpl = kx if kx < tw // 2 else kx - tw
+
+        # Scale template-space displacement back to image space.
+        scale_y = h / th
+        scale_x = w / tw
+        x_new = x + int(round(dx_tmpl * scale_x))
+        y_new = y + int(round(dy_tmpl * scale_y))
+
+        # ---- Step 2: Scale search ------------------------------------------
+        best_scale_factor = 1.0
+        best_peak = -np.inf
+
+        for sf in self._scale_pool:
+            cand_w = max(self._MIN_DIM, int(round(w * sf)))
+            cand_h = max(self._MIN_DIM, int(round(h * sf)))
+            cand = _extract_and_resize(gray, x_new, y_new, cand_w, cand_h, tw, th)
+            resp = np.real(np.fft.ifft2(self._H_conj * np.fft.fft2(self._preprocess(cand))))
+            peak = float(resp.max())
+            if peak > best_peak:
+                best_peak = peak
+                best_scale_factor = sf
+
+        # ---- Step 3: Scale EMA smoothing -----------------------------------
+        # Blend the raw winner scale toward 1.0 (i.e. no change) at rate scale_lr
+        # to suppress per-frame noise while still tracking genuine size changes.
+        self._current_scale *= (1.0 - self.scale_lr) + self.scale_lr * best_scale_factor
+
+        w_new = max(self._MIN_DIM, int(round(self._init_w * self._current_scale)))
+        h_new = max(self._MIN_DIM, int(round(self._init_h * self._current_scale)))
+        self._bbox = [x_new, y_new, w_new, h_new]
+
+        # ---- Step 4: Online filter update ----------------------------------
+        new_patch = _extract_and_resize(gray, x_new, y_new, w_new, h_new, tw, th)
+        G = np.fft.fft2(_gaussian_response(th, tw, self.sigma))
+        Fi_new = np.fft.fft2(self._preprocess(new_patch))
+        H_conj_new = (G * np.conj(Fi_new)) / (Fi_new * np.conj(Fi_new) + 1e-5)
+        self._H_conj = (
+            (1.0 - self.learning_rate) * self._H_conj
+            + self.learning_rate * H_conj_new
+        )
+
+        return (float(x_new), float(y_new), float(w_new), float(h_new))
+
+    # ------------------------------------------------------------------ #
+    # Preprocessing                                                        #
+    # ------------------------------------------------------------------ #
+
+    def _preprocess(self, patch: np.ndarray) -> np.ndarray:
+        """Log-normalise the patch and apply the Hann window."""
+        f = np.log1p(patch.astype(np.float32))
+        f = (f - f.mean()) / (f.std() + 1e-5)
+        return f * self._window  # type: ignore[operator]
+
+
+# ------------------------------------------------------------------ #
+# Module-level helpers (shared with MOSSETracker by convention)       #
+# ------------------------------------------------------------------ #
+
+def _to_gray(frame: np.ndarray) -> np.ndarray:
+    """Convert BGR / BGRA / grayscale image to single-channel uint8."""
+    if frame.ndim == 2:
+        return frame
+    if frame.shape[2] == 4:
+        return cv2.cvtColor(frame, cv2.COLOR_BGRA2GRAY)
+    return cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+
+def _gaussian_response(h: int, w: int, sigma: float) -> np.ndarray:
+    """2-D Gaussian centred at ``(h//2, w//2)`` with standard deviation *sigma*."""
+    cy, cx = h // 2, w // 2
+    ys, xs = np.ogrid[:h, :w]
+    g = np.exp(-((xs - cx) ** 2 + (ys - cy) ** 2) / (2.0 * sigma ** 2))
+    return (g / (g.sum() + 1e-6)).astype(np.float32)
+
+
+def _extract_and_resize(
+    gray: np.ndarray,
+    x: int,
+    y: int,
+    src_w: int,
+    src_h: int,
+    dst_w: int,
+    dst_h: int,
+) -> np.ndarray:
+    """Extract a ``(src_h, src_w)`` region and resize to ``(dst_h, dst_w)``.
+
+    Coordinates are clipped to the image boundary so the result is always
+    well-defined, even when the target is partially out of frame.
+    """
+    ih, iw = gray.shape
+    x1 = max(0, x)
+    y1 = max(0, y)
+    x2 = min(iw, x + src_w)
+    y2 = min(ih, y + src_h)
+    patch = gray[y1:y2, x1:x2]
+    if patch.size == 0:
+        return np.zeros((dst_h, dst_w), dtype=np.float32)
+    if patch.shape != (dst_h, dst_w):
+        patch = cv2.resize(patch, (dst_w, dst_h), interpolation=cv2.INTER_LINEAR)
+    return patch

--- a/tests/test_scale_adaptive_mosse.py
+++ b/tests/test_scale_adaptive_mosse.py
@@ -1,0 +1,193 @@
+"""Tests for the Scale-Adaptive MOSSE tracker."""
+
+import numpy as np
+import pytest
+
+from eovot.trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _synthetic_frame(h: int = 240, w: int = 320) -> np.ndarray:
+    """Return a random BGR frame."""
+    rng = np.random.default_rng(0)
+    return rng.integers(0, 255, (h, w, 3), dtype=np.uint8)
+
+
+def _solid_frame(h: int = 240, w: int = 320, val: int = 128) -> np.ndarray:
+    """Return a uniform gray BGR frame."""
+    return np.full((h, w, 3), val, dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+class TestConstruction:
+    def test_default_name(self):
+        t = ScaleAdaptiveMOSSETracker()
+        assert t.name == "ScaleAdaptiveMOSSE"
+
+    def test_repr(self):
+        t = ScaleAdaptiveMOSSETracker()
+        assert "ScaleAdaptiveMOSSE" in repr(t)
+
+    def test_invalid_n_scales(self):
+        with pytest.raises(ValueError):
+            ScaleAdaptiveMOSSETracker(n_scales=0)
+
+    def test_invalid_scale_step(self):
+        with pytest.raises(ValueError):
+            ScaleAdaptiveMOSSETracker(scale_step=1.0)
+
+    def test_invalid_learning_rate_zero(self):
+        with pytest.raises(ValueError):
+            ScaleAdaptiveMOSSETracker(learning_rate=0.0)
+
+    def test_invalid_scale_lr_zero(self):
+        with pytest.raises(ValueError):
+            ScaleAdaptiveMOSSETracker(scale_lr=0.0)
+
+    def test_scale_pool_length(self):
+        t = ScaleAdaptiveMOSSETracker(n_scales=5, scale_step=1.05)
+        assert len(t._scale_pool) == 5
+
+    def test_scale_pool_symmetric(self):
+        t = ScaleAdaptiveMOSSETracker(n_scales=7, scale_step=1.03)
+        pool = t._scale_pool
+        # Pool should be symmetric: pool[k] ≈ 1/pool[-(k+1)]
+        assert abs(pool[0] * pool[-1] - 1.0) < 1e-9
+
+    def test_scale_pool_centre_is_one(self):
+        t = ScaleAdaptiveMOSSETracker(n_scales=7)
+        centre = len(t._scale_pool) // 2
+        assert abs(t._scale_pool[centre] - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+class TestInitialization:
+    def test_state_after_init(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _synthetic_frame()
+        t.initialize(frame, (50, 40, 60, 50))
+        assert t._H_conj is not None
+        assert t._window is not None
+        assert t._bbox is not None
+        assert t._template_size == (50, 60)
+
+    def test_init_bbox_too_small(self):
+        t = ScaleAdaptiveMOSSETracker()
+        with pytest.raises(ValueError):
+            t.initialize(_synthetic_frame(), (10, 10, 2, 2))
+
+    def test_init_scale_reset(self):
+        t = ScaleAdaptiveMOSSETracker()
+        t.initialize(_synthetic_frame(), (30, 30, 40, 40))
+        assert t._current_scale == 1.0
+
+    def test_window_shape(self):
+        t = ScaleAdaptiveMOSSETracker()
+        t.initialize(_synthetic_frame(), (10, 10, 50, 40))
+        assert t._window.shape == (40, 50)
+
+    def test_grayscale_input(self):
+        t = ScaleAdaptiveMOSSETracker()
+        gray = np.random.randint(0, 255, (240, 320), dtype=np.uint8)
+        t.initialize(gray, (50, 50, 60, 60))
+        assert t._H_conj is not None
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+class TestUpdate:
+    def test_update_before_init_raises(self):
+        t = ScaleAdaptiveMOSSETracker()
+        with pytest.raises(RuntimeError):
+            t.update(_synthetic_frame())
+
+    def test_update_returns_four_tuple(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _synthetic_frame()
+        t.initialize(frame, (50, 40, 60, 50))
+        bbox = t.update(_synthetic_frame())
+        assert len(bbox) == 4
+
+    def test_update_returns_floats(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _synthetic_frame()
+        t.initialize(frame, (50, 40, 60, 50))
+        bbox = t.update(_synthetic_frame())
+        assert all(isinstance(v, float) for v in bbox)
+
+    def test_update_positive_dimensions(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _synthetic_frame()
+        t.initialize(frame, (50, 40, 60, 50))
+        for _ in range(5):
+            _, _, w, h = t.update(_synthetic_frame())
+            assert w > 0 and h > 0
+
+    def test_multi_step_update(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _synthetic_frame()
+        t.initialize(frame, (50, 40, 60, 50))
+        for _ in range(10):
+            bbox = t.update(_synthetic_frame())
+        assert len(bbox) == 4
+
+    def test_scale_changes_over_sequence(self):
+        """Scale should remain close to 1 on a static-looking scene."""
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _solid_frame()
+        t.initialize(frame, (100, 80, 60, 50))
+        for _ in range(5):
+            t.update(_solid_frame())
+        # On a flat scene, accumulated scale should stay near 1
+        assert 0.5 < t._current_scale < 2.0
+
+
+# ---------------------------------------------------------------------------
+# Scale pool behaviour
+# ---------------------------------------------------------------------------
+
+class TestScalePool:
+    def test_n_scales_one(self):
+        t = ScaleAdaptiveMOSSETracker(n_scales=1)
+        frame = _synthetic_frame()
+        t.initialize(frame, (50, 50, 60, 60))
+        bbox = t.update(_synthetic_frame())
+        assert len(bbox) == 4
+
+    def test_large_scale_pool(self):
+        t = ScaleAdaptiveMOSSETracker(n_scales=9, scale_step=1.02)
+        frame = _synthetic_frame()
+        t.initialize(frame, (50, 50, 60, 60))
+        bbox = t.update(_synthetic_frame())
+        assert len(bbox) == 4
+
+
+# ---------------------------------------------------------------------------
+# Benchmark interface compatibility
+# ---------------------------------------------------------------------------
+
+class TestInterface:
+    def test_base_tracker_subclass(self):
+        from eovot.trackers.base import BaseTracker
+        assert issubclass(ScaleAdaptiveMOSSETracker, BaseTracker)
+
+    def test_registered_in_experiment_runner(self):
+        from eovot.experiment.runner import ExperimentRunner
+        cfg = {"name": "ScaleAdaptiveMOSSE", "params": {}}
+        tracker = ExperimentRunner._build_tracker(cfg)
+        assert tracker.name == "ScaleAdaptiveMOSSE"
+
+    def test_importable_from_package(self):
+        from eovot.trackers import ScaleAdaptiveMOSSETracker as T
+        assert T is ScaleAdaptiveMOSSETracker


### PR DESCRIPTION
## What was added

`ScaleAdaptiveMOSSETracker` — a correlation filter tracker that extends the standard MOSSE with a discrete scale pool search, enabling the tracker to handle targets that grow or shrink during a sequence.

### Algorithm

Every frame the tracker runs **four steps**:

1. **Translation** — standard MOSSE correlation response peak locates the displacement `(dx, dy)` in template space; the offset is scaled back to image space by the current `(w/tw, h/th)` ratio.
2. **Scale search** — `n_scales` candidate physical patches (ranging from `scale_step^(−n//2)` to `scale_step^(+n//2)` times the current size) are extracted, resized to the fixed template resolution `(tw, th)`, and correlated with the learned filter. The candidate with the highest peak is selected.
3. **Scale EMA** — the raw winning scale factor is blended with the identity (scale = 1) via `scale_lr` to suppress frame-to-frame jitter while still tracking genuine size changes.
4. **Filter update** — EMA update on the new-scale patch, exactly as in standard MOSSE.

The correlation filter **never changes shape** — all scale variation is absorbed by resizing candidate patches before correlation. Aspect ratio is always preserved.

### Why it matters

All classical trackers in the current codebase (MOSSE, KCF, MedianFlow) maintain a **fixed bounding box size** from initialisation. This causes progressive drift on real sequences where the target approaches, recedes, or changes apparent size. Scale adaptation is the #1 algorithmic gap between the current baseline trackers and research-grade methods.

## Files changed

| File | Change |
|------|--------|
| `eovot/trackers/scale_adaptive_mosse.py` | New tracker implementation (~210 LOC) |
| `eovot/trackers/__init__.py` | Export `ScaleAdaptiveMOSSETracker` |
| `eovot/experiment/runner.py` | Register `"ScaleAdaptiveMOSSE"` in the tracker factory |
| `tests/test_scale_adaptive_mosse.py` | 25 unit tests — all passing |
| `configs/experiments/scale_adaptation_demo.yaml` | Demo config comparing MOSSE vs. SA-MOSSE vs. KCF |

## Example usage

```python
from eovot.trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
from eovot.benchmark.engine import BenchmarkEngine
from eovot.datasets.synthetic import SyntheticDataset

tracker = ScaleAdaptiveMOSSETracker(n_scales=7, scale_step=1.03, scale_lr=0.35)
dataset = SyntheticDataset(num_sequences=10, num_frames=150)

engine = BenchmarkEngine()
result = engine.run(tracker, dataset, dataset_name="Synthetic")
print(result)
```

Run the comparison experiment:
```bash
python scripts/run_experiment.py \
  --config configs/experiments/scale_adaptation_demo.yaml
```

## No breaking changes

- `ScaleAdaptiveMOSSETracker` is a new class; no existing trackers are modified.
- The `ExperimentRunner` registry is additive; existing configs are unaffected.
- All 25 new tests pass; no existing tests broken.


---
_Generated by [Claude Code](https://claude.ai/code/session_019RvZ8vuCLmQ3AqSqqXcPXa)_