### PR TITLE
[feat] Add SequenceDifficulty analyzer for GT-based sequence characterization

### DIFF
--- a/eovot/datasets/__init__.py
+++ b/eovot/datasets/__init__.py
@@ -2,6 +2,7 @@ from .base import BBox, Sequence, BaseDataset, OTBDataset
 from .got10k import GOT10kDataset
 from .lasot import LaSOTDataset
 from .synthetic import SyntheticDataset
+from .difficulty import DifficultyAnalyzer, SequenceDifficulty
 
 __all__ = [
     "BBox",
@@ -11,4 +12,6 @@ __all__ = [
     "GOT10kDataset",
     "LaSOTDataset",
     "SyntheticDataset",
+    "DifficultyAnalyzer",
+    "SequenceDifficulty",
 ]

--- a/eovot/datasets/difficulty.py
+++ b/eovot/datasets/difficulty.py
@@ -1,0 +1,286 @@
+"""Sequence difficulty analysis for EOVOT datasets.
+
+Provides tools to characterize tracking sequences by difficulty attributes
+derived entirely from ground-truth annotations — no frame decoding required.
+
+Difficulty dimensions
+---------------------
+- **motion_speed**: Mean per-frame centroid displacement (px/frame).  High
+  values indicate fast-moving targets that outpace slower trackers.
+- **scale_variation**: Std-dev of relative bounding-box area change between
+  consecutive frames.  High values indicate targets that zoom in/out.
+- **aspect_ratio_change**: Std-dev of width/height ratio across all frames.
+  Indicates non-rigid or rotating targets.
+- **out_of_view_ratio**: Fraction of frames where the GT centroid is within
+  ``boundary_margin`` pixels of the frame edge (or outside it).  Requires
+  the caller to supply ``frame_size``; returns 0.0 otherwise.
+- **overall_score**: Normalised composite score in [0, 1] (higher = harder),
+  combining the four attributes with configurable weights via a soft-sigmoid
+  saturation model so no single extreme outlier dominates.
+
+Usage::
+
+    from eovot.datasets.difficulty import DifficultyAnalyzer
+    from eovot.datasets.synthetic import SyntheticDataset
+
+    ds = SyntheticDataset(num_sequences=5, motion="random")
+    analyzer = DifficultyAnalyzer(frame_size=(320, 240))
+    for seq in ds:
+        d = analyzer.analyze(seq)
+        print(seq.name, f"score={d.overall_score:.3f}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .base import BaseDataset, Sequence
+
+
+@dataclass
+class SequenceDifficulty:
+    """Difficulty attributes for a single tracking sequence.
+
+    All numeric fields are Python floats for easy JSON serialisation.
+    """
+
+    name: str
+    num_frames: int
+    motion_speed: float
+    scale_variation: float
+    aspect_ratio_change: float
+    out_of_view_ratio: float
+    overall_score: float
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a JSON-serialisable dict representation."""
+        return {
+            "name": self.name,
+            "num_frames": self.num_frames,
+            "motion_speed": round(self.motion_speed, 4),
+            "scale_variation": round(self.scale_variation, 4),
+            "aspect_ratio_change": round(self.aspect_ratio_change, 4),
+            "out_of_view_ratio": round(self.out_of_view_ratio, 4),
+            "overall_score": round(self.overall_score, 4),
+        }
+
+
+class DifficultyAnalyzer:
+    """Analyze tracking sequences to quantify difficulty from GT annotations.
+
+    Analysis operates purely on ground-truth bounding boxes — no frame images
+    are decoded — making it fast even on datasets with thousands of sequences.
+
+    Args:
+        frame_size: ``(width, height)`` in pixels, used to compute the
+            out-of-view ratio.  Pass ``None`` to disable that attribute
+            (it will always be 0.0).
+        boundary_margin: Pixels from the frame edge within which a target
+            centroid counts as "near boundary".  Default: ``10``.
+        weights: Per-attribute weights for the composite score.  Unspecified
+            keys fall back to their defaults.  Weights are normalised
+            internally so only relative magnitudes matter.
+
+    Example::
+
+        analyzer = DifficultyAnalyzer(frame_size=(320, 240))
+        difficulty = analyzer.analyze(sequence)
+        print(f"overall difficulty = {difficulty.overall_score:.3f}")
+    """
+
+    _DEFAULT_WEIGHTS: Dict[str, float] = {
+        "motion_speed": 1.0,
+        "scale_variation": 1.2,
+        "aspect_ratio_change": 0.8,
+        "out_of_view_ratio": 0.6,
+    }
+
+    # Saturation scales for the soft-sigmoid mapping (x -> 1 - exp(-x/scale)).
+    # Chosen so that a "typical hard" value maps to ~0.63 and "extreme" → 1.
+    _SIGMOID_SCALES: Dict[str, float] = {
+        "motion_speed": 20.0,      # 20 px/frame is fast (near saturation)
+        "scale_variation": 0.30,   # 30 % area std-dev is significant
+        "aspect_ratio_change": 0.20,
+    }
+
+    def __init__(
+        self,
+        frame_size: Optional[Tuple[int, int]] = None,
+        boundary_margin: int = 10,
+        weights: Optional[Dict[str, float]] = None,
+    ) -> None:
+        self.frame_size = frame_size
+        self.boundary_margin = boundary_margin
+        w = dict(self._DEFAULT_WEIGHTS)
+        if weights:
+            w.update(weights)
+        self._weights = w
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def analyze(self, seq: Sequence) -> SequenceDifficulty:
+        """Compute difficulty attributes for *seq* from its ground truth.
+
+        Args:
+            seq: A :class:`~eovot.datasets.base.Sequence` with valid
+                ``ground_truth`` of shape ``(N, 4)``.
+
+        Returns:
+            :class:`SequenceDifficulty` populated with computed attributes.
+        """
+        gt = seq.ground_truth  # (N, 4) — x, y, w, h
+
+        ms = self._motion_speed(gt)
+        sv = self._scale_variation(gt)
+        arc = self._aspect_ratio_change(gt)
+        oov = self._out_of_view_ratio(gt)
+        score = self._composite_score(ms, sv, arc, oov)
+
+        return SequenceDifficulty(
+            name=seq.name,
+            num_frames=len(gt),
+            motion_speed=ms,
+            scale_variation=sv,
+            aspect_ratio_change=arc,
+            out_of_view_ratio=oov,
+            overall_score=score,
+        )
+
+    def analyze_dataset(self, dataset: BaseDataset) -> List[SequenceDifficulty]:
+        """Analyze every sequence in *dataset* and return results in order."""
+        return [self.analyze(dataset[i]) for i in range(len(dataset))]
+
+    def rank(
+        self,
+        difficulties: List[SequenceDifficulty],
+        ascending: bool = False,
+    ) -> List[SequenceDifficulty]:
+        """Sort *difficulties* by ``overall_score`` (hardest first by default).
+
+        Args:
+            ascending: If ``True``, easiest sequences appear first.
+
+        Returns:
+            A new sorted list; the original list is not modified.
+        """
+        return sorted(difficulties, key=lambda d: d.overall_score, reverse=not ascending)
+
+    def filter(
+        self,
+        difficulties: List[SequenceDifficulty],
+        min_score: float = 0.0,
+        max_score: float = 1.0,
+    ) -> List[SequenceDifficulty]:
+        """Return only sequences whose ``overall_score`` is in [*min_score*, *max_score*].
+
+        Args:
+            min_score: Inclusive lower bound.
+            max_score: Inclusive upper bound.
+        """
+        return [d for d in difficulties if min_score <= d.overall_score <= max_score]
+
+    def summary(self, difficulties: List[SequenceDifficulty]) -> Dict[str, float]:
+        """Compute mean / std / min / max for each difficulty attribute.
+
+        Returns an empty dict if *difficulties* is empty.
+        """
+        if not difficulties:
+            return {}
+        attrs = [
+            "motion_speed",
+            "scale_variation",
+            "aspect_ratio_change",
+            "out_of_view_ratio",
+            "overall_score",
+        ]
+        stats: Dict[str, float] = {}
+        for attr in attrs:
+            vals = np.array([getattr(d, attr) for d in difficulties])
+            stats[f"{attr}_mean"] = float(vals.mean())
+            stats[f"{attr}_std"] = float(vals.std())
+            stats[f"{attr}_min"] = float(vals.min())
+            stats[f"{attr}_max"] = float(vals.max())
+        return stats
+
+    # ------------------------------------------------------------------
+    # Attribute computations (private)
+    # ------------------------------------------------------------------
+
+    def _motion_speed(self, gt: np.ndarray) -> float:
+        """Mean per-frame centroid displacement in pixels."""
+        if len(gt) < 2:
+            return 0.0
+        cx = gt[:, 0] + gt[:, 2] / 2.0
+        cy = gt[:, 1] + gt[:, 3] / 2.0
+        dx = np.diff(cx)
+        dy = np.diff(cy)
+        return float(np.sqrt(dx ** 2 + dy ** 2).mean())
+
+    def _scale_variation(self, gt: np.ndarray) -> float:
+        """Std-dev of relative bounding-box area change between frames."""
+        if len(gt) < 2:
+            return 0.0
+        areas = gt[:, 2] * gt[:, 3]
+        safe_prev = np.maximum(areas[:-1], 1e-6)
+        ratios = areas[1:] / safe_prev
+        # Mask degenerate source boxes to avoid inflating variance.
+        valid = areas[:-1] > 0
+        if not valid.any():
+            return 0.0
+        return float(ratios[valid].std())
+
+    def _aspect_ratio_change(self, gt: np.ndarray) -> float:
+        """Std-dev of width/height ratio across all frames."""
+        heights = gt[:, 3]
+        valid = heights > 0
+        if not valid.any():
+            return 0.0
+        ratios = gt[valid, 2] / np.maximum(heights[valid], 1e-6)
+        return float(ratios.std())
+
+    def _out_of_view_ratio(self, gt: np.ndarray) -> float:
+        """Fraction of frames where the centroid is near or outside the frame."""
+        if self.frame_size is None or len(gt) == 0:
+            return 0.0
+        W, H = self.frame_size
+        m = self.boundary_margin
+        cx = gt[:, 0] + gt[:, 2] / 2.0
+        cy = gt[:, 1] + gt[:, 3] / 2.0
+        near = (cx < m) | (cx > W - m) | (cy < m) | (cy > H - m)
+        return float(near.mean())
+
+    def _composite_score(
+        self,
+        motion_speed: float,
+        scale_variation: float,
+        aspect_ratio_change: float,
+        out_of_view_ratio: float,
+    ) -> float:
+        """Weighted average of per-attribute scores, each mapped to [0, 1]."""
+
+        def _soft_sigmoid(x: float, scale: float) -> float:
+            return float(1.0 - np.exp(-x / max(scale, 1e-9)))
+
+        attr_scores = {
+            "motion_speed": _soft_sigmoid(
+                motion_speed, self._SIGMOID_SCALES["motion_speed"]
+            ),
+            "scale_variation": _soft_sigmoid(
+                scale_variation, self._SIGMOID_SCALES["scale_variation"]
+            ),
+            "aspect_ratio_change": _soft_sigmoid(
+                aspect_ratio_change, self._SIGMOID_SCALES["aspect_ratio_change"]
+            ),
+            "out_of_view_ratio": float(np.clip(out_of_view_ratio, 0.0, 1.0)),
+        }
+
+        total_weight = sum(self._weights.values())
+        composite = sum(
+            self._weights.get(k, 1.0) * v for k, v in attr_scores.items()
+        ) / total_weight
+        return float(np.clip(composite, 0.0, 1.0))

--- a/scripts/analyze_difficulty.py
+++ b/scripts/analyze_difficulty.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Analyze and report sequence difficulty for an EOVOT dataset.
+
+Computes per-sequence difficulty scores from ground-truth annotations (no
+frame decoding required) and prints a ranked table to stdout.
+
+Usage::
+
+    # Analyze a synthetic dataset (no data download required)
+    python scripts/analyze_difficulty.py --dataset synthetic --num-sequences 10
+
+    # Show only the 5 hardest sequences
+    python scripts/analyze_difficulty.py --dataset synthetic --top-k 5
+
+    # Filter to hard sequences (score >= 0.4) and save results
+    python scripts/analyze_difficulty.py --dataset synthetic \\
+        --min-score 0.4 --output results/difficulty.json
+
+    # Analyze an OTB-style dataset
+    python scripts/analyze_difficulty.py --dataset otb --root /data/OTB100
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from eovot.datasets.difficulty import DifficultyAnalyzer
+from eovot.datasets.synthetic import SyntheticDataset
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Rank and filter tracking sequences by difficulty.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--dataset",
+        choices=["synthetic", "otb"],
+        default="synthetic",
+        help="Dataset type to analyze.",
+    )
+    p.add_argument("--root", default=None, help="Path to OTB dataset root.")
+    p.add_argument(
+        "--num-sequences", type=int, default=10,
+        help="Number of synthetic sequences to generate.",
+    )
+    p.add_argument(
+        "--num-frames", type=int, default=100,
+        help="Frames per synthetic sequence.",
+    )
+    p.add_argument(
+        "--motion",
+        choices=["linear", "circular", "random"],
+        default="linear",
+        help="Motion pattern for synthetic sequences.",
+    )
+    p.add_argument("--frame-width", type=int, default=320)
+    p.add_argument("--frame-height", type=int, default=240)
+    p.add_argument(
+        "--min-score", type=float, default=0.0,
+        help="Minimum overall_score to include in output.",
+    )
+    p.add_argument(
+        "--max-score", type=float, default=1.0,
+        help="Maximum overall_score to include in output.",
+    )
+    p.add_argument(
+        "--top-k", type=int, default=None,
+        help="Show only the top-K hardest sequences.",
+    )
+    p.add_argument(
+        "--output", default=None,
+        help="Save results to this JSON path.",
+    )
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
+
+    if args.dataset == "synthetic":
+        dataset = SyntheticDataset(
+            num_sequences=args.num_sequences,
+            num_frames=args.num_frames,
+            motion=args.motion,
+        )
+    else:
+        from eovot.datasets.base import OTBDataset
+        if args.root is None:
+            print("Error: --root is required for OTB dataset.", file=sys.stderr)
+            sys.exit(1)
+        dataset = OTBDataset(args.root)
+
+    analyzer = DifficultyAnalyzer(
+        frame_size=(args.frame_width, args.frame_height)
+    )
+
+    print(f"Analyzing {len(dataset)} sequences ...\n")
+    difficulties = analyzer.analyze_dataset(dataset)
+
+    filtered = analyzer.filter(difficulties, min_score=args.min_score, max_score=args.max_score)
+    ranked = analyzer.rank(filtered)
+    if args.top_k is not None:
+        ranked = ranked[: args.top_k]
+
+    col_w = 34
+    header = (
+        f"{'Sequence':<{col_w}} {'Speed':>8} {'Scale':>8} "
+        f"{'AR-chg':>8} {'OOV':>8} {'Score':>8}"
+    )
+    sep = "-" * len(header)
+    print(header)
+    print(sep)
+    for d in ranked:
+        print(
+            f"{d.name:<{col_w}} "
+            f"{d.motion_speed:>8.2f} "
+            f"{d.scale_variation:>8.4f} "
+            f"{d.aspect_ratio_change:>8.4f} "
+            f"{d.out_of_view_ratio:>8.4f} "
+            f"{d.overall_score:>8.4f}"
+        )
+
+    if difficulties:
+        stats = analyzer.summary(difficulties)
+        print()
+        print(
+            f"Dataset summary ({len(difficulties)} sequences) — "
+            f"score: mean={stats['overall_score_mean']:.4f}  "
+            f"std={stats['overall_score_std']:.4f}  "
+            f"min={stats['overall_score_min']:.4f}  "
+            f"max={stats['overall_score_max']:.4f}"
+        )
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "dataset": args.dataset,
+            "num_sequences_analyzed": len(difficulties),
+            "num_sequences_shown": len(ranked),
+            "sequences": [d.to_dict() for d in ranked],
+            "summary": analyzer.summary(difficulties),
+        }
+        with open(out_path, "w") as f:
+            json.dump(payload, f, indent=2)
+        print(f"\nResults saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_difficulty.py
+++ b/tests/test_difficulty.py
@@ -1,0 +1,287 @@
+"""Tests for SequenceDifficulty and DifficultyAnalyzer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.datasets.difficulty import DifficultyAnalyzer, SequenceDifficulty
+from eovot.datasets.synthetic import SyntheticDataset
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockSequence:
+    """Minimal Sequence stand-in for tests that don't need frame data."""
+
+    def __init__(self, name: str, ground_truth: np.ndarray) -> None:
+        self.name = name
+        self.ground_truth = ground_truth
+
+    def __len__(self) -> int:
+        return len(self.ground_truth)
+
+
+def _seq(name: str, positions, w: float = 40.0, h: float = 40.0) -> _MockSequence:
+    """Build a mock sequence from (cx, cy) positions."""
+    boxes = np.array(
+        [(cx - w / 2, cy - h / 2, w, h) for cx, cy in positions],
+        dtype=np.float64,
+    )
+    return _MockSequence(name, boxes)
+
+
+# ---------------------------------------------------------------------------
+# DifficultyAnalyzer — motion_speed
+# ---------------------------------------------------------------------------
+
+
+class TestMotionSpeed:
+    def setup_method(self):
+        self.analyzer = DifficultyAnalyzer()
+
+    def test_static_sequence_zero_speed(self):
+        s = _seq("static", [(100, 100)] * 30)
+        d = self.analyzer.analyze(s)
+        assert d.motion_speed == pytest.approx(0.0, abs=1e-6)
+
+    def test_faster_motion_higher_speed(self):
+        slow = _seq("slow", [(100 + i * 1, 100) for i in range(30)])
+        fast = _seq("fast", [(100 + i * 10, 100) for i in range(30)])
+        d_slow = self.analyzer.analyze(slow)
+        d_fast = self.analyzer.analyze(fast)
+        assert d_fast.motion_speed > d_slow.motion_speed
+
+    def test_single_frame_zero_speed(self):
+        s = _seq("single", [(160, 120)])
+        d = self.analyzer.analyze(s)
+        assert d.motion_speed == pytest.approx(0.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# DifficultyAnalyzer — scale_variation
+# ---------------------------------------------------------------------------
+
+
+class TestScaleVariation:
+    def setup_method(self):
+        self.analyzer = DifficultyAnalyzer()
+
+    def test_constant_size_zero_variation(self):
+        s = _seq("const", [(100 + i, 100) for i in range(20)])
+        d = self.analyzer.analyze(s)
+        assert d.scale_variation == pytest.approx(0.0, abs=1e-6)
+
+    def test_growing_box_nonzero_variation(self):
+        boxes = np.array(
+            [(100.0, 100.0, 20.0 + i * 2, 20.0 + i * 2) for i in range(20)],
+            dtype=np.float64,
+        )
+        s = _MockSequence("growing", boxes)
+        d = self.analyzer.analyze(s)
+        assert d.scale_variation > 0.0
+
+    def test_single_frame_zero_variation(self):
+        s = _seq("single", [(100, 100)])
+        d = self.analyzer.analyze(s)
+        assert d.scale_variation == pytest.approx(0.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# DifficultyAnalyzer — out_of_view_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestOutOfViewRatio:
+    def test_no_frame_size_always_zero(self):
+        analyzer = DifficultyAnalyzer(frame_size=None)
+        s = _seq("near_edge", [(5, 5)] * 20)
+        d = analyzer.analyze(s)
+        assert d.out_of_view_ratio == pytest.approx(0.0, abs=1e-6)
+
+    def test_centroid_near_boundary_detected(self):
+        analyzer = DifficultyAnalyzer(frame_size=(320, 240), boundary_margin=15)
+        # All centroids at (5, 120) — well inside the left boundary margin.
+        s = _seq("near_left", [(5, 120)] * 20)
+        d = analyzer.analyze(s)
+        assert d.out_of_view_ratio == pytest.approx(1.0, abs=1e-6)
+
+    def test_centroid_in_centre_zero_ratio(self):
+        analyzer = DifficultyAnalyzer(frame_size=(320, 240), boundary_margin=10)
+        s = _seq("centre", [(160, 120)] * 20)
+        d = analyzer.analyze(s)
+        assert d.out_of_view_ratio == pytest.approx(0.0, abs=1e-6)
+
+    def test_half_near_boundary(self):
+        analyzer = DifficultyAnalyzer(frame_size=(320, 240), boundary_margin=15)
+        positions = [(5, 120)] * 10 + [(160, 120)] * 10
+        s = _seq("half_near", positions)
+        d = analyzer.analyze(s)
+        assert d.out_of_view_ratio == pytest.approx(0.5, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# DifficultyAnalyzer — overall_score range and monotonicity
+# ---------------------------------------------------------------------------
+
+
+class TestOverallScore:
+    def setup_method(self):
+        self.analyzer = DifficultyAnalyzer(frame_size=(320, 240))
+
+    def test_score_in_unit_interval(self):
+        ds = SyntheticDataset(num_sequences=5, num_frames=50)
+        for seq in ds:
+            d = self.analyzer.analyze(seq)
+            assert 0.0 <= d.overall_score <= 1.0
+
+    def test_harder_sequence_higher_score(self):
+        slow = _seq("slow", [(100 + i, 100) for i in range(50)])
+        fast = _seq("fast", [(100 + i * 15, 100) for i in range(50)])
+        d_slow = self.analyzer.analyze(slow)
+        d_fast = self.analyzer.analyze(fast)
+        assert d_fast.overall_score > d_slow.overall_score
+
+    def test_static_centre_sequence_low_score(self):
+        s = _seq("static_centre", [(160, 120)] * 50)
+        d = self.analyzer.analyze(s)
+        assert d.overall_score < 0.1
+
+
+# ---------------------------------------------------------------------------
+# DifficultyAnalyzer — rank and filter
+# ---------------------------------------------------------------------------
+
+
+class TestRankAndFilter:
+    def setup_method(self):
+        self.analyzer = DifficultyAnalyzer(frame_size=(320, 240))
+        ds = SyntheticDataset(num_sequences=8, num_frames=50, motion="linear")
+        self.difficulties = self.analyzer.analyze_dataset(ds)
+
+    def test_rank_descending_by_default(self):
+        ranked = self.analyzer.rank(self.difficulties)
+        scores = [d.overall_score for d in ranked]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_rank_ascending(self):
+        ranked = self.analyzer.rank(self.difficulties, ascending=True)
+        scores = [d.overall_score for d in ranked]
+        assert scores == sorted(scores)
+
+    def test_rank_does_not_mutate_input(self):
+        original_order = [d.name for d in self.difficulties]
+        self.analyzer.rank(self.difficulties)
+        assert [d.name for d in self.difficulties] == original_order
+
+    def test_filter_min_score(self):
+        min_s = 0.2
+        filtered = self.analyzer.filter(self.difficulties, min_score=min_s)
+        assert all(d.overall_score >= min_s for d in filtered)
+
+    def test_filter_max_score(self):
+        max_s = 0.5
+        filtered = self.analyzer.filter(self.difficulties, max_score=max_s)
+        assert all(d.overall_score <= max_s for d in filtered)
+
+    def test_filter_returns_subset(self):
+        filtered = self.analyzer.filter(self.difficulties, min_score=0.0, max_score=1.0)
+        assert len(filtered) == len(self.difficulties)
+
+
+# ---------------------------------------------------------------------------
+# DifficultyAnalyzer — summary statistics
+# ---------------------------------------------------------------------------
+
+
+class TestSummary:
+    def setup_method(self):
+        self.analyzer = DifficultyAnalyzer()
+        ds = SyntheticDataset(num_sequences=5, num_frames=50)
+        self.difficulties = self.analyzer.analyze_dataset(ds)
+
+    def test_summary_keys_present(self):
+        stats = self.analyzer.summary(self.difficulties)
+        for attr in ["motion_speed", "scale_variation", "aspect_ratio_change",
+                     "out_of_view_ratio", "overall_score"]:
+            for stat in ["mean", "std", "min", "max"]:
+                assert f"{attr}_{stat}" in stats
+
+    def test_summary_empty_list(self):
+        stats = self.analyzer.summary([])
+        assert stats == {}
+
+    def test_mean_within_min_max(self):
+        stats = self.analyzer.summary(self.difficulties)
+        for attr in ["overall_score"]:
+            assert stats[f"{attr}_min"] <= stats[f"{attr}_mean"] <= stats[f"{attr}_max"]
+
+
+# ---------------------------------------------------------------------------
+# SequenceDifficulty — to_dict
+# ---------------------------------------------------------------------------
+
+
+class TestToDictMethod:
+    def test_to_dict_has_all_keys(self):
+        d = SequenceDifficulty(
+            name="test",
+            num_frames=50,
+            motion_speed=3.5,
+            scale_variation=0.05,
+            aspect_ratio_change=0.02,
+            out_of_view_ratio=0.1,
+            overall_score=0.42,
+        )
+        result = d.to_dict()
+        expected_keys = {
+            "name", "num_frames", "motion_speed", "scale_variation",
+            "aspect_ratio_change", "out_of_view_ratio", "overall_score",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_to_dict_values_are_rounded(self):
+        d = SequenceDifficulty(
+            name="test",
+            num_frames=100,
+            motion_speed=1.23456789,
+            scale_variation=0.12345678,
+            aspect_ratio_change=0.01234567,
+            out_of_view_ratio=0.5,
+            overall_score=0.33333333,
+        )
+        result = d.to_dict()
+        assert result["motion_speed"] == pytest.approx(1.2346, abs=1e-4)
+        assert result["overall_score"] == pytest.approx(0.3333, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Integration: analyze_dataset with SyntheticDataset
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeDatasetIntegration:
+    def test_returns_one_result_per_sequence(self):
+        analyzer = DifficultyAnalyzer()
+        ds = SyntheticDataset(num_sequences=6, num_frames=40)
+        results = analyzer.analyze_dataset(ds)
+        assert len(results) == 6
+
+    def test_names_match_sequences(self):
+        analyzer = DifficultyAnalyzer()
+        ds = SyntheticDataset(num_sequences=4, num_frames=30)
+        results = analyzer.analyze_dataset(ds)
+        for i, d in enumerate(results):
+            assert d.name == ds[i].name
+
+    def test_different_motions_produce_different_scores(self):
+        analyzer = DifficultyAnalyzer(frame_size=(320, 240))
+        linear_ds = SyntheticDataset(num_sequences=3, num_frames=50, motion="linear")
+        random_ds = SyntheticDataset(num_sequences=3, num_frames=50, motion="random")
+        linear_scores = [analyzer.analyze(linear_ds[i]).overall_score for i in range(3)]
+        random_scores = [analyzer.analyze(random_ds[i]).overall_score for i in range(3)]
+        # Both should be valid floats in [0, 1]; not all equal to each other.
+        assert not (linear_scores == random_scores)


### PR DESCRIPTION
## What was added

`DifficultyAnalyzer` — a new module in `eovot/datasets/difficulty.py` that quantifies tracking sequence difficulty directly from ground-truth bounding-box annotations, **without decoding any frames**. Analysis is fast even on large datasets (GOT-10k, LaSOT).

### Difficulty attributes

| Attribute | Description |
|---|---|
| `motion_speed` | Mean per-frame centroid displacement (px/frame) |
| `scale_variation` | Std-dev of relative bounding-box area change |
| `aspect_ratio_change` | Std-dev of width/height ratio across frames |
| `out_of_view_ratio` | Fraction of frames near/outside the frame boundary |
| `overall_score` | Weighted composite in **[0, 1]** — higher = harder |

The composite score uses a soft-sigmoid saturation model so no single extreme attribute dominates.

## Why it matters

Benchmarks that report only aggregate mIoU hide *where* trackers fail. With `DifficultyAnalyzer`, researchers can:

- **Stratify evaluation** — compare tracker X on easy vs. hard subsets
- **Diagnose failure modes** — correlate low IoU with high `motion_speed` or `out_of_view_ratio`
- **Filter sequences** — select only hard sequences for ablation studies
- **Generate reproducible difficulty tables** for paper appendices

## Files changed

| File | Role |
|---|---|
| `eovot/datasets/difficulty.py` | `DifficultyAnalyzer` + `SequenceDifficulty` dataclass |
| `tests/test_difficulty.py` | 27 unit + integration tests (all passing) |
| `scripts/analyze_difficulty.py` | CLI: ranked difficulty table + optional JSON export |
| `eovot/datasets/__init__.py` | Export `DifficultyAnalyzer`, `SequenceDifficulty` |

## Example usage

```python
from eovot.datasets.difficulty import DifficultyAnalyzer
from eovot.datasets.synthetic import SyntheticDataset

ds       = SyntheticDataset(num_sequences=10, num_frames=100, motion="random")
analyzer = DifficultyAnalyzer(frame_size=(320, 240))

difficulties = analyzer.analyze_dataset(ds)
hard = analyzer.filter(difficulties, min_score=0.4)
ranked = analyzer.rank(hard)

for d in ranked:
    print(f"{d.name:<30} score={d.overall_score:.3f}  speed={d.motion_speed:.1f}px/fr")
```

CLI:
```bash
python scripts/analyze_difficulty.py --dataset synthetic --num-sequences 20 --top-k 5
python scripts/analyze_difficulty.py --dataset synthetic --min-score 0.3 --output results/hard_seqs.json
```

## No breaking changes

Purely additive — no existing API is modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_015qkYYKNp7NPGPB4gYqv3jC)_