### PR TITLE
[feat] Add FrameSkipTracker for edge-deployment accuracy–efficiency trade-off study

### DIFF
--- a/configs/experiments/frame_skip_experiment.yaml
+++ b/configs/experiments/frame_skip_experiment.yaml
@@ -1,0 +1,61 @@
+# Frame-skip accuracy–efficiency trade-off experiment
+#
+# Evaluates MOSSE and KCF trackers at three skip rates (1, 2, 3) to quantify
+# how adaptive frame skipping reduces compute load while trading off accuracy.
+# This is a key measurement for edge deployment decisions: a researcher can
+# read the leaderboard to answer "how much accuracy do I lose at half the
+# frame rate?"
+#
+# Usage:
+#   python scripts/run_experiment.py --config configs/experiments/frame_skip_experiment.yaml
+
+experiment:
+  name: frame_skip_tradeoff
+  description: >
+    Compares MOSSE and KCF wrapped at skip_rate 1 (baseline), 2, and 3.
+    Quantifies the accuracy-efficiency trade-off of adaptive frame skipping
+    for edge-constrained deployments.
+  output_dir: results/frame_skip_tradeoff
+  seed: 42
+
+dataset:
+  name: synthetic_linear
+  loader: synthetic
+  num_sequences: 10
+  num_frames: 100
+  motion: linear
+
+trackers:
+  - name: mosse_skip1
+    type: mosse
+    skip_rate: 1
+
+  - name: mosse_skip2
+    type: mosse
+    skip_rate: 2
+
+  - name: mosse_skip3
+    type: mosse
+    skip_rate: 3
+
+  - name: kcf_skip1
+    type: kcf
+    skip_rate: 1
+
+  - name: kcf_skip2
+    type: kcf
+    skip_rate: 2
+
+  - name: kcf_skip3
+    type: kcf
+    skip_rate: 3
+
+benchmark:
+  verbose: true
+  save_predictions: false
+
+reporting:
+  formats:
+    - json
+    - markdown
+  print_summary: true

--- a/eovot/trackers/__init__.py
+++ b/eovot/trackers/__init__.py
@@ -3,6 +3,7 @@ from .mosse import MOSSETracker
 from .kcf import KCFTracker
 from .csrt import CSRTTracker
 from .median_flow import MedianFlowTracker
+from .frame_skip import FrameSkipTracker
 
 __all__ = [
     "BaseTracker",
@@ -11,4 +12,5 @@ __all__ = [
     "KCFTracker",
     "CSRTTracker",
     "MedianFlowTracker",
+    "FrameSkipTracker",
 ]

--- a/eovot/trackers/frame_skip.py
+++ b/eovot/trackers/frame_skip.py
@@ -1,0 +1,168 @@
+"""Adaptive frame-skip wrapper for any BaseTracker.
+
+On resource-constrained edge devices, processing every video frame at full
+rate is often infeasible.  ``FrameSkipTracker`` wraps any ``BaseTracker`` and
+invokes the underlying tracker only on every ``skip_rate``-th frame, while
+interpolating bounding boxes for the intermediate frames using a constant-
+velocity linear predictor.
+
+This design enables **systematic study of the accuracy–efficiency trade-off**
+for a fixed tracker algorithm without re-implementing the tracker:
+
+- ``skip_rate=1`` → standard evaluation, no skipping (baseline).
+- ``skip_rate=2`` → tracker runs at half the frame rate (~2× compute saving).
+- ``skip_rate=N`` → tracker runs at 1/N the frame rate (~N× compute saving).
+
+The wrapper is fully transparent to ``BenchmarkEngine`` — it satisfies the
+``BaseTracker`` interface and can be substituted anywhere a tracker is used.
+
+Interpolation model
+-------------------
+Skipped frames receive bounding-box predictions from a **constant-velocity**
+extrapolator: the velocity is estimated as the displacement between the two
+most recently processed frames, then projected forward proportionally to the
+number of frames since the last real update.  Box size is linearly
+interpolated from the same two reference frames.  This simple model is
+intentionally lightweight — the primary goal is a fast, deterministic baseline
+that approximates where the tracker *would* have placed the box.
+
+Usage::
+
+    from eovot.trackers.mosse import MOSSETracker
+    from eovot.trackers.frame_skip import FrameSkipTracker
+
+    base    = MOSSETracker()
+    tracker = FrameSkipTracker(base, skip_rate=3)  # invoke MOSSE every 3rd frame
+
+    engine = BenchmarkEngine(verbose=True)
+    result = engine.run(tracker, dataset, dataset_name="OTB100")
+    # tracker.name → "MOSSETracker[skip=3]"
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .base import BaseTracker, BBox
+
+
+class FrameSkipTracker(BaseTracker):
+    """Wraps a BaseTracker to process only every *skip_rate*-th frame.
+
+    Frames that are not processed by the underlying tracker receive bounding-
+    box predictions extrapolated from the last two processed frames using a
+    constant-velocity model.
+
+    Args:
+        tracker: Any concrete :class:`~eovot.trackers.base.BaseTracker`.
+        skip_rate: Number of frames between two consecutive tracker invocations.
+            ``1`` disables skipping (every frame is processed, equivalent to
+            the unwrapped tracker).  Must be a positive integer.
+
+    Raises:
+        ValueError: If ``skip_rate < 1``.
+
+    Attributes:
+        skip_rate: The configured skip rate (read-only after construction).
+
+    Example::
+
+        from eovot.trackers.kcf import KCFTracker
+
+        wrapped = FrameSkipTracker(KCFTracker(), skip_rate=2)
+        # wrapped.name  →  "KCFTracker[skip=2]"
+    """
+
+    def __init__(self, tracker: BaseTracker, skip_rate: int = 2) -> None:
+        if skip_rate < 1:
+            raise ValueError(f"skip_rate must be >= 1, got {skip_rate!r}")
+        super().__init__(name=f"{tracker.name}[skip={skip_rate}]")
+        self._tracker = tracker
+        self.skip_rate = skip_rate
+
+        # Per-sequence state — reset on initialize().
+        self._frame_index: int = 0
+        self._last_bbox: Optional[BBox] = None   # bbox from the most recent process-frame
+        self._prev_bbox: Optional[BBox] = None   # bbox from the process-frame before that
+        self._last_processed_at: int = 0         # _frame_index value when last processed
+
+    # ------------------------------------------------------------------
+    # BaseTracker interface
+    # ------------------------------------------------------------------
+
+    def initialize(self, frame: np.ndarray, bbox: BBox) -> None:
+        """Initialise the underlying tracker and reset all skip state.
+
+        Args:
+            frame: BGR image ``(H, W, 3)`` uint8.
+            bbox:  Ground-truth ``(x, y, w, h)`` for the first frame.
+        """
+        self._tracker.initialize(frame, bbox)
+        self._frame_index = 0
+        self._last_bbox = bbox
+        self._prev_bbox = bbox   # zero velocity at start
+        self._last_processed_at = 0
+
+    def update(self, frame: np.ndarray) -> BBox:
+        """Predict the target location for the next frame.
+
+        Invokes the underlying tracker when ``frame_index % skip_rate == 0``;
+        otherwise extrapolates from the last two processed-frame positions.
+
+        Args:
+            frame: BGR image ``(H, W, 3)`` uint8.
+
+        Returns:
+            Predicted ``(x, y, w, h)`` bounding box.
+        """
+        self._frame_index += 1
+
+        if self._frame_index % self.skip_rate == 0:
+            bbox = self._tracker.update(frame)
+            self._prev_bbox = self._last_bbox
+            self._last_bbox = bbox
+            self._last_processed_at = self._frame_index
+        else:
+            bbox = self._extrapolate()
+
+        return bbox
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _extrapolate(self) -> BBox:
+        """Project the last known position forward with constant velocity.
+
+        Velocity is the per-frame displacement between ``_prev_bbox`` and
+        ``_last_bbox``.  For a frame that is *k* steps after the last
+        processed frame, the predicted position is offset by *k × velocity*.
+        Box size is linearly interpolated (clamped to a minimum of 1 px).
+        """
+        assert self._last_bbox is not None and self._prev_bbox is not None
+
+        frames_ahead = self._frame_index - self._last_processed_at
+
+        lx, ly, lw, lh = self._last_bbox
+        px, py, pw, ph = self._prev_bbox
+
+        # Constant-velocity position update.
+        vx = lx - px
+        vy = ly - py
+        ex = lx + frames_ahead * vx
+        ey = ly + frames_ahead * vy
+
+        # Linear size interpolation clamped above zero.
+        alpha = min(frames_ahead / max(self.skip_rate, 1), 1.0)
+        ew = max(lw + alpha * (lw - pw), 1.0)
+        eh = max(lh + alpha * (lh - ph), 1.0)
+
+        return (ex, ey, ew, eh)
+
+    def __repr__(self) -> str:
+        return (
+            f"FrameSkipTracker(tracker={self._tracker!r}, "
+            f"skip_rate={self.skip_rate})"
+        )

--- a/tests/test_frame_skip.py
+++ b/tests/test_frame_skip.py
@@ -1,0 +1,263 @@
+"""Tests for FrameSkipTracker."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.trackers.base import BaseTracker, BBox
+from eovot.trackers.frame_skip import FrameSkipTracker
+
+
+# ---------------------------------------------------------------------------
+# Test double
+# ---------------------------------------------------------------------------
+
+
+class _LinearTracker(BaseTracker):
+    """Deterministic tracker: moves the box 1 px right per update() call."""
+
+    def __init__(self) -> None:
+        super().__init__(name="LinearTracker")
+        self.update_count = 0
+        self._bbox: BBox = (0.0, 0.0, 40.0, 40.0)
+
+    def initialize(self, frame: np.ndarray, bbox: BBox) -> None:
+        self._bbox = bbox
+        self.update_count = 0
+
+    def update(self, frame: np.ndarray) -> BBox:
+        self.update_count += 1
+        x, y, w, h = self._bbox
+        self._bbox = (x + 1.0, y, w, h)
+        return self._bbox
+
+
+def _blank_frame() -> np.ndarray:
+    return np.zeros((240, 320, 3), dtype=np.uint8)
+
+
+def _run(tracker: BaseTracker, n_updates: int = 10) -> list[BBox]:
+    frame = _blank_frame()
+    tracker.initialize(frame, (50.0, 50.0, 40.0, 40.0))
+    return [tracker.update(frame) for _ in range(n_updates)]
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_name_includes_skip_rate(self) -> None:
+        t = FrameSkipTracker(_LinearTracker(), skip_rate=4)
+        assert "skip=4" in t.name
+
+    def test_name_includes_base_tracker_name(self) -> None:
+        t = FrameSkipTracker(_LinearTracker(), skip_rate=2)
+        assert "LinearTracker" in t.name
+
+    def test_invalid_skip_rate_zero(self) -> None:
+        with pytest.raises(ValueError, match="skip_rate must be >= 1"):
+            FrameSkipTracker(_LinearTracker(), skip_rate=0)
+
+    def test_invalid_skip_rate_negative(self) -> None:
+        with pytest.raises(ValueError, match="skip_rate must be >= 1"):
+            FrameSkipTracker(_LinearTracker(), skip_rate=-3)
+
+    def test_repr_contains_skip_rate(self) -> None:
+        t = FrameSkipTracker(_LinearTracker(), skip_rate=3)
+        assert "skip_rate=3" in repr(t)
+
+
+# ---------------------------------------------------------------------------
+# Underlying tracker invocation counts
+# ---------------------------------------------------------------------------
+
+
+class TestInvocationCounts:
+    """Verify that update() is called on the base tracker exactly the right
+    number of times for various (skip_rate, n_updates) combinations."""
+
+    def _count_calls(self, skip_rate: int, n_updates: int) -> int:
+        base = _LinearTracker()
+        wrapped = FrameSkipTracker(base, skip_rate=skip_rate)
+        _run(wrapped, n_updates)
+        return base.update_count
+
+    def test_skip1_calls_every_frame(self) -> None:
+        assert self._count_calls(skip_rate=1, n_updates=9) == 9
+
+    def test_skip2_calls_half_frames(self) -> None:
+        # 10 updates → frame_index 1..10, process at 2,4,6,8,10 → 5 calls
+        assert self._count_calls(skip_rate=2, n_updates=10) == 5
+
+    def test_skip3_correct_count(self) -> None:
+        # 9 updates → frame_index 1..9, process at 3,6,9 → 3 calls
+        assert self._count_calls(skip_rate=3, n_updates=9) == 3
+
+    def test_skip5_correct_count(self) -> None:
+        # 15 updates → process at 5,10,15 → 3 calls
+        assert self._count_calls(skip_rate=5, n_updates=15) == 3
+
+    def test_no_frames_after_init(self) -> None:
+        base = _LinearTracker()
+        wrapped = FrameSkipTracker(base, skip_rate=2)
+        wrapped.initialize(_blank_frame(), (50.0, 50.0, 40.0, 40.0))
+        assert base.update_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Output shape and positivity
+# ---------------------------------------------------------------------------
+
+
+class TestOutputProperties:
+    def test_returns_four_element_tuple(self) -> None:
+        results = _run(FrameSkipTracker(_LinearTracker(), skip_rate=2), n_updates=9)
+        for bbox in results:
+            assert len(bbox) == 4
+
+    def test_width_and_height_positive(self) -> None:
+        results = _run(FrameSkipTracker(_LinearTracker(), skip_rate=5), n_updates=20)
+        for x, y, w, h in results:
+            assert w >= 1.0
+            assert h >= 1.0
+
+    def test_correct_number_of_predictions(self) -> None:
+        n = 15
+        results = _run(FrameSkipTracker(_LinearTracker(), skip_rate=3), n_updates=n)
+        assert len(results) == n
+
+
+# ---------------------------------------------------------------------------
+# skip_rate=1 passes through to base tracker exactly
+# ---------------------------------------------------------------------------
+
+
+class TestSkipRate1Passthrough:
+    def test_predictions_match_base(self) -> None:
+        base_a = _LinearTracker()
+        base_b = _LinearTracker()
+        wrapped = FrameSkipTracker(base_a, skip_rate=1)
+
+        frame = _blank_frame()
+        init_bbox: BBox = (50.0, 50.0, 40.0, 40.0)
+        base_b.initialize(frame, init_bbox)
+        wrapped.initialize(frame, init_bbox)
+
+        for _ in range(8):
+            expected = base_b.update(frame)
+            actual = wrapped.update(frame)
+            assert actual == pytest.approx(expected, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Extrapolation correctness
+# ---------------------------------------------------------------------------
+
+
+class TestExtrapolation:
+    def test_skipped_frame_advances_position(self) -> None:
+        """Extrapolated frame should move in the same direction as the tracker."""
+        base = _LinearTracker()
+        wrapped = FrameSkipTracker(base, skip_rate=3)
+        results = _run(wrapped, n_updates=6)
+
+        # Frame indices 1..6; processed at 3 and 6.
+        # Index 1 (skip): extrapolation from init (velocity=0) → same as init
+        # Index 2 (skip): same
+        # Index 3 (process): real tracker call
+        # Index 4 (skip): should be ahead of index-3 prediction
+        x_at_3 = results[2][0]  # result index 2 → frame_index 3 (processed)
+        x_at_4 = results[3][0]  # result index 3 → frame_index 4 (skipped)
+        # The tracker moves +1 px per call; we expect extrapolation to project
+        # forward, so x_at_4 >= x_at_3 (velocity >= 0).
+        assert x_at_4 >= x_at_3
+
+    def test_process_frame_updates_velocity(self) -> None:
+        """After the second process-frame the velocity estimate should be non-zero."""
+        base = _LinearTracker()
+        wrapped = FrameSkipTracker(base, skip_rate=2)
+        frame = _blank_frame()
+        wrapped.initialize(frame, (100.0, 100.0, 40.0, 40.0))
+        # Run enough frames to get two process-frames.
+        results = [wrapped.update(frame) for _ in range(6)]
+
+        # Frame 2 (process): tracker moved to (101,100) → _last_bbox=(101,100,40,40)
+        # Frame 4 (process): tracker moved to (102,100) → velocity=(1,0)
+        # Frame 5 (skip): extrapolated → x should be ~103
+        x5 = results[4][0]
+        x4 = results[3][0]
+        assert x5 > x4
+
+
+# ---------------------------------------------------------------------------
+# Re-initialization resets state
+# ---------------------------------------------------------------------------
+
+
+class TestReinitialization:
+    def test_frame_index_resets_to_zero(self) -> None:
+        base = _LinearTracker()
+        wrapped = FrameSkipTracker(base, skip_rate=2)
+        _run(wrapped, n_updates=8)
+        assert wrapped._frame_index == 8
+
+        # Re-initialize.
+        wrapped.initialize(_blank_frame(), (10.0, 10.0, 20.0, 20.0))
+        assert wrapped._frame_index == 0
+
+    def test_predictions_reproducible_after_reinit(self) -> None:
+        base = _LinearTracker()
+        wrapped = FrameSkipTracker(base, skip_rate=2)
+        frame = _blank_frame()
+        init_bbox: BBox = (50.0, 50.0, 40.0, 40.0)
+
+        wrapped.initialize(frame, init_bbox)
+        run1 = [wrapped.update(frame) for _ in range(6)]
+
+        wrapped.initialize(frame, init_bbox)
+        run2 = [wrapped.update(frame) for _ in range(6)]
+
+        for b1, b2 in zip(run1, run2):
+            assert b1 == pytest.approx(b2, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Integration: FrameSkipTracker + BenchmarkEngine
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkEngineIntegration:
+    def test_engine_runs_without_error(self) -> None:
+        from eovot.benchmark.engine import BenchmarkEngine
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.trackers.mosse import MOSSETracker
+
+        base = MOSSETracker()
+        tracker = FrameSkipTracker(base, skip_rate=2)
+        dataset = SyntheticDataset(num_sequences=2, num_frames=30, motion="linear")
+        engine = BenchmarkEngine(verbose=False)
+        result = engine.run(tracker, dataset, dataset_name="synthetic")
+
+        assert result.tracker_name == tracker.name
+        assert len(result.sequence_results) == 2
+        assert result.mean_fps > 0.0
+
+    def test_skip1_and_no_wrap_have_similar_iou(self) -> None:
+        """skip_rate=1 should produce the same mIoU as the unwrapped tracker."""
+        from eovot.benchmark.engine import BenchmarkEngine
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.trackers.mosse import MOSSETracker
+
+        dataset = SyntheticDataset(num_sequences=3, num_frames=30, motion="linear", seed=0)
+        engine = BenchmarkEngine(verbose=False)
+
+        base = MOSSETracker()
+        skip1 = FrameSkipTracker(MOSSETracker(), skip_rate=1)
+
+        r_base = engine.run(base, dataset, dataset_name="test")
+        r_skip = engine.run(skip1, dataset, dataset_name="test")
+
+        assert r_base.mean_iou == pytest.approx(r_skip.mean_iou, abs=1e-6)


### PR DESCRIPTION
## What was added

`FrameSkipTracker` — a transparent wrapper in `eovot/trackers/frame_skip.py` that processes only every **N-th frame** through the underlying tracker, interpolating bounding boxes for skipped frames using a **constant-velocity linear predictor**.

## Why it matters

Edge devices (Raspberry Pi 4, Jetson Nano, Coral) often cannot process video at full frame rate. The existing benchmark always evaluates at 1:1 frame ratio, which does not reflect real deployment constraints. `FrameSkipTracker` enables:

- **Systematic accuracy–efficiency trade-off analysis** for any tracker without modifying it
- Benchmarking the *degradation curve*: how much IoU is lost at skip=2, skip=3, …?
- Answering the deployment question: *"Can this tracker run at 15 FPS on a Pi 4 and still achieve acceptable accuracy?"*

## How it works

```
skip_rate=3:  process─────skip──skip──process─────skip──skip──process
              frame 3     4     5     6           7     8     9
```

Skipped frames use a constant-velocity extrapolator: velocity = displacement between the last two processed frames, projected forward. Box size is linearly interpolated. The model is intentionally lightweight — its role is a deterministic, fast baseline, not a learned predictor.

## Files changed

| File | Role |
|---|---|
| `eovot/trackers/frame_skip.py` | `FrameSkipTracker` with CV extrapolator |
| `tests/test_frame_skip.py` | 20 tests: invocation counts, output props, extrapolation, re-init, BenchmarkEngine integration |
| `configs/experiments/frame_skip_experiment.yaml` | MOSSE + KCF at skip=1/2/3 on synthetic sequences |
| `eovot/trackers/__init__.py` | Export `FrameSkipTracker` |

## Example usage

```python
from eovot.trackers.mosse import MOSSETracker
from eovot.trackers.frame_skip import FrameSkipTracker
from eovot.benchmark.engine import BenchmarkEngine
from eovot.datasets.synthetic import SyntheticDataset

dataset = SyntheticDataset(num_sequences=10, num_frames=100)
engine  = BenchmarkEngine(verbose=True)

for skip_rate in [1, 2, 3]:
    tracker = FrameSkipTracker(MOSSETracker(), skip_rate=skip_rate)
    result  = engine.run(tracker, dataset, dataset_name="Synthetic")
    print(f"skip={skip_rate}  mIoU={result.mean_iou:.3f}  FPS={result.mean_fps:.0f}")
```

Run the pre-built experiment config:
```bash
python scripts/run_experiment.py --config configs/experiments/frame_skip_experiment.yaml
```

## No breaking changes

Purely additive — no existing tracker or engine code is modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_015qkYYKNp7NPGPB4gYqv3jC)_