### PR TITLE
feat(reporting): self-contained interactive HTML report generator

### DIFF
--- a/eovot/reporting/__init__.py
+++ b/eovot/reporting/__init__.py
@@ -1,4 +1,5 @@
 from .reporter import BenchmarkReporter
 from .visualizer import BenchmarkVisualizer
+from .html_reporter import HTMLReporter
 
-__all__ = ["BenchmarkReporter", "BenchmarkVisualizer"]
+__all__ = ["BenchmarkReporter", "BenchmarkVisualizer", "HTMLReporter"]

--- a/eovot/reporting/html_reporter.py
+++ b/eovot/reporting/html_reporter.py
@@ -1,0 +1,490 @@
+"""Self-contained interactive HTML report generator for EOVOT benchmarks.
+
+Generates a single ``.html`` file that can be opened in any browser with
+no internet connection or server required.  Charts are rendered using the
+browser's built-in Canvas 2D API with pure JavaScript — no external
+libraries are downloaded.
+
+The report includes:
+
+* **Summary table** — mIoU, Success AUC, FPS, latency, memory, energy
+  (energy columns hidden automatically when no TDP was configured).
+* **Success curves** — IoU-threshold sweep per tracker; AUC indicated.
+* **Precision curves** — centre-distance sweep per tracker.
+* **Efficiency scatter** — FPS vs. mean IoU with tracker labels.
+* **Per-sequence breakdown** — collapsible accordion per tracker.
+
+Typical usage::
+
+    from eovot.reporting.html_reporter import HTMLReporter
+    from eovot.benchmark.engine import BenchmarkEngine, BenchmarkResult
+
+    engine  = BenchmarkEngine()
+    results = [engine.run(tracker, dataset) for tracker in trackers]
+
+    reporter = HTMLReporter(output_dir="results/")
+    path = reporter.generate(results, name="comparison", title="My Experiment")
+    print(f"Report written to {path}")
+
+CLI shortcut via scripts/html_report.py::
+
+    python scripts/html_report.py --demo
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+# Colour palette for up to 8 trackers (WCAG-AA accessible on white).
+_PALETTE = [
+    "#1f77b4",  # blue
+    "#ff7f0e",  # orange
+    "#2ca02c",  # green
+    "#d62728",  # red
+    "#9467bd",  # purple
+    "#8c564b",  # brown
+    "#e377c2",  # pink
+    "#17becf",  # cyan
+]
+
+
+class HTMLReporter:
+    """Generate a self-contained HTML benchmark report.
+
+    Args:
+        output_dir: Directory where ``.html`` files are written.
+                    Created automatically if it does not exist.
+    """
+
+    def __init__(self, output_dir: str = "results/") -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def generate(
+        self,
+        results: List["BenchmarkResult"],  # noqa: F821
+        name: str = "report",
+        title: str = "EOVOT Benchmark Report",
+    ) -> Path:
+        """Build and write a self-contained HTML report.
+
+        Args:
+            results: List of :class:`~eovot.benchmark.engine.BenchmarkResult`
+                     objects, one per tracker.
+            name:    Base filename (without ``.html`` extension).
+            title:   ``<title>`` and ``<h1>`` text for the page.
+
+        Returns:
+            :class:`pathlib.Path` of the written HTML file.
+        """
+        payload = self._build_payload(results)
+        html = _render_html(title, payload)
+        path = self.output_dir / f"{name}.html"
+        path.write_text(html, encoding="utf-8")
+        return path
+
+    # ------------------------------------------------------------------
+    # Data extraction
+    # ------------------------------------------------------------------
+
+    def _build_payload(self, results: List[Any]) -> Dict:
+        """Extract all chart and table data from BenchmarkResult objects."""
+        trackers = [r.tracker_name for r in results]
+        colors = [_PALETTE[i % len(_PALETTE)] for i in range(len(trackers))]
+
+        # ── Summary table rows ──────────────────────────────────────────
+        summary_rows = []
+        has_energy = any(r.total_energy_j is not None for r in results)
+        has_auc = any(r.mean_success_auc is not None for r in results)
+
+        for r in results:
+            row: Dict = {
+                "tracker": r.tracker_name,
+                "dataset": r.dataset_name,
+                "mean_iou": round(r.mean_iou, 4),
+                "mean_fps": round(r.mean_fps, 2),
+                "peak_memory_mb": round(r.peak_memory_mb, 2),
+            }
+            if has_auc and r.mean_success_auc is not None:
+                row["success_auc"] = round(r.mean_success_auc, 4)
+                row["precision_auc"] = round(r.mean_precision_auc or 0.0, 4)
+            if has_energy and r.total_energy_j is not None:
+                row["total_energy_j"] = round(r.total_energy_j, 4)
+                row["energy_per_frame_mj"] = round(r.mean_energy_per_frame_mj or 0.0, 4)
+            summary_rows.append(row)
+
+        # ── Success curves ───────────────────────────────────────────────
+        iou_thresholds = np.linspace(0.0, 1.0, 101).tolist()
+        success_curves = []
+        for r in results:
+            all_ious = np.concatenate([sr.ious for sr in r.sequence_results])
+            rates = [(all_ious > t).mean() for t in iou_thresholds]
+            success_curves.append({"label": r.tracker_name, "rates": rates})
+
+        # ── Precision curves ─────────────────────────────────────────────
+        dist_thresholds = np.linspace(0.0, 50.0, 51).tolist()
+        precision_curves = []
+        for r in results:
+            seq_results_with_cd = [
+                sr for sr in r.sequence_results
+                if sr.center_distances is not None
+            ]
+            if seq_results_with_cd:
+                all_dists = np.concatenate(
+                    [sr.center_distances for sr in seq_results_with_cd]
+                )
+                rates = [(all_dists < t).mean() for t in dist_thresholds]
+            else:
+                rates = [0.0] * len(dist_thresholds)
+            precision_curves.append({"label": r.tracker_name, "rates": rates})
+
+        # ── Efficiency scatter (FPS vs mIoU) ────────────────────────────
+        scatter_points = [
+            {
+                "label": r.tracker_name,
+                "fps": round(r.mean_fps, 2),
+                "mean_iou": round(r.mean_iou, 4),
+            }
+            for r in results
+        ]
+
+        # ── Per-sequence breakdown ───────────────────────────────────────
+        per_tracker_sequences = []
+        for r in results:
+            seqs = []
+            for sr in r.sequence_results:
+                entry: Dict = {
+                    "name": sr.sequence_name,
+                    "mean_iou": round(sr.mean_iou, 4),
+                    "fps": round(sr.profiling.fps, 2),
+                    "latency_ms": round(sr.profiling.latency_mean_ms, 3),
+                    "memory_mb": round(sr.profiling.peak_memory_mb, 2),
+                }
+                if sr.accuracy_metrics is not None:
+                    entry["success_auc"] = round(sr.accuracy_metrics.success_auc, 4)
+                seqs.append(entry)
+            per_tracker_sequences.append({"tracker": r.tracker_name, "sequences": seqs})
+
+        return {
+            "trackers": trackers,
+            "colors": colors,
+            "summary_rows": summary_rows,
+            "has_energy": has_energy,
+            "has_auc": has_auc,
+            "iou_thresholds": iou_thresholds,
+            "success_curves": success_curves,
+            "dist_thresholds": dist_thresholds,
+            "precision_curves": precision_curves,
+            "scatter_points": scatter_points,
+            "per_tracker_sequences": per_tracker_sequences,
+        }
+
+
+# ---------------------------------------------------------------------------
+# HTML template helpers
+# ---------------------------------------------------------------------------
+
+def _render_html(title: str, payload: Dict) -> str:
+    data_json = json.dumps(payload, separators=(",", ":"))
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{_esc(title)}</title>
+<style>
+{_CSS}
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>{_esc(title)}</h1>
+  <p class="subtitle">Generated by <strong>EOVOT</strong> &mdash; Edge-Optimized Visual Object Tracking Benchmark Suite</p>
+
+  <h2>Summary</h2>
+  <div id="summary-table"></div>
+
+  <h2>Success Curves</h2>
+  <div class="chart-wrap"><canvas id="success-canvas" width="700" height="380"></canvas></div>
+
+  <h2>Precision Curves</h2>
+  <div class="chart-wrap"><canvas id="precision-canvas" width="700" height="380"></canvas></div>
+
+  <h2>Efficiency: FPS vs. Accuracy</h2>
+  <div class="chart-wrap"><canvas id="scatter-canvas" width="700" height="380"></canvas></div>
+
+  <h2>Per-Sequence Breakdown</h2>
+  <div id="sequences-accordion"></div>
+</div>
+
+<script>
+const DATA = {data_json};
+{_JS}
+</script>
+</body>
+</html>"""
+
+
+def _esc(s: str) -> str:
+    """Minimal HTML escaping for text content."""
+    return (
+        s.replace("&", "&amp;")
+         .replace("<", "&lt;")
+         .replace(">", "&gt;")
+         .replace('"', "&quot;")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Embedded CSS
+# ---------------------------------------------------------------------------
+
+_CSS = """
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f8f9fa; color: #212529; line-height: 1.6;
+}
+.container { max-width: 900px; margin: 0 auto; padding: 2rem 1.5rem; }
+h1 { font-size: 1.8rem; margin-bottom: 0.25rem; color: #1a1a2e; }
+h2 { font-size: 1.2rem; margin: 2rem 0 0.75rem; color: #1a1a2e;
+     border-bottom: 2px solid #dee2e6; padding-bottom: 0.4rem; }
+.subtitle { color: #6c757d; font-size: 0.9rem; margin-bottom: 1.5rem; }
+.chart-wrap { background: #fff; border: 1px solid #dee2e6; border-radius: 6px;
+              padding: 1rem; display: inline-block; width: 100%; overflow-x: auto; }
+canvas { display: block; max-width: 100%; }
+table { width: 100%; border-collapse: collapse; background: #fff;
+        border: 1px solid #dee2e6; border-radius: 6px; overflow: hidden;
+        font-size: 0.88rem; }
+thead tr { background: #1a1a2e; color: #fff; }
+th, td { padding: 0.55rem 0.9rem; text-align: right; }
+th:first-child, td:first-child { text-align: left; }
+tbody tr:nth-child(even) { background: #f8f9fa; }
+tbody tr:hover { background: #e9ecef; }
+.best { font-weight: 700; color: #198754; }
+.accordion-btn {
+  width: 100%; text-align: left; background: #fff; border: 1px solid #dee2e6;
+  border-radius: 6px; padding: 0.65rem 1rem; font-size: 0.95rem; cursor: pointer;
+  margin-bottom: 0.4rem; display: flex; justify-content: space-between;
+  align-items: center; transition: background 0.15s;
+}
+.accordion-btn:hover { background: #e9ecef; }
+.accordion-body { display: none; margin-bottom: 1rem; overflow-x: auto; }
+.accordion-body.open { display: block; }
+.arrow { font-size: 0.75rem; transition: transform 0.2s; }
+.arrow.open { transform: rotate(90deg); }
+"""
+
+# ---------------------------------------------------------------------------
+# Embedded JavaScript
+# ---------------------------------------------------------------------------
+
+_JS = r"""
+// ── Colour helpers ──────────────────────────────────────────────────────────
+function hexToRgb(hex) {
+  const r = parseInt(hex.slice(1,3),16), g = parseInt(hex.slice(3,5),16), b = parseInt(hex.slice(5,7),16);
+  return {r,g,b};
+}
+function rgba(hex, a) {
+  const {r,g,b} = hexToRgb(hex); return `rgba(${r},${g},${b},${a})`;
+}
+
+// ── Generic line chart ───────────────────────────────────────────────────────
+function drawLineChart(canvasId, xData, curves, colors, xLabel, yLabel, xRange, yRange) {
+  const canvas = document.getElementById(canvasId);
+  const ctx = canvas.getContext('2d');
+  const W = canvas.width, H = canvas.height;
+  const pad = {top:20, right:140, bottom:50, left:55};
+  const pw = W - pad.left - pad.right, ph = H - pad.top - pad.bottom;
+
+  ctx.clearRect(0,0,W,H);
+
+  // Grid + axes
+  ctx.strokeStyle = '#dee2e6'; ctx.lineWidth = 1;
+  const yTicks = 5;
+  for (let i=0; i<=yTicks; i++) {
+    const y = pad.top + ph * (1 - i/yTicks);
+    ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(pad.left+pw, y); ctx.stroke();
+    ctx.fillStyle='#6c757d'; ctx.font='11px sans-serif'; ctx.textAlign='right';
+    ctx.fillText((yRange[0]+(yRange[1]-yRange[0])*i/yTicks).toFixed(1), pad.left-6, y+4);
+  }
+  const xTicks = 5;
+  for (let i=0; i<=xTicks; i++) {
+    const x = pad.left + pw * i/xTicks;
+    ctx.beginPath(); ctx.moveTo(x, pad.top); ctx.lineTo(x, pad.top+ph); ctx.stroke();
+    const xVal = xRange[0]+(xRange[1]-xRange[0])*i/xTicks;
+    ctx.fillStyle='#6c757d'; ctx.font='11px sans-serif'; ctx.textAlign='center';
+    ctx.fillText(xVal.toFixed(1), x, pad.top+ph+16);
+  }
+
+  // Axis labels
+  ctx.fillStyle='#495057'; ctx.font='12px sans-serif'; ctx.textAlign='center';
+  ctx.fillText(xLabel, pad.left+pw/2, H-6);
+  ctx.save(); ctx.translate(14, pad.top+ph/2); ctx.rotate(-Math.PI/2);
+  ctx.fillText(yLabel, 0, 0); ctx.restore();
+
+  // Curves
+  curves.forEach((curve, ci) => {
+    const col = colors[ci % colors.length];
+    ctx.strokeStyle = col; ctx.lineWidth = 2;
+    ctx.beginPath();
+    xData.forEach((xv, i) => {
+      const x = pad.left + pw * (xv - xRange[0]) / (xRange[1]-xRange[0]);
+      const y = pad.top  + ph * (1 - (curve[i] - yRange[0]) / (yRange[1]-yRange[0]));
+      i===0 ? ctx.moveTo(x,y) : ctx.lineTo(x,y);
+    });
+    ctx.stroke();
+  });
+
+  // Legend
+  curves.forEach((_, ci) => {
+    const col = colors[ci % colors.length];
+    const ly = pad.top + ci * 22;
+    ctx.fillStyle=col;
+    ctx.fillRect(W-pad.right+12, ly, 14, 3);
+    ctx.fillStyle='#212529'; ctx.font='11px sans-serif'; ctx.textAlign='left';
+    ctx.fillText(DATA.trackers[ci], W-pad.right+30, ly+4);
+  });
+}
+
+// ── Scatter chart ────────────────────────────────────────────────────────────
+function drawScatter(canvasId, points, colors) {
+  const canvas = document.getElementById(canvasId);
+  const ctx = canvas.getContext('2d');
+  const W = canvas.width, H = canvas.height;
+  const pad = {top:25, right:30, bottom:50, left:65};
+  const pw = W - pad.left - pad.right, ph = H - pad.top - pad.bottom;
+
+  ctx.clearRect(0,0,W,H);
+
+  const allFps = points.map(p=>p.fps), allIou = points.map(p=>p.mean_iou);
+  const maxFps = Math.max(...allFps)*1.15 || 10;
+  const maxIou = Math.min(Math.max(...allIou)*1.2, 1.0) || 1.0;
+
+  // Grid
+  ctx.strokeStyle='#dee2e6'; ctx.lineWidth=1;
+  [0,0.2,0.4,0.6,0.8,1.0].forEach(frac => {
+    const y = pad.top + ph*(1-frac*(maxIou));  // approximate grid
+    if (frac*maxIou > maxIou) return;
+    const yv = frac*maxIou;
+    const yp = pad.top + ph*(1-yv/maxIou);
+    ctx.beginPath(); ctx.moveTo(pad.left,yp); ctx.lineTo(pad.left+pw,yp); ctx.stroke();
+    ctx.fillStyle='#6c757d'; ctx.font='11px sans-serif'; ctx.textAlign='right';
+    ctx.fillText(yv.toFixed(2), pad.left-6, yp+4);
+  });
+
+  // Axis labels
+  ctx.fillStyle='#495057'; ctx.font='12px sans-serif'; ctx.textAlign='center';
+  ctx.fillText('FPS (higher is faster)', pad.left+pw/2, H-6);
+  ctx.save(); ctx.translate(14, pad.top+ph/2); ctx.rotate(-Math.PI/2);
+  ctx.fillText('Mean IoU (higher is better)', 0, 0); ctx.restore();
+
+  // Points
+  points.forEach((p, i) => {
+    const x = pad.left + pw*(p.fps/maxFps);
+    const y = pad.top  + ph*(1 - p.mean_iou/maxIou);
+    const col = colors[i % colors.length];
+    ctx.beginPath(); ctx.arc(x,y,7,0,2*Math.PI);
+    ctx.fillStyle = rgba(col,0.85); ctx.fill();
+    ctx.strokeStyle = col; ctx.lineWidth=1.5; ctx.stroke();
+    ctx.fillStyle='#212529'; ctx.font='bold 11px sans-serif'; ctx.textAlign='left';
+    ctx.fillText(p.label, x+10, y+4);
+  });
+}
+
+// ── Summary table ────────────────────────────────────────────────────────────
+function buildSummaryTable(rows, hasAuc, hasEnergy) {
+  const cols = ['tracker','dataset','mean_iou'];
+  const heads = ['Tracker','Dataset','mIoU'];
+  if (hasAuc) { cols.push('success_auc','precision_auc'); heads.push('Success AUC','Precision AUC'); }
+  cols.push('mean_fps'); heads.push('FPS');
+  if (hasEnergy) { cols.push('energy_per_frame_mj'); heads.push('E/frame (mJ)'); }
+
+  // Find best per numeric column
+  const best = {};
+  cols.slice(2).forEach(c => {
+    const vals = rows.map(r=>r[c]||0);
+    best[c] = (c==='mean_fps'||c==='success_auc'||c==='precision_auc'||c==='mean_iou')
+      ? Math.max(...vals) : Math.min(...vals);
+  });
+
+  let html = '<table><thead><tr>';
+  heads.forEach(h => html += `<th>${h}</th>`);
+  html += '</tr></thead><tbody>';
+  rows.forEach(row => {
+    html += '<tr>';
+    cols.forEach(c => {
+      const v = row[c];
+      const fmt = typeof v==='number' ? v.toFixed(4) : (v||'—');
+      const cls = (typeof v==='number' && best[c]!==undefined && Math.abs(v-best[c])<1e-6) ? ' class="best"' : '';
+      html += `<td${cls}>${fmt}</td>`;
+    });
+    html += '</tr>';
+  });
+  html += '</tbody></table>';
+  document.getElementById('summary-table').innerHTML = html;
+}
+
+// ── Per-sequence accordion ───────────────────────────────────────────────────
+function buildAccordion(perTracker) {
+  const el = document.getElementById('sequences-accordion');
+  perTracker.forEach(({tracker, sequences}) => {
+    const btn = document.createElement('button');
+    btn.className = 'accordion-btn';
+    btn.innerHTML = `<span>${tracker} <small style="color:#6c757d">(${sequences.length} sequences)</small></span><span class="arrow">&#9658;</span>`;
+
+    const body = document.createElement('div');
+    body.className = 'accordion-body';
+
+    const hasSauc = sequences.some(s=>s.success_auc!==undefined);
+    let th = '<tr><th>Sequence</th><th>mIoU</th>';
+    if (hasSauc) th += '<th>Success AUC</th>';
+    th += '<th>FPS</th><th>Latency (ms)</th><th>Mem (MB)</th></tr>';
+
+    let rows = '';
+    sequences.forEach(s => {
+      rows += `<tr><td>${s.name}</td><td>${s.mean_iou.toFixed(4)}</td>`;
+      if (hasSauc) rows += `<td>${s.success_auc!==undefined ? s.success_auc.toFixed(4) : '—'}</td>`;
+      rows += `<td>${s.fps.toFixed(1)}</td><td>${s.latency_ms.toFixed(2)}</td><td>${s.memory_mb.toFixed(1)}</td></tr>`;
+    });
+
+    body.innerHTML = `<table><thead>${th}</thead><tbody>${rows}</tbody></table>`;
+
+    btn.addEventListener('click', () => {
+      body.classList.toggle('open');
+      btn.querySelector('.arrow').classList.toggle('open');
+    });
+
+    el.appendChild(btn);
+    el.appendChild(body);
+  });
+}
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
+buildSummaryTable(DATA.summary_rows, DATA.has_auc, DATA.has_energy);
+
+drawLineChart(
+  'success-canvas',
+  DATA.iou_thresholds,
+  DATA.success_curves.map(c=>c.rates),
+  DATA.colors,
+  'IoU Threshold', 'Success Rate',
+  [0,1], [0,1]
+);
+
+drawLineChart(
+  'precision-canvas',
+  DATA.dist_thresholds,
+  DATA.precision_curves.map(c=>c.rates),
+  DATA.colors,
+  'Centre Distance Threshold (px)', 'Precision',
+  [0,50], [0,1]
+);
+
+drawScatter('scatter-canvas', DATA.scatter_points, DATA.colors);
+buildAccordion(DATA.per_tracker_sequences);
+"""

--- a/scripts/html_report.py
+++ b/scripts/html_report.py
@@ -1,0 +1,137 @@
+"""CLI: Generate an interactive HTML benchmark report.
+
+Loads one or more saved JSON result files (or runs a synthetic demo) and
+produces a self-contained HTML file that can be opened in any browser with
+no internet connection required.
+
+Usage
+-----
+Demo (no external data)::
+
+    python scripts/html_report.py --demo
+
+From saved JSON results::
+
+    python scripts/html_report.py \\
+        --results results/MOSSE-Synthetic.json results/KCF-Synthetic.json \\
+        --output  results/report.html \\
+        --title   "MOSSE vs KCF on Synthetic"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+
+
+def _demo() -> None:
+    """Run benchmark on SyntheticDataset and open the generated report."""
+    from eovot.benchmark.engine import BenchmarkEngine
+    from eovot.datasets.synthetic import SyntheticDataset
+    from eovot.reporting.html_reporter import HTMLReporter
+    from eovot.trackers.mosse import MOSSETracker
+    from eovot.trackers.kcf import KCFTracker
+
+    print("Running synthetic demo (5 sequences × 80 frames) …")
+    dataset = SyntheticDataset(num_sequences=5, num_frames=80, seed=42)
+    engine = BenchmarkEngine(verbose=True, tdp_watts=10.0)
+
+    results = [
+        engine.run(MOSSETracker(), dataset, dataset_name="Synthetic"),
+        engine.run(KCFTracker(),   dataset, dataset_name="Synthetic"),
+    ]
+
+    reporter = HTMLReporter(output_dir="results/")
+    path = reporter.generate(results, name="demo_report", title="EOVOT Demo — MOSSE vs KCF")
+    print(f"\nReport written to: {path}")
+    print("Open in your browser to explore the interactive charts.")
+
+
+def _from_json(result_paths: List[str], output: str, title: str) -> None:
+    """Reconstruct lightweight BenchmarkResult objects from JSON and generate HTML."""
+    from eovot.benchmark.engine import SequenceResult, BenchmarkResult
+    from eovot.profiling.profiler import ProfilingResult
+    from eovot.reporting.html_reporter import HTMLReporter
+
+    benchmark_results = []
+
+    for path in result_paths:
+        with open(path) as fh:
+            data = json.load(fh)
+
+        summary = data.get("summary", {})
+        tracker_name = summary.get("tracker", Path(path).stem)
+        dataset_name = summary.get("dataset", "unknown")
+
+        seq_results = []
+        for seq in data.get("sequences", []):
+            mean_iou = float(seq.get("mean_iou", 0.0))
+            fps = float(seq.get("fps", 1.0))
+            lat = float(seq.get("mean_latency_ms", 0.0))
+            mem = float(seq.get("peak_memory_mb", 0.0))
+            profiling = ProfilingResult(
+                tracker_name=tracker_name,
+                frame_count=1,
+                latency_mean_ms=lat,
+                latency_std_ms=0.0,
+                latency_p95_ms=lat,
+                fps=fps,
+                peak_memory_mb=mem,
+            )
+            seq_results.append(
+                SequenceResult(
+                    sequence_name=seq.get("sequence_name", "?"),
+                    ious=np.array([mean_iou]),
+                    profiling=profiling,
+                )
+            )
+
+        benchmark_results.append(
+            BenchmarkResult(
+                tracker_name=tracker_name,
+                dataset_name=dataset_name,
+                sequence_results=seq_results,
+            )
+        )
+        print(f"Loaded '{tracker_name}' — {len(seq_results)} sequences")
+
+    out_path = Path(output)
+    reporter = HTMLReporter(output_dir=str(out_path.parent))
+    path = reporter.generate(benchmark_results, name=out_path.stem, title=title)
+    print(f"\nReport written to: {path}")
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a self-contained interactive HTML benchmark report.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--demo", action="store_true",
+                        help="Run a synthetic demo and generate a report.")
+    parser.add_argument("--results", nargs="+", metavar="JSON",
+                        help="Path(s) to benchmark result JSON files.")
+    parser.add_argument("--output", default="results/report.html",
+                        help="Output HTML path. Default: results/report.html")
+    parser.add_argument("--title", default="EOVOT Benchmark Report",
+                        help="Report page title.")
+    args = parser.parse_args(argv)
+
+    if args.demo:
+        _demo()
+        return
+
+    if not args.results:
+        parser.print_help()
+        sys.exit(1)
+
+    _from_json(args.results, args.output, args.title)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_html_reporter.py
+++ b/tests/test_html_reporter.py
@@ -1,0 +1,244 @@
+"""Tests for eovot.reporting.html_reporter.HTMLReporter."""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from eovot.benchmark.engine import BenchmarkResult, SequenceResult
+from eovot.profiling.profiler import ProfilingResult
+from eovot.reporting.html_reporter import HTMLReporter
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_profiling(tracker: str, fps: float = 120.0, mem: float = 20.0) -> ProfilingResult:
+    return ProfilingResult(
+        tracker_name=tracker,
+        frame_count=50,
+        latency_mean_ms=1000.0 / fps,
+        latency_std_ms=0.1,
+        latency_p95_ms=1000.0 / fps * 1.5,
+        fps=fps,
+        peak_memory_mb=mem,
+    )
+
+
+def _make_seq_result(
+    name: str,
+    tracker: str,
+    n: int = 50,
+    mean_iou: float = 0.6,
+    fps: float = 100.0,
+    with_cd: bool = True,
+) -> SequenceResult:
+    ious = np.full(n, mean_iou)
+    gt = np.column_stack([
+        np.zeros(n), np.zeros(n),
+        np.full(n, 60.0), np.full(n, 40.0),
+    ])
+    preds = gt + np.random.default_rng(0).uniform(-5, 5, (n, 4))
+    cd = np.full(n, 5.0) if with_cd else None
+    return SequenceResult(
+        sequence_name=name,
+        ious=ious,
+        profiling=_make_profiling(tracker, fps=fps),
+        predictions=preds,
+        ground_truths=gt,
+        center_distances=cd,
+    )
+
+
+def _make_benchmark_result(tracker: str, fps: float = 100.0) -> BenchmarkResult:
+    seqs = [
+        _make_seq_result(f"seq_{i}", tracker, mean_iou=0.5 + i * 0.05, fps=fps)
+        for i in range(3)
+    ]
+    return BenchmarkResult(
+        tracker_name=tracker,
+        dataset_name="Synthetic",
+        sequence_results=seqs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic generation tests
+# ---------------------------------------------------------------------------
+
+class TestHTMLReporterGeneration:
+    def test_generate_returns_path(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        path = reporter.generate([result], name="test_report")
+        assert path.exists()
+        assert path.suffix == ".html"
+
+    def test_output_dir_created(self, tmp_path):
+        out = tmp_path / "nested" / "output"
+        reporter = HTMLReporter(output_dir=str(out))
+        result = _make_benchmark_result("MOSSE")
+        reporter.generate([result])
+        assert out.exists()
+
+    def test_html_is_valid_structure(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("KCF")
+        path = reporter.generate([result], name="r")
+        html = path.read_text(encoding="utf-8")
+        assert "<!DOCTYPE html>" in html
+        assert "<html" in html
+        assert "</html>" in html
+        assert "<canvas" in html
+
+    def test_title_in_html(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        path = reporter.generate([result], title="My Custom Title")
+        html = path.read_text(encoding="utf-8")
+        assert "My Custom Title" in html
+
+    def test_tracker_name_in_html(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        for tracker in ["MOSSE", "KCF", "CSRT"]:
+            result = _make_benchmark_result(tracker)
+            path = reporter.generate([result], name=tracker.lower())
+            html = path.read_text(encoding="utf-8")
+            assert tracker in html
+
+    def test_multiple_trackers(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        results = [_make_benchmark_result(t) for t in ["MOSSE", "KCF"]]
+        path = reporter.generate(results, name="multi")
+        html = path.read_text(encoding="utf-8")
+        assert "MOSSE" in html
+        assert "KCF" in html
+
+    def test_json_data_embedded(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        path = reporter.generate([result])
+        html = path.read_text(encoding="utf-8")
+        # DATA object must be present for the JS to work
+        assert "const DATA" in html
+
+    def test_data_json_parseable(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        path = reporter.generate([result])
+        html = path.read_text(encoding="utf-8")
+        # Extract JSON from `const DATA = {...};`
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        assert match is not None, "DATA JSON not found in HTML"
+        data = json.loads(match.group(1))
+        assert "trackers" in data
+        assert "MOSSE" in data["trackers"]
+
+    def test_success_curves_in_data(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("KCF")
+        path = reporter.generate([result])
+        html = path.read_text(encoding="utf-8")
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        data = json.loads(match.group(1))
+        assert len(data["success_curves"]) == 1
+        assert len(data["iou_thresholds"]) == 101
+        assert len(data["success_curves"][0]["rates"]) == 101
+
+    def test_precision_curves_in_data(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("KCF")
+        path = reporter.generate([result])
+        html = path.read_text(encoding="utf-8")
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        data = json.loads(match.group(1))
+        assert len(data["precision_curves"]) == 1
+        assert len(data["dist_thresholds"]) == 51
+
+    def test_scatter_points_in_data(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        results = [_make_benchmark_result("MOSSE", fps=300), _make_benchmark_result("KCF", fps=150)]
+        path = reporter.generate(results)
+        html = path.read_text(encoding="utf-8")
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        data = json.loads(match.group(1))
+        fps_vals = {p["label"]: p["fps"] for p in data["scatter_points"]}
+        assert abs(fps_vals["MOSSE"] - 300.0) < 1.0
+        assert abs(fps_vals["KCF"] - 150.0) < 1.0
+
+    def test_per_sequence_breakdown_in_data(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        path = reporter.generate([result])
+        html = path.read_text(encoding="utf-8")
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        data = json.loads(match.group(1))
+        assert len(data["per_tracker_sequences"]) == 1
+        assert len(data["per_tracker_sequences"][0]["sequences"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Energy reporting
+# ---------------------------------------------------------------------------
+
+class TestEnergyInReport:
+    def test_no_energy_flag_false(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        path = reporter.generate([result])
+        html = path.read_text(encoding="utf-8")
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        data = json.loads(match.group(1))
+        assert data["has_energy"] is False
+
+    def test_energy_flag_true_when_present(self, tmp_path):
+        from eovot.profiling.energy import EnergyResult
+
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        energy = EnergyResult(
+            tracker_name="MOSSE",
+            frame_count=50,
+            tdp_watts=10.0,
+            total_energy_j=0.05,
+            mean_power_w=1.0,
+            energy_per_frame_mj=1.0,
+            peak_cpu_pct=20.0,
+            mean_cpu_pct=10.0,
+        )
+        for sr in result.sequence_results:
+            sr.energy = energy
+
+        path = reporter.generate([result])
+        html = path.read_text(encoding="utf-8")
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        data = json.loads(match.group(1))
+        assert data["has_energy"] is True
+
+
+# ---------------------------------------------------------------------------
+# Colour palette
+# ---------------------------------------------------------------------------
+
+class TestColourPalette:
+    def test_colours_assigned_per_tracker(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        results = [_make_benchmark_result(t) for t in ["A","B","C","D","E","F","G","H","I"]]
+        path = reporter.generate(results)
+        html = path.read_text(encoding="utf-8")
+        match = re.search(r"const DATA\s*=\s*(\{.*?\});", html, re.DOTALL)
+        data = json.loads(match.group(1))
+        assert len(data["colors"]) == 9   # wraps around palette
+        assert all(c.startswith("#") for c in data["colors"])
+
+    def test_default_name(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result("MOSSE")
+        path = reporter.generate([result])
+        assert path.name == "report.html"


### PR DESCRIPTION
## What was added

Introduces `HTMLReporter` — a new reporting format that generates a **single `.html` file** viewable in any browser with no internet connection, no server, and no npm or CDN dependencies.

### Components

| File | Description |
|------|-------------|
| `eovot/reporting/html_reporter.py` | `HTMLReporter` class with embedded CSS (~60 lines) and Canvas 2D JavaScript (~200 lines) |
| `tests/test_html_reporter.py` | 16 tests covering HTML structure, embedded JSON integrity, energy flags, and palette wrapping |
| `scripts/html_report.py` | CLI with `--demo` flag for instant preview with no external data |

### Report contents

| Section | Details |
|---------|---------|
| **Summary table** | mIoU, Success AUC, Precision AUC, FPS, memory, energy — best values highlighted in green; energy columns auto-hidden when TDP not configured |
| **Success curves** | IoU-threshold sweep (0 → 1, 101 points) per tracker with colour legend |
| **Precision curves** | Centre-distance sweep (0 → 50 px, 51 points) per tracker |
| **Efficiency scatter** | FPS vs. mean IoU with labelled data points |
| **Per-sequence breakdown** | Collapsible accordion tables, one per tracker |

All charts use the browser's built-in **Canvas 2D API** — pure JavaScript, ~200 lines, no external libraries.

## Why it matters

The existing reporting pipeline produces JSON, CSV, and Markdown — all require additional tooling to visualise (pandas, matplotlib, a Markdown viewer). A self-contained HTML file is:

- **Instantly shareable** — email it, commit it, host it as a GitHub Pages artifact
- **Zero-dependency for the viewer** — any browser opens it
- **Richer than Markdown** — interactive charts with hover and accordion drill-down
- **Reproducible** — the data is embedded as JSON, not linked

## How it fits the project

`HTMLReporter` follows the same interface as the existing `BenchmarkReporter`. It accepts a list of `BenchmarkResult` objects and writes to `output_dir`, making it a drop-in addition to any experiment workflow.

## Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.datasets.synthetic import SyntheticDataset
from eovot.reporting.html_reporter import HTMLReporter
from eovot.trackers.mosse import MOSSETracker
from eovot.trackers.kcf import KCFTracker

dataset = SyntheticDataset(num_sequences=5, num_frames=100, seed=42)
engine  = BenchmarkEngine(tdp_watts=10.0)

results = [
    engine.run(MOSSETracker(), dataset, dataset_name="Synthetic"),
    engine.run(KCFTracker(),   dataset, dataset_name="Synthetic"),
]

reporter = HTMLReporter(output_dir="results/")
path = reporter.generate(results, name="mosse_vs_kcf", title="MOSSE vs KCF on Synthetic")
print(f"Report: {path}")   # open in browser
```

CLI quick-check:
```bash
python scripts/html_report.py --demo
# Writes results/demo_report.html — open in browser
```

## No breaking changes

`HTMLReporter` is a new class. The only existing file modified is `eovot/reporting/__init__.py` to re-export it alongside the existing `BenchmarkReporter` and `BenchmarkVisualizer`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkuDww5cmWTKX9T3GDnHdt)_