### PR TITLE
[feat] DeploymentReportEngine: multi-tracker, multi-device edge analysis

### DIFF
--- a/eovot/reporting/__init__.py
+++ b/eovot/reporting/__init__.py
@@ -1,4 +1,5 @@
 from .reporter import BenchmarkReporter
 from .visualizer import BenchmarkVisualizer
+from .deployment_report import DeploymentReportEngine, DeploymentReport
 
-__all__ = ["BenchmarkReporter", "BenchmarkVisualizer"]
+__all__ = ["BenchmarkReporter", "BenchmarkVisualizer", "DeploymentReportEngine", "DeploymentReport"]

--- a/eovot/reporting/deployment_report.py
+++ b/eovot/reporting/deployment_report.py
@@ -1,0 +1,478 @@
+"""Multi-tracker edge deployment analysis report.
+
+Bridges the gap between ``BenchmarkEngine`` results and ``DeviceSimulator``
+by projecting every tracker's profiling data onto every built-in edge device
+in a single call.  The output answers the practitioner's core question:
+
+    *"Given these benchmark results, which tracker should I deploy on each
+    of my target devices?"*
+
+Computation overview
+--------------------
+1. For each ``BenchmarkResult``, compute an *aggregate* ``ProfilingResult``
+   that summarises all sequences into a single representative timing profile.
+2. Feed that aggregate into ``DeviceSimulator.simulate_all`` to obtain
+   projected latency, FPS, memory, and energy per device.
+3. Compute a *device-specific* Edge Efficiency Score (EES) using the
+   projected FPS instead of the host-measured FPS::
+
+       EES_device = mean_iou × log1p(device_fps) / (1 + mem_mb / budget_mb)
+
+4. On each device, identify the Pareto front in the (mean_iou, EES_device)
+   objective space and recommend the tracker with the highest device-EES.
+
+Typical usage::
+
+    from eovot.benchmark.engine import BenchmarkEngine
+    from eovot.reporting.deployment_report import DeploymentReportEngine
+
+    engine = BenchmarkEngine()
+    results = [engine.run(t, dataset) for t in trackers]
+
+    report_engine = DeploymentReportEngine()
+    report = report_engine.analyze(results)
+
+    print(report_engine.to_markdown(report))
+    report_engine.save(report, output_dir="results/deployment")
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from ..profiling.device_sim import DeviceSimulator, DeviceSimResult
+from ..profiling.profiler import ProfilingResult
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DeviceTrackerEntry:
+    """Performance of one tracker projected onto one edge device.
+
+    Attributes:
+        tracker_name: Human-readable tracker identifier.
+        device_name: Short device key (e.g. ``"rpi4"``).
+        display_name: Human-readable device label.
+        mean_iou: Mean IoU measured on the host benchmark.
+        device_fps: Projected frames per second on the target device.
+        device_latency_ms: Projected mean per-frame latency (ms).
+        peak_memory_mb: Peak RSS memory footprint (algorithm-determined).
+        memory_limit_mb: Total device RAM.
+        fits_in_memory: Whether the tracker fits within device memory.
+        device_ees: Device-specific Edge Efficiency Score.
+        thermal_state: ``"nominal"``, ``"transitioning"``, or ``"throttled"``.
+        energy_mj_per_frame: Projected energy consumption per frame (mJ).
+        on_pareto_front: ``True`` if no other tracker dominates this one
+            on this device in both mIoU and device_ees.
+        is_recommended: ``True`` for the highest device_ees tracker on this
+            device that also fits in memory.
+    """
+
+    tracker_name: str
+    device_name: str
+    display_name: str
+    mean_iou: float
+    device_fps: float
+    device_latency_ms: float
+    peak_memory_mb: float
+    memory_limit_mb: float
+    fits_in_memory: bool
+    device_ees: float
+    thermal_state: str
+    energy_mj_per_frame: float
+    on_pareto_front: bool = field(default=False)
+    is_recommended: bool = field(default=False)
+
+
+@dataclass
+class DeploymentReport:
+    """Full deployment analysis across all trackers and devices.
+
+    Attributes:
+        dataset_name: Name of the dataset used for benchmarking.
+        sustained_seconds: Sustained-load duration used for thermal modelling.
+        devices: Ordered list of device keys included in the report.
+        entries: All (tracker, device) pairs; length = n_trackers × n_devices.
+        recommendations: Mapping ``device_name → tracker_name`` for the
+            highest device-EES memory-feasible tracker on each device.
+    """
+
+    dataset_name: str
+    sustained_seconds: float
+    devices: List[str]
+    entries: List[DeviceTrackerEntry] = field(default_factory=list)
+    recommendations: Dict[str, str] = field(default_factory=dict)
+
+    def entries_for_device(self, device_name: str) -> List[DeviceTrackerEntry]:
+        """Return all entries for a specific device, sorted by device_ees desc."""
+        out = [e for e in self.entries if e.device_name == device_name]
+        out.sort(key=lambda e: e.device_ees, reverse=True)
+        return out
+
+    def entries_for_tracker(self, tracker_name: str) -> List[DeviceTrackerEntry]:
+        """Return all device entries for a specific tracker."""
+        return [e for e in self.entries if e.tracker_name == tracker_name]
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+class DeploymentReportEngine:
+    """Analyse benchmark results across edge devices and produce deployment guidance.
+
+    Args:
+        memory_budget_mb: Memory ceiling (MB) for EES computation.
+            Trackers within budget receive full memory credit.
+            Default: ``512.0`` MB.
+        sustained_seconds: Duration of continuous tracking on the device,
+            used for thermal throttling modelling.
+            ``0.0`` (default) models a cold-start burst scenario.
+        host_calibration_factor: Passed to :class:`DeviceSimulator` to correct
+            for a host that is faster/slower than the reference i7 class.
+            Default: ``1.0``.
+        device_names: Explicit list of device keys to include.  If ``None``
+            all built-in devices are used.
+    """
+
+    def __init__(
+        self,
+        memory_budget_mb: float = 512.0,
+        sustained_seconds: float = 0.0,
+        host_calibration_factor: float = 1.0,
+        device_names: Optional[List[str]] = None,
+    ) -> None:
+        if memory_budget_mb <= 0:
+            raise ValueError("memory_budget_mb must be positive.")
+        self.memory_budget_mb = memory_budget_mb
+        self.sustained_seconds = sustained_seconds
+        self._sim = DeviceSimulator(host_calibration_factor=host_calibration_factor)
+        self._device_names: List[str] = (
+            device_names if device_names is not None else self._sim.list_devices()
+        )
+
+    # ------------------------------------------------------------------
+    # Primary API
+    # ------------------------------------------------------------------
+
+    def analyze(
+        self,
+        results: "List[BenchmarkResult]",  # noqa: F821 — resolved at runtime
+    ) -> DeploymentReport:
+        """Run the full deployment analysis.
+
+        Args:
+            results: One :class:`~eovot.benchmark.engine.BenchmarkResult` per
+                tracker, all evaluated on the same dataset.
+
+        Returns:
+            :class:`DeploymentReport` with all entries populated and
+            ``recommendations`` filled.
+
+        Raises:
+            ValueError: If *results* is empty.
+        """
+        if not results:
+            raise ValueError("results must contain at least one BenchmarkResult.")
+
+        dataset_name = results[0].dataset_name
+        entries: List[DeviceTrackerEntry] = []
+
+        for bench in results:
+            agg_profiling = _aggregate_profiling(bench)
+            sim_results: List[DeviceSimResult] = self._sim.simulate_all(
+                agg_profiling,
+                sustained_seconds=self.sustained_seconds,
+                device_names=self._device_names,
+            )
+            for sim in sim_results:
+                ees = _device_ees(bench.mean_iou, sim.estimated_fps, sim.estimated_memory_mb, self.memory_budget_mb)
+                entries.append(
+                    DeviceTrackerEntry(
+                        tracker_name=bench.tracker_name,
+                        device_name=sim.device_name,
+                        display_name=sim.display_name,
+                        mean_iou=bench.mean_iou,
+                        device_fps=sim.estimated_fps,
+                        device_latency_ms=sim.estimated_latency_ms,
+                        peak_memory_mb=sim.estimated_memory_mb,
+                        memory_limit_mb=sim.memory_limit_mb,
+                        fits_in_memory=sim.fits_in_memory,
+                        device_ees=ees,
+                        thermal_state=sim.thermal_state,
+                        energy_mj_per_frame=sim.estimated_energy_mj_per_frame,
+                    )
+                )
+
+        report = DeploymentReport(
+            dataset_name=dataset_name,
+            sustained_seconds=self.sustained_seconds,
+            devices=list(self._device_names),
+            entries=entries,
+        )
+        self._mark_pareto(report)
+        self._pick_recommendations(report)
+        return report
+
+    # ------------------------------------------------------------------
+    # Formatting
+    # ------------------------------------------------------------------
+
+    def to_markdown(self, report: DeploymentReport) -> str:
+        """Render the deployment report as a multi-section Markdown document.
+
+        Produces one table per device showing all trackers ranked by
+        device-specific EES, plus a summary recommendations table.
+
+        Args:
+            report: Output of :meth:`analyze`.
+
+        Returns:
+            Multi-line Markdown string ready for embedding in a README or paper.
+        """
+        lines = [
+            "# EOVOT Edge Deployment Analysis Report\n",
+            f"**Dataset:** {report.dataset_name}  ",
+            f"**Thermal scenario:** {'sustained ' + str(int(report.sustained_seconds)) + 's' if report.sustained_seconds > 0 else 'cold-start (burst)'}  ",
+            f"**Memory budget:** {self.memory_budget_mb:.0f} MB\n",
+            "---\n",
+        ]
+
+        # Per-device tables
+        for device_key in report.devices:
+            device_entries = report.entries_for_device(device_key)
+            if not device_entries:
+                continue
+            display = device_entries[0].display_name
+            mem_limit = device_entries[0].memory_limit_mb
+            lines.append(f"## {display} (RAM: {mem_limit:.0f} MB)\n")
+            lines.append(
+                "| Rank | Tracker | mIoU | FPS | Latency (ms) | Mem (MB) | Fits? | EES | Thermal | mJ/frame | Pareto |"
+            )
+            lines.append(
+                "|------|---------|-----:|----:|-------------:|---------:|:-----:|----:|---------|----------|:------:|"
+            )
+            for rank, e in enumerate(device_entries, start=1):
+                fits = "✓" if e.fits_in_memory else "✗ OOM"
+                pareto = "✓" if e.on_pareto_front else ""
+                rec = " ★" if e.is_recommended else ""
+                lines.append(
+                    f"| {rank} | {e.tracker_name}{rec} "
+                    f"| {e.mean_iou:.4f} "
+                    f"| {e.device_fps:.1f} "
+                    f"| {e.device_latency_ms:.1f} "
+                    f"| {e.peak_memory_mb:.0f} "
+                    f"| {fits} "
+                    f"| {e.device_ees:.4f} "
+                    f"| {e.thermal_state} "
+                    f"| {e.energy_mj_per_frame:.3f} "
+                    f"| {pareto} |"
+                )
+            lines.append("")
+
+        # Recommendation summary
+        lines.append("---\n")
+        lines.append("## Recommended Tracker per Device\n")
+        lines.append("| Device | Recommended Tracker | Reason |")
+        lines.append("|--------|--------------------:|--------|")
+        for device_key in report.devices:
+            rec_tracker = report.recommendations.get(device_key, "none (all OOM)")
+            device_entries = report.entries_for_device(device_key)
+            display = device_entries[0].display_name if device_entries else device_key
+            if rec_tracker != "none (all OOM)":
+                matched = next((e for e in device_entries if e.tracker_name == rec_tracker), None)
+                reason = (
+                    f"highest EES ({matched.device_ees:.4f}), "
+                    f"{matched.device_fps:.1f} FPS, "
+                    f"fits in memory"
+                ) if matched else "highest device EES"
+            else:
+                reason = "all trackers exceed device RAM"
+            lines.append(f"| {display} | {rec_tracker} | {reason} |")
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def to_dict(self, report: DeploymentReport) -> dict:
+        """Serialise the report to a JSON-compatible dict.
+
+        Args:
+            report: Output of :meth:`analyze`.
+
+        Returns:
+            Nested dict with keys ``"metadata"``, ``"recommendations"``,
+            and ``"per_device"`` (one entry per device).
+        """
+        per_device: Dict[str, list] = {}
+        for device_key in report.devices:
+            per_device[device_key] = [
+                {
+                    "tracker": e.tracker_name,
+                    "mean_iou": round(e.mean_iou, 4),
+                    "device_fps": round(e.device_fps, 2),
+                    "device_latency_ms": round(e.device_latency_ms, 3),
+                    "peak_memory_mb": round(e.peak_memory_mb, 1),
+                    "memory_limit_mb": e.memory_limit_mb,
+                    "fits_in_memory": e.fits_in_memory,
+                    "device_ees": round(e.device_ees, 4),
+                    "thermal_state": e.thermal_state,
+                    "energy_mj_per_frame": round(e.energy_mj_per_frame, 4),
+                    "on_pareto_front": e.on_pareto_front,
+                    "is_recommended": e.is_recommended,
+                }
+                for e in report.entries_for_device(device_key)
+            ]
+        return {
+            "metadata": {
+                "dataset": report.dataset_name,
+                "sustained_seconds": report.sustained_seconds,
+                "memory_budget_mb": self.memory_budget_mb,
+                "devices": report.devices,
+            },
+            "recommendations": report.recommendations,
+            "per_device": per_device,
+        }
+
+    def save(self, report: DeploymentReport, output_dir: str = "results/deployment") -> Dict[str, Path]:
+        """Write the Markdown report and JSON data to *output_dir*.
+
+        Args:
+            report: Output of :meth:`analyze`.
+            output_dir: Directory to write files into (created if absent).
+
+        Returns:
+            ``{"markdown": Path(...), "json": Path(...)}`` mapping.
+        """
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        md_path = out / "deployment_report.md"
+        md_path.write_text(self.to_markdown(report), encoding="utf-8")
+
+        json_path = out / "deployment_report.json"
+        with open(json_path, "w") as fh:
+            json.dump(self.to_dict(report), fh, indent=2)
+
+        return {"markdown": md_path, "json": json_path}
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _mark_pareto(self, report: DeploymentReport) -> None:
+        """Set ``on_pareto_front`` for each entry in (mIoU, device_ees) space."""
+        for device_key in report.devices:
+            device_entries = [e for e in report.entries if e.device_name == device_key]
+            for i, cand in enumerate(device_entries):
+                dominated = False
+                for j, other in enumerate(device_entries):
+                    if i == j:
+                        continue
+                    if (
+                        other.mean_iou >= cand.mean_iou
+                        and other.device_ees >= cand.device_ees
+                        and (other.mean_iou > cand.mean_iou or other.device_ees > cand.device_ees)
+                    ):
+                        dominated = True
+                        break
+                cand.on_pareto_front = not dominated
+
+    def _pick_recommendations(self, report: DeploymentReport) -> None:
+        """Set ``is_recommended`` and populate ``report.recommendations``."""
+        for device_key in report.devices:
+            device_entries = report.entries_for_device(device_key)
+            feasible = [e for e in device_entries if e.fits_in_memory]
+            if not feasible:
+                report.recommendations[device_key] = "none (all OOM)"
+                continue
+            best = max(feasible, key=lambda e: e.device_ees)
+            best.is_recommended = True
+            report.recommendations[device_key] = best.tracker_name
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+def _aggregate_profiling(bench: "BenchmarkResult") -> ProfilingResult:  # noqa: F821
+    """Build a single representative ProfilingResult from a BenchmarkResult.
+
+    Collects all per-sequence latency statistics and the peak memory across
+    all sequences to produce a host-level summary suitable for device projection.
+
+    Args:
+        bench: Benchmark result containing one or more sequence results.
+
+    Returns:
+        :class:`~eovot.profiling.profiler.ProfilingResult` aggregating all
+        sequence-level profiling data.
+    """
+    seqs = bench.sequence_results
+    if not seqs:
+        raise ValueError(f"BenchmarkResult for '{bench.tracker_name}' has no sequence results.")
+
+    # Reconstruct individual frame latencies from summary stats via normal approx.
+    # We use the mean and std already stored; this is sufficient for device projection.
+    all_means = np.array([s.profiling.latency_mean_ms for s in seqs])
+    all_stds = np.array([s.profiling.latency_std_ms for s in seqs])
+    all_counts = np.array([s.profiling.frame_count for s in seqs], dtype=np.float64)
+
+    total_frames = int(all_counts.sum())
+    # Grand mean: weighted average of per-sequence means
+    grand_mean_ms = float(np.average(all_means, weights=all_counts))
+    # Grand std: pooled standard deviation
+    grand_var = float(
+        np.average(all_stds ** 2 + (all_means - grand_mean_ms) ** 2, weights=all_counts)
+    )
+    grand_std_ms = math.sqrt(max(grand_var, 0.0))
+    # p95: assume normal distribution for the aggregate
+    grand_p95_ms = grand_mean_ms + 1.645 * grand_std_ms
+
+    peak_mem = bench.peak_memory_mb
+    fps = 1_000.0 / grand_mean_ms if grand_mean_ms > 0 else 0.0
+
+    return ProfilingResult(
+        tracker_name=bench.tracker_name,
+        frame_count=total_frames,
+        fps=fps,
+        latency_mean_ms=grand_mean_ms,
+        latency_std_ms=grand_std_ms,
+        latency_p95_ms=grand_p95_ms,
+        peak_memory_mb=peak_mem,
+    )
+
+
+def _device_ees(
+    mean_iou: float,
+    device_fps: float,
+    peak_memory_mb: float,
+    memory_budget_mb: float,
+) -> float:
+    """Compute the device-specific Edge Efficiency Score.
+
+    Uses the same formula as :class:`~eovot.metrics.efficiency.EfficiencyMetricsEngine`
+    but with the device-projected FPS rather than the host-measured FPS::
+
+        EES = mean_iou × log1p(device_fps) / (1 + peak_memory_mb / memory_budget_mb)
+
+    Args:
+        mean_iou: Mean IoU on the host benchmark, in ``[0, 1]``.
+        device_fps: Projected FPS on the target edge device.
+        peak_memory_mb: Peak RSS memory footprint.
+        memory_budget_mb: Memory ceiling for the penalty denominator.
+
+    Returns:
+        EES scalar ≥ 0.  Returns ``0.0`` for non-positive fps or negative IoU.
+    """
+    if device_fps <= 0 or mean_iou < 0:
+        return 0.0
+    return (mean_iou * math.log1p(device_fps)) / (1.0 + peak_memory_mb / memory_budget_mb)

--- a/scripts/deployment_analysis.py
+++ b/scripts/deployment_analysis.py
@@ -1,0 +1,176 @@
+"""CLI for edge deployment analysis.
+
+Runs a set of trackers on a synthetic dataset (no external data required)
+and generates a full deployment analysis report projecting performance
+onto all built-in edge devices.
+
+Usage::
+
+    python scripts/deployment_analysis.py \\
+        --trackers MOSSE KCF \\
+        --output results/deployment \\
+        --sustained 60
+
+    # With explicit device subset:
+    python scripts/deployment_analysis.py \\
+        --trackers MOSSE KCF CSRT \\
+        --devices rpi4 rpi5 jetson_nano \\
+        --output results/deployment
+
+    # Adjust memory budget and thermal scenario:
+    python scripts/deployment_analysis.py \\
+        --trackers MOSSE KCF \\
+        --memory-budget 256 \\
+        --sustained 120
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running as a script without installing the package.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eovot.benchmark.engine import BenchmarkEngine
+from eovot.datasets.synthetic import SyntheticDataset
+from eovot.experiment.runner import ExperimentRunner
+from eovot.reporting.deployment_report import DeploymentReportEngine
+
+
+_DEFAULT_TRACKERS = ["MOSSE", "KCF", "CSRT", "MedianFlow"]
+
+_TRACKER_PARAMS = {
+    "MOSSE": {"learning_rate": 0.125, "sigma": 2.0},
+    "KCF": {"learning_rate": 0.075, "padding": 1.5},
+    "CSRT": {},
+    "MedianFlow": {},
+    "MIL": {},
+    "ScaleAdaptiveMOSSE": {"learning_rate": 0.125, "n_scales": 7, "scale_step": 1.03},
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Run benchmark and generate edge deployment analysis report.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--trackers",
+        nargs="+",
+        default=_DEFAULT_TRACKERS,
+        metavar="NAME",
+        help="Tracker names to benchmark. Default: %(default)s",
+    )
+    p.add_argument(
+        "--devices",
+        nargs="+",
+        default=None,
+        metavar="DEVICE",
+        help=(
+            "Edge device keys to include. "
+            "Default: all built-in devices "
+            "(rpi4, rpi5, jetson_nano, jetson_xnx, coral_board, snapdragon888)."
+        ),
+    )
+    p.add_argument(
+        "--output",
+        default="results/deployment",
+        metavar="DIR",
+        help="Output directory for the report. Default: %(default)s",
+    )
+    p.add_argument(
+        "--num-sequences",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Number of synthetic sequences to benchmark. Default: %(default)s",
+    )
+    p.add_argument(
+        "--num-frames",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Frames per synthetic sequence. Default: %(default)s",
+    )
+    p.add_argument(
+        "--memory-budget",
+        type=float,
+        default=512.0,
+        metavar="MB",
+        help="Memory budget for EES computation (MB). Default: %(default)s",
+    )
+    p.add_argument(
+        "--sustained",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help=(
+            "Sustained-load duration for thermal throttling model. "
+            "0 = cold-start burst. Default: %(default)s"
+        ),
+    )
+    p.add_argument(
+        "--tdp-watts",
+        type=float,
+        default=None,
+        metavar="W",
+        help=(
+            "Host CPU TDP for energy profiling during benchmarking. "
+            "Omit to disable energy measurement."
+        ),
+    )
+    p.add_argument("--quiet", action="store_true", help="Suppress benchmark progress output.")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    dataset = SyntheticDataset(
+        num_sequences=args.num_sequences,
+        num_frames=args.num_frames,
+        frame_size=(320, 240),
+        bbox_size=(40, 40),
+        motion="linear",
+        seed=42,
+    )
+
+    engine = BenchmarkEngine(verbose=not args.quiet, tdp_watts=args.tdp_watts)
+    bench_results = []
+
+    for name in args.trackers:
+        params = _TRACKER_PARAMS.get(name, {})
+        cfg = {"name": name, "params": params}
+        try:
+            tracker = ExperimentRunner._build_tracker(cfg)
+        except ValueError as exc:
+            print(f"[skip] {exc}", file=sys.stderr)
+            continue
+        result = engine.run(tracker, dataset, dataset_name="Synthetic")
+        bench_results.append(result)
+
+    if not bench_results:
+        print("No valid trackers — exiting.", file=sys.stderr)
+        return 1
+
+    report_engine = DeploymentReportEngine(
+        memory_budget_mb=args.memory_budget,
+        sustained_seconds=args.sustained,
+        device_names=args.devices,
+    )
+    report = report_engine.analyze(bench_results)
+    paths = report_engine.save(report, output_dir=args.output)
+
+    print(f"\nDeployment report written:")
+    for fmt, path in paths.items():
+        print(f"  {fmt}: {path}")
+
+    print("\n" + report_engine.to_markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_deployment_report.py
+++ b/tests/test_deployment_report.py
@@ -1,0 +1,370 @@
+"""Tests for the edge deployment analysis report module."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from eovot.reporting.deployment_report import (
+    DeploymentReport,
+    DeploymentReportEngine,
+    DeviceTrackerEntry,
+    _aggregate_profiling,
+    _device_ees,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _mock_profiling(
+    tracker_name: str = "TestTracker",
+    latency_ms: float = 5.0,
+    fps: float = 200.0,
+    peak_mem: float = 100.0,
+    frame_count: int = 99,
+) -> MagicMock:
+    p = MagicMock()
+    p.tracker_name = tracker_name
+    p.latency_mean_ms = latency_ms
+    p.latency_std_ms = 0.5
+    p.latency_p95_ms = latency_ms + 1.0
+    p.fps = fps
+    p.peak_memory_mb = peak_mem
+    p.frame_count = frame_count
+    return p
+
+
+def _mock_sequence_result(
+    tracker_name: str = "T",
+    latency_ms: float = 5.0,
+    peak_mem: float = 100.0,
+) -> MagicMock:
+    sr = MagicMock()
+    sr.profiling = _mock_profiling(tracker_name, latency_ms, 1000.0 / latency_ms, peak_mem)
+    return sr
+
+
+def _mock_benchmark_result(
+    tracker_name: str = "TestTracker",
+    mean_iou: float = 0.65,
+    mean_fps: float = 200.0,
+    peak_memory_mb: float = 120.0,
+    dataset_name: str = "Synthetic",
+    n_sequences: int = 3,
+) -> MagicMock:
+    br = MagicMock()
+    br.tracker_name = tracker_name
+    br.dataset_name = dataset_name
+    br.mean_iou = mean_iou
+    br.mean_fps = mean_fps
+    br.peak_memory_mb = peak_memory_mb
+    latency_ms = 1000.0 / mean_fps
+    br.sequence_results = [
+        _mock_sequence_result(tracker_name, latency_ms, peak_memory_mb)
+        for _ in range(n_sequences)
+    ]
+    return br
+
+
+# ---------------------------------------------------------------------------
+# _device_ees
+# ---------------------------------------------------------------------------
+
+class TestDeviceEES:
+    def test_positive_values(self):
+        ees = _device_ees(0.7, 100.0, 150.0, 512.0)
+        assert ees > 0
+
+    def test_zero_fps(self):
+        assert _device_ees(0.7, 0.0, 150.0, 512.0) == 0.0
+
+    def test_negative_fps(self):
+        assert _device_ees(0.7, -1.0, 150.0, 512.0) == 0.0
+
+    def test_zero_iou(self):
+        assert _device_ees(0.0, 100.0, 150.0, 512.0) == 0.0
+
+    def test_negative_iou(self):
+        assert _device_ees(-0.1, 100.0, 150.0, 512.0) == 0.0
+
+    def test_memory_penalty(self):
+        ees_within = _device_ees(0.7, 100.0, 200.0, 512.0)
+        ees_over = _device_ees(0.7, 100.0, 1024.0, 512.0)
+        assert ees_within > ees_over
+
+    def test_higher_fps_higher_ees(self):
+        ees_low = _device_ees(0.7, 10.0, 150.0, 512.0)
+        ees_high = _device_ees(0.7, 100.0, 150.0, 512.0)
+        assert ees_high > ees_low
+
+    def test_diminishing_returns(self):
+        # Going from 10→100 FPS should gain more than 1000→1100 FPS
+        gain_low = _device_ees(0.7, 100.0, 100.0, 512.0) - _device_ees(0.7, 10.0, 100.0, 512.0)
+        gain_high = _device_ees(0.7, 1100.0, 100.0, 512.0) - _device_ees(0.7, 1000.0, 100.0, 512.0)
+        assert gain_low > gain_high
+
+    def test_formula_correctness(self):
+        expected = 0.6 * math.log1p(50.0) / (1.0 + 100.0 / 512.0)
+        got = _device_ees(0.6, 50.0, 100.0, 512.0)
+        assert abs(got - expected) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_profiling
+# ---------------------------------------------------------------------------
+
+class TestAggregateProfilering:
+    def test_basic(self):
+        bench = _mock_benchmark_result("T", mean_fps=100.0, peak_memory_mb=150.0, n_sequences=4)
+        result = _aggregate_profiling(bench)
+        assert result.tracker_name == "T"
+        assert result.fps > 0
+        assert result.peak_memory_mb == 150.0
+        assert result.frame_count > 0
+
+    def test_empty_sequences_raises(self):
+        bench = _mock_benchmark_result()
+        bench.sequence_results = []
+        with pytest.raises(ValueError):
+            _aggregate_profiling(bench)
+
+    def test_latency_mean_consistent_with_fps(self):
+        bench = _mock_benchmark_result("T", mean_fps=200.0, n_sequences=2)
+        result = _aggregate_profiling(bench)
+        expected_latency = 1000.0 / result.fps
+        assert abs(result.latency_mean_ms - expected_latency) < 0.01
+
+    def test_grand_p95_above_mean(self):
+        bench = _mock_benchmark_result("T", n_sequences=5)
+        result = _aggregate_profiling(bench)
+        assert result.latency_p95_ms >= result.latency_mean_ms
+
+
+# ---------------------------------------------------------------------------
+# DeploymentReportEngine construction
+# ---------------------------------------------------------------------------
+
+class TestEngineConstruction:
+    def test_default_construction(self):
+        engine = DeploymentReportEngine()
+        assert engine.memory_budget_mb == 512.0
+        assert engine.sustained_seconds == 0.0
+
+    def test_invalid_memory_budget(self):
+        with pytest.raises(ValueError):
+            DeploymentReportEngine(memory_budget_mb=0.0)
+
+    def test_custom_devices(self):
+        engine = DeploymentReportEngine(device_names=["rpi4", "rpi5"])
+        assert engine._device_names == ["rpi4", "rpi5"]
+
+    def test_all_devices_loaded(self):
+        engine = DeploymentReportEngine()
+        # Should include the 6 built-in profiles
+        assert len(engine._device_names) >= 6
+
+
+# ---------------------------------------------------------------------------
+# DeploymentReportEngine.analyze
+# ---------------------------------------------------------------------------
+
+class TestAnalyze:
+    def test_empty_results_raises(self):
+        engine = DeploymentReportEngine()
+        with pytest.raises(ValueError):
+            engine.analyze([])
+
+    def test_single_tracker_single_device(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        bench = _mock_benchmark_result("MOSSE", mean_iou=0.6, mean_fps=500.0, peak_memory_mb=80.0)
+        report = engine.analyze([bench])
+        assert len(report.entries) == 1
+        assert report.entries[0].tracker_name == "MOSSE"
+        assert report.entries[0].device_name == "rpi4"
+
+    def test_entries_count(self):
+        engine = DeploymentReportEngine(device_names=["rpi4", "rpi5"])
+        trackers = [
+            _mock_benchmark_result("A", mean_fps=200.0),
+            _mock_benchmark_result("B", mean_fps=50.0),
+            _mock_benchmark_result("C", mean_fps=10.0),
+        ]
+        report = engine.analyze(trackers)
+        # 3 trackers × 2 devices = 6 entries
+        assert len(report.entries) == 6
+
+    def test_recommendations_populated(self):
+        engine = DeploymentReportEngine(device_names=["rpi4", "rpi5"])
+        trackers = [
+            _mock_benchmark_result("MOSSE", mean_fps=500.0, mean_iou=0.5),
+            _mock_benchmark_result("CSRT", mean_fps=30.0, mean_iou=0.75),
+        ]
+        report = engine.analyze(trackers)
+        assert "rpi4" in report.recommendations
+        assert "rpi5" in report.recommendations
+
+    def test_recommendation_is_in_entries(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        trackers = [
+            _mock_benchmark_result("A", mean_fps=100.0, mean_iou=0.6),
+            _mock_benchmark_result("B", mean_fps=200.0, mean_iou=0.4),
+        ]
+        report = engine.analyze(trackers)
+        rec = report.recommendations["rpi4"]
+        names = [e.tracker_name for e in report.entries_for_device("rpi4")]
+        assert rec in names
+
+    def test_pareto_flags_set(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        trackers = [
+            _mock_benchmark_result("A", mean_fps=500.0, mean_iou=0.3),
+            _mock_benchmark_result("B", mean_fps=30.0, mean_iou=0.8),
+        ]
+        report = engine.analyze(trackers)
+        pareto_entries = [e for e in report.entries if e.on_pareto_front]
+        assert len(pareto_entries) >= 1
+
+    def test_exactly_one_recommendation_per_device(self):
+        engine = DeploymentReportEngine(device_names=["rpi4", "jetson_nano"])
+        trackers = [
+            _mock_benchmark_result("X", mean_fps=200.0),
+            _mock_benchmark_result("Y", mean_fps=100.0),
+        ]
+        report = engine.analyze(trackers)
+        for device in ["rpi4", "jetson_nano"]:
+            is_rec = [e.is_recommended for e in report.entries if e.device_name == device]
+            assert sum(is_rec) == 1
+
+    def test_dataset_name_propagated(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        bench = _mock_benchmark_result(dataset_name="OTB100")
+        report = engine.analyze([bench])
+        assert report.dataset_name == "OTB100"
+
+
+# ---------------------------------------------------------------------------
+# to_markdown
+# ---------------------------------------------------------------------------
+
+class TestToMarkdown:
+    def _make_report(self):
+        engine = DeploymentReportEngine(device_names=["rpi4", "rpi5"])
+        trackers = [
+            _mock_benchmark_result("MOSSE", mean_fps=400.0, mean_iou=0.5),
+            _mock_benchmark_result("KCF", mean_fps=200.0, mean_iou=0.6),
+        ]
+        return engine, engine.analyze(trackers)
+
+    def test_returns_string(self):
+        engine, report = self._make_report()
+        md = engine.to_markdown(report)
+        assert isinstance(md, str)
+
+    def test_contains_tracker_names(self):
+        engine, report = self._make_report()
+        md = engine.to_markdown(report)
+        assert "MOSSE" in md
+        assert "KCF" in md
+
+    def test_contains_device_names(self):
+        engine, report = self._make_report()
+        md = engine.to_markdown(report)
+        assert "Raspberry Pi 4" in md or "rpi4" in md
+
+    def test_recommendation_section_present(self):
+        engine, report = self._make_report()
+        md = engine.to_markdown(report)
+        assert "Recommended Tracker" in md
+
+    def test_markdown_tables_present(self):
+        engine, report = self._make_report()
+        md = engine.to_markdown(report)
+        assert "| Rank |" in md
+
+
+# ---------------------------------------------------------------------------
+# to_dict
+# ---------------------------------------------------------------------------
+
+class TestToDict:
+    def test_structure(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        bench = _mock_benchmark_result("T")
+        report = engine.analyze([bench])
+        d = engine.to_dict(report)
+        assert "metadata" in d
+        assert "recommendations" in d
+        assert "per_device" in d
+
+    def test_metadata_fields(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        bench = _mock_benchmark_result("T", dataset_name="OTB100")
+        report = engine.analyze([bench])
+        meta = engine.to_dict(report)["metadata"]
+        assert meta["dataset"] == "OTB100"
+        assert "memory_budget_mb" in meta
+        assert "devices" in meta
+
+    def test_per_device_has_trackers(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        bench = _mock_benchmark_result("T")
+        report = engine.analyze([bench])
+        d = engine.to_dict(report)
+        assert "rpi4" in d["per_device"]
+        assert len(d["per_device"]["rpi4"]) == 1
+
+    def test_entry_fields(self):
+        engine = DeploymentReportEngine(device_names=["rpi4"])
+        bench = _mock_benchmark_result("T")
+        report = engine.analyze([bench])
+        entry = engine.to_dict(report)["per_device"]["rpi4"][0]
+        required = {
+            "tracker", "mean_iou", "device_fps", "device_latency_ms",
+            "fits_in_memory", "device_ees", "is_recommended",
+        }
+        assert required.issubset(entry.keys())
+
+
+# ---------------------------------------------------------------------------
+# DeploymentReport helpers
+# ---------------------------------------------------------------------------
+
+class TestDeploymentReportHelpers:
+    def _make_report_obj(self):
+        engine = DeploymentReportEngine(device_names=["rpi4", "rpi5"])
+        t = [_mock_benchmark_result("A"), _mock_benchmark_result("B")]
+        return engine.analyze(t)
+
+    def test_entries_for_device(self):
+        report = self._make_report_obj()
+        rpi4 = report.entries_for_device("rpi4")
+        assert all(e.device_name == "rpi4" for e in rpi4)
+
+    def test_entries_for_device_sorted_by_ees(self):
+        report = self._make_report_obj()
+        rpi4 = report.entries_for_device("rpi4")
+        ees_vals = [e.device_ees for e in rpi4]
+        assert ees_vals == sorted(ees_vals, reverse=True)
+
+    def test_entries_for_tracker(self):
+        report = self._make_report_obj()
+        entries = report.entries_for_tracker("A")
+        assert all(e.tracker_name == "A" for e in entries)
+        # Should appear on both devices
+        assert len(entries) == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration: importable from package
+# ---------------------------------------------------------------------------
+
+def test_importable_from_package():
+    from eovot.reporting import DeploymentReportEngine as D
+    assert D is DeploymentReportEngine


### PR DESCRIPTION
## What was added

`DeploymentReportEngine` — closes the loop between `BenchmarkEngine` results and `DeviceSimulator` by projecting **every tracker** onto **every edge device** in a single call and answering the practitioner's core question:

> *"Given these benchmark results, which tracker should I deploy on each of my target devices?"*

### How it works

1. For each `BenchmarkResult`, compute an **aggregate `ProfilingResult`** using weighted mean latency and pooled standard deviation across all sequences.
2. Feed that into `DeviceSimulator.simulate_all` to obtain projected latency, FPS, memory, and energy for all registered devices.
3. Compute a **device-specific EES** using projected FPS instead of host FPS:
   ```
   EES_device = mean_iou × log1p(device_fps) / (1 + mem_mb / budget_mb)
   ```
4. On each device, identify the **Pareto front** in `(mean_iou, device_ees)` space.
5. Flag the memory-feasible tracker with the highest device_ees as the **recommendation** for that device.

### Output

**Markdown** — one ranked table per device + a summary recommendations table:

```
## Raspberry Pi 4B (4 GB) (RAM: 3800 MB)

| Rank | Tracker    | mIoU   | FPS  | Latency (ms) | Mem (MB) | Fits? | EES    | Thermal | mJ/frame | Pareto |
|------|------------|-------:|-----:|-------------:|---------:|:-----:|-------:|---------|----------|:------:|
|    1 | MOSSE ★   | 0.5200 | 63.1 |         15.8 |       95 |  ✓   | 0.6183 | nominal |    0.829 |  ✓    |
|    2 | KCF        | 0.6100 |  9.8 |        102.0 |      105 |  ✓   | 0.5231 | nominal |    5.355 |  ✓    |
```

**JSON** — full structured dict with `metadata`, `recommendations`, and `per_device` entries.

### Why it matters

`DeviceSimulator` already existed but had **no integration with the reporting pipeline**. Without this module, a researcher had to manually loop over trackers, call `sim.simulate_all` for each, and assemble a comparison by hand. `DeploymentReportEngine` makes the complete analysis a two-line call, which is the practical workflow needed for EOVOT's core thesis of hardware-aware benchmarking.

## Files changed

| File | Change |
|------|--------|
| `eovot/reporting/deployment_report.py` | New module — `DeploymentReportEngine`, `DeploymentReport`, `DeviceTrackerEntry`, `_aggregate_profiling`, `_device_ees` |
| `eovot/reporting/__init__.py` | Export new classes |
| `scripts/deployment_analysis.py` | CLI runner (uses synthetic data — no external downloads required) |
| `tests/test_deployment_report.py` | 38 unit tests — all passing |

## Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.datasets.synthetic import SyntheticDataset
from eovot.reporting.deployment_report import DeploymentReportEngine
from eovot.trackers.mosse import MOSSETracker
from eovot.trackers.kcf import KCFTracker

dataset = SyntheticDataset(num_sequences=10, num_frames=100)
engine = BenchmarkEngine(verbose=False)
results = [engine.run(t, dataset) for t in [MOSSETracker(), KCFTracker()]]

report_engine = DeploymentReportEngine(memory_budget_mb=512, sustained_seconds=60)
report = report_engine.analyze(results)
print(report_engine.to_markdown(report))
report_engine.save(report, output_dir="results/deployment")
```

CLI (zero dependencies on external datasets):
```bash
python scripts/deployment_analysis.py \
  --trackers MOSSE KCF CSRT \
  --sustained 60 \
  --output results/deployment
```

## No breaking changes

- Pure addition — no existing classes or APIs modified.
- `DeviceSimulator`, `BenchmarkEngine`, and all reporters remain unchanged.
- All 38 new tests pass; no existing tests broken.


---
_Generated by [Claude Code](https://claude.ai/code/session_019RvZ8vuCLmQ3AqSqqXcPXa)_