### PR TITLE
[feat] Add ScaleAdaptiveMOSSETracker with multi-scale pyramid search

### DIFF
--- a/configs/experiments/scale_adaptation_comparison.yaml
+++ b/configs/experiments/scale_adaptation_comparison.yaml
@@ -1,0 +1,43 @@
+# Scale adaptation comparison experiment
+#
+# Compares MOSSE (fixed-scale) against ScaleAdaptiveMOSSE (scale-pyramid)
+# on the synthetic dataset so the experiment runs without downloading
+# real-world data.
+#
+# Run with:
+#   python scripts/run_experiment.py \
+#       --config configs/experiments/scale_adaptation_comparison.yaml
+#
+# Key research question:
+#   Does scale-pyramid search improve tracking accuracy on sequences
+#   where the target undergoes size changes?
+
+experiment:
+  name: "scale-adaptation-comparison"
+  seed: 42
+  tdp_watts: null
+
+dataset:
+  loader: SyntheticDataset
+  name: Synthetic-ScaleTest
+  num_sequences: 10
+  num_frames: 100
+  frame_size: [320, 240]
+  bbox_size: [40, 40]
+  motion: "linear"
+  seed: 42
+
+trackers:
+  - name: MOSSE
+    params:
+      learning_rate: 0.125
+      sigma: 2.0
+
+  - name: ScaleAdaptiveMOSSE
+    params:
+      learning_rate: 0.125
+      sigma: 2.0
+      n_scales: 5
+      scale_step: 1.05
+      scale_lr: 0.35
+      psr_threshold: 6.0

--- a/eovot/experiment/runner.py
+++ b/eovot/experiment/runner.py
@@ -275,6 +275,7 @@ class ExperimentRunner:
         from ..trackers.median_flow import MedianFlowTracker
         from ..trackers.mil import MILTracker
         from ..trackers.mosse import MOSSETracker
+        from ..trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
 
         registry = {
             "MOSSE": MOSSETracker,
@@ -282,6 +283,7 @@ class ExperimentRunner:
             "CSRT": CSRTTracker,
             "MIL": MILTracker,
             "MedianFlow": MedianFlowTracker,
+            "ScaleAdaptiveMOSSE": ScaleAdaptiveMOSSETracker,
         }
         name = cfg["name"]
         if name not in registry:

--- a/eovot/trackers/__init__.py
+++ b/eovot/trackers/__init__.py
@@ -3,6 +3,7 @@ from .mosse import MOSSETracker
 from .kcf import KCFTracker
 from .csrt import CSRTTracker
 from .median_flow import MedianFlowTracker
+from .scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
 
 __all__ = [
     "BaseTracker",
@@ -11,4 +12,5 @@ __all__ = [
     "KCFTracker",
     "CSRTTracker",
     "MedianFlowTracker",
+    "ScaleAdaptiveMOSSETracker",
 ]

--- a/eovot/trackers/scale_adaptive_mosse.py
+++ b/eovot/trackers/scale_adaptive_mosse.py
@@ -1,0 +1,379 @@
+"""Scale-adaptive MOSSE correlation filter tracker.
+
+Extends the base MOSSE tracker with a multi-scale search pyramid that lets
+the filter adapt to target size changes over time.  At each frame, correlation
+responses are computed at S discrete scale levels; the scale yielding the
+highest Peak-to-Sidelobe Ratio (PSR) is selected and used for the online
+filter update.
+
+Scale-change is one of the hardest tracking challenges in OTB, LaSOT, and
+GOT-10k.  Plain MOSSE uses a fixed-size template and fails when a target
+grows or shrinks significantly.  This tracker closes that gap with only an
+O(S·N log N) cost increase per frame — still fully viable on edge hardware.
+
+Algorithm
+---------
+1. **Initialization** — train a standard MOSSE filter on the initial patch
+   at canonical template size ``(tw, th)``.
+2. **Detection (per frame)**:
+   a. Compute scale levels:
+      ``s_k = scale_step^k  for  k ∈ {-⌊n//2⌋, …, 0, …, ⌊n//2⌋}``
+   b. For each scale ``s_k``, extract a patch of size
+      ``(round(tw·s_k), round(th·s_k))`` and **resize to ``(tw, th)``** before
+      computing the DFT.  This preserves the filter dimensions.
+   c. Compute the MOSSE response map for each resized patch.
+   d. Evaluate PSR for each response; keep the scale with the highest PSR.
+3. **Online update** — update the MOSSE filter using the patch extracted at
+   the winning scale (after converting the scale offset to a smooth EMA on
+   the running template size).
+
+PSR definition::
+
+    PSR = (peak_val − μ_sidelobe) / σ_sidelobe
+
+where the sidelobe is the response map with an ``(11×11)`` window around the
+peak masked out.  Values above ~7 typically indicate confident detections.
+
+References
+----------
+Bolme et al. "Visual Object Tracking using Adaptive Correlation Filters."
+    IEEE CVPR 2010.
+
+Danelljan et al. "Accurate Scale Estimation for Robust Visual Tracking."
+    BMVC 2014  (motivation for scale pyramid in correlation filters).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from .base import BaseTracker, BBox
+
+
+class ScaleAdaptiveMOSSETracker(BaseTracker):
+    """MOSSE tracker with scale-pyramid adaptation.
+
+    At each frame the tracker evaluates correlation responses at ``n_scales``
+    discrete scale levels and selects the scale that yields the highest
+    Peak-to-Sidelobe Ratio (PSR).  The running template size is updated with
+    an exponential moving average so scale transitions are smooth rather than
+    abrupt.
+
+    Args:
+        learning_rate: EMA weight for online MOSSE filter update.
+            Default ``0.125`` (matches original paper).
+        sigma: Standard deviation of the Gaussian regression target in pixels.
+            Default ``2.0``.
+        n_scales: Number of scale levels in the pyramid.  Must be a positive
+            odd integer so the current scale (factor 1.0) is always included.
+            Default ``5``.
+        scale_step: Multiplicative gap between adjacent scale levels.
+            With ``scale_step=1.05`` and ``n_scales=5`` the tested factors are
+            ``[0.90, 0.95, 1.00, 1.05, 1.10]``.  Default ``1.05``.
+        scale_lr: Exponential moving-average weight for updating the running
+            template size after a scale change is detected.  Lower values
+            give smoother (but slower) adaptation.  Default ``0.35``.
+        psr_threshold: Minimum PSR below which a frame's detection is treated
+            as unreliable.  The tracker keeps its previous prediction when PSR
+            is below this threshold.  Set to ``0`` to disable.
+            Default ``6.0``.
+
+    Example::
+
+        from eovot.trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.benchmark.engine import BenchmarkEngine
+
+        tracker = ScaleAdaptiveMOSSETracker(n_scales=5, scale_step=1.05)
+        dataset = SyntheticDataset(num_sequences=3, motion="linear")
+        engine  = BenchmarkEngine(verbose=False)
+        result  = engine.run(tracker, dataset, dataset_name="Synthetic")
+        print(result)
+    """
+
+    # PSR computation: mask a window of this half-size around the peak.
+    _PSR_MASK_HALFSIZE: int = 5
+
+    def __init__(
+        self,
+        learning_rate: float = 0.125,
+        sigma: float = 2.0,
+        n_scales: int = 5,
+        scale_step: float = 1.05,
+        scale_lr: float = 0.35,
+        psr_threshold: float = 6.0,
+    ) -> None:
+        super().__init__(name="ScaleAdaptiveMOSSE")
+        if n_scales < 1 or n_scales % 2 == 0:
+            raise ValueError(
+                f"n_scales must be a positive odd integer, got {n_scales}."
+            )
+        if scale_step <= 1.0:
+            raise ValueError(
+                f"scale_step must be > 1.0, got {scale_step}."
+            )
+        self.learning_rate = learning_rate
+        self.sigma = sigma
+        self.n_scales = n_scales
+        self.scale_step = scale_step
+        self.scale_lr = scale_lr
+        self.psr_threshold = psr_threshold
+
+        # Pre-compute scale factors: symmetric around 1.0.
+        half = n_scales // 2
+        self._scale_factors: List[float] = [
+            scale_step ** k for k in range(-half, half + 1)
+        ]
+
+        # Internal state — populated by initialize().
+        self._H_conj: Optional[np.ndarray] = None
+        self._window: Optional[np.ndarray] = None
+        self._yf: Optional[np.ndarray] = None
+        self._pos: Optional[Tuple[float, float]] = None
+        self._target_w: float = 0.0
+        self._target_h: float = 0.0
+        self._template_w: int = 0
+        self._template_h: int = 0
+
+    # ------------------------------------------------------------------
+    # BaseTracker interface
+    # ------------------------------------------------------------------
+
+    def initialize(self, frame: np.ndarray, bbox: BBox) -> None:
+        """Initialise the scale-adaptive MOSSE filter on the first frame.
+
+        Args:
+            frame: BGR or grayscale image, shape ``(H, W[, C])``.
+            bbox: Ground-truth box ``(x, y, w, h)`` in pixel coordinates.
+        """
+        x, y, w, h = bbox
+        if w <= 0 or h <= 0:
+            raise ValueError(f"Invalid bbox {bbox}: w and h must be positive.")
+
+        cx, cy = x + w / 2.0, y + h / 2.0
+        self._pos = (cx, cy)
+        self._target_w = float(w)
+        self._target_h = float(h)
+        self._template_w = max(1, int(round(w)))
+        self._template_h = max(1, int(round(h)))
+
+        tw, th = self._template_w, self._template_h
+        self._window = np.outer(np.hanning(th), np.hanning(tw)).astype(np.float32)
+        G = np.fft.fft2(self._gaussian_response(th, tw))
+        self._yf = G
+
+        gray = self._to_gray(frame)
+        patch = self._extract_and_resize(gray, cx, cy, tw, th)
+        Fi = np.fft.fft2(self._preprocess(patch))
+        self._H_conj = (G * np.conj(Fi)) / (Fi * np.conj(Fi) + 1e-5)
+
+    def update(self, frame: np.ndarray) -> BBox:
+        """Predict and track the target with scale adaptation.
+
+        Args:
+            frame: Current BGR or grayscale frame, shape ``(H, W[, C])``.
+
+        Returns:
+            Predicted bounding box ``(x, y, w, h)``.
+
+        Raises:
+            RuntimeError: If called before :meth:`initialize`.
+        """
+        if self._H_conj is None or self._pos is None:
+            raise RuntimeError(
+                "ScaleAdaptiveMOSSETracker not initialised. Call initialize() first."
+            )
+
+        cx, cy = self._pos
+        gray = self._to_gray(frame)
+        tw, th = self._template_w, self._template_h
+
+        # ------------------------------------------------------------------
+        # 1. Multi-scale correlation responses
+        # ------------------------------------------------------------------
+        best_psr = -1.0
+        best_dx = 0.0
+        best_dy = 0.0
+        best_scale_idx = self.n_scales // 2  # default: current scale (factor 1.0)
+
+        for k, sf in enumerate(self._scale_factors):
+            scaled_w = max(1, int(round(self._target_w * sf)))
+            scaled_h = max(1, int(round(self._target_h * sf)))
+            patch = self._extract_and_resize(gray, cx, cy, scaled_w, scaled_h, out_w=tw, out_h=th)
+            Zf = np.fft.fft2(self._preprocess(patch))
+            response = np.real(np.fft.ifft2(self._H_conj * Zf))
+            psr, peak_y, peak_x = self._compute_psr(response)
+            if psr > best_psr:
+                best_psr = psr
+                best_scale_idx = k
+                dy = float(peak_y) if peak_y <= th // 2 else float(peak_y - th)
+                dx = float(peak_x) if peak_x <= tw // 2 else float(peak_x - tw)
+                best_dy, best_dx = dy, dx
+
+        # ------------------------------------------------------------------
+        # 2. Accept or reject the detection based on PSR confidence
+        # ------------------------------------------------------------------
+        if best_psr >= self.psr_threshold:
+            new_cx = cx + best_dx
+            new_cy = cy + best_dy
+            self._pos = (new_cx, new_cy)
+
+            # Smooth scale update via EMA.
+            winning_sf = self._scale_factors[best_scale_idx]
+            self._target_w = (
+                (1.0 - self.scale_lr) * self._target_w
+                + self.scale_lr * self._target_w * winning_sf
+            )
+            self._target_h = (
+                (1.0 - self.scale_lr) * self._target_h
+                + self.scale_lr * self._target_h * winning_sf
+            )
+        else:
+            # Low confidence: hold position, no scale update.
+            new_cx, new_cy = cx, cy
+
+        # ------------------------------------------------------------------
+        # 3. Online MOSSE filter update at the (possibly updated) scale
+        # ------------------------------------------------------------------
+        new_patch = self._extract_and_resize(
+            gray, new_cx, new_cy,
+            max(1, int(round(self._target_w))),
+            max(1, int(round(self._target_h))),
+            out_w=tw, out_h=th,
+        )
+        Fi_new = np.fft.fft2(self._preprocess(new_patch))
+        H_conj_new = (self._yf * np.conj(Fi_new)) / (Fi_new * np.conj(Fi_new) + 1e-5)
+        lr = self.learning_rate
+        self._H_conj = (1.0 - lr) * self._H_conj + lr * H_conj_new
+
+        # Return bounding box centred at the updated position.
+        return (
+            new_cx - self._target_w / 2.0,
+            new_cy - self._target_h / 2.0,
+            self._target_w,
+            self._target_h,
+        )
+
+    def reset(self) -> None:
+        """Clear all internal state for re-initialisation."""
+        self._H_conj = None
+        self._window = None
+        self._yf = None
+        self._pos = None
+        self._target_w = 0.0
+        self._target_h = 0.0
+        self._template_w = 0
+        self._template_h = 0
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _compute_psr(
+        self, response: np.ndarray
+    ) -> Tuple[float, int, int]:
+        """Compute Peak-to-Sidelobe Ratio and peak location.
+
+        The sidelobe region is the response map with a rectangular mask of
+        half-size ``_PSR_MASK_HALFSIZE`` around the peak zeroed out.
+
+        Args:
+            response: Real-valued correlation response map, shape ``(H, W)``.
+
+        Returns:
+            ``(psr, peak_y, peak_x)`` — PSR scalar and integer peak indices.
+        """
+        h, w = response.shape
+        peak_idx = int(response.argmax())
+        peak_y, peak_x = divmod(peak_idx, w)
+        peak_val = float(response.flat[peak_idx])
+
+        # Build sidelobe mask — exclude the peak neighbourhood.
+        mask = np.ones_like(response, dtype=bool)
+        hs = self._PSR_MASK_HALFSIZE
+        y1 = max(0, peak_y - hs)
+        y2 = min(h, peak_y + hs + 1)
+        x1 = max(0, peak_x - hs)
+        x2 = min(w, peak_x + hs + 1)
+        mask[y1:y2, x1:x2] = False
+
+        sidelobe = response[mask]
+        if sidelobe.size == 0:
+            return 0.0, peak_y, peak_x
+
+        mu = float(sidelobe.mean())
+        std = float(sidelobe.std())
+        psr = (peak_val - mu) / (std + 1e-6)
+        return psr, peak_y, peak_x
+
+    def _extract_and_resize(
+        self,
+        gray: np.ndarray,
+        cx: float,
+        cy: float,
+        src_w: int,
+        src_h: int,
+        out_w: Optional[int] = None,
+        out_h: Optional[int] = None,
+    ) -> np.ndarray:
+        """Extract a patch of size ``(src_h, src_w)`` centred at ``(cx, cy)``.
+
+        If ``out_w`` / ``out_h`` differ from ``src_w`` / ``src_h`` the patch
+        is resized to ``(out_h, out_w)`` using bilinear interpolation.  This
+        is the key operation that maps scale-pyramid patches back to the
+        canonical filter dimensions.
+
+        Edge-padding (``mode="edge"``) prevents black borders for patches that
+        extend beyond frame boundaries.
+        """
+        fh, fw = gray.shape[:2]
+        x1 = int(round(cx - src_w / 2.0))
+        y1 = int(round(cy - src_h / 2.0))
+        x2 = x1 + src_w
+        y2 = y1 + src_h
+
+        pad_l = max(0, -x1)
+        pad_t = max(0, -y1)
+        pad_r = max(0, x2 - fw)
+        pad_b = max(0, y2 - fh)
+        if pad_l or pad_t or pad_r or pad_b:
+            gray = np.pad(gray, ((pad_t, pad_b), (pad_l, pad_r)), mode="edge")
+            x1 += pad_l
+            y1 += pad_t
+            x2 += pad_l
+            y2 += pad_t
+
+        patch = gray[y1:y2, x1:x2]
+
+        target_w = out_w if out_w is not None else src_w
+        target_h = out_h if out_h is not None else src_h
+        if patch.shape != (target_h, target_w):
+            patch = cv2.resize(
+                patch, (target_w, target_h), interpolation=cv2.INTER_LINEAR
+            )
+        return patch
+
+    def _preprocess(self, patch: np.ndarray) -> np.ndarray:
+        """Log-normalise and apply the Hann window."""
+        f = np.log1p(patch.astype(np.float32))
+        f = (f - f.mean()) / (f.std() + 1e-5)
+        return f * self._window
+
+    def _gaussian_response(self, h: int, w: int) -> np.ndarray:
+        """2-D Gaussian centred at ``(h//2, w//2)`` with std = ``sigma``."""
+        cy, cx = h // 2, w // 2
+        ys, xs = np.ogrid[:h, :w]
+        g = np.exp(-((xs - cx) ** 2 + (ys - cy) ** 2) / (2.0 * self.sigma ** 2))
+        return (g / (g.sum() + 1e-6)).astype(np.float32)
+
+    @staticmethod
+    def _to_gray(frame: np.ndarray) -> np.ndarray:
+        """Convert BGR / BGRA image to single-channel grayscale."""
+        if frame.ndim == 2:
+            return frame
+        if frame.shape[2] == 4:
+            return cv2.cvtColor(frame, cv2.COLOR_BGRA2GRAY)
+        return cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -36,9 +36,9 @@ from eovot.datasets.got10k import GOT10kDataset
 from eovot.datasets.lasot import LaSOTDataset
 from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.mosse import MOSSETracker
-from eovot.trackers.kcf import KCFTracker
 from eovot.trackers.csrt import CSRTTracker
 from eovot.trackers.median_flow import MedianFlowTracker
+from eovot.trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
 
 
 # ------------------------------------------------------------------ #
@@ -50,6 +50,7 @@ TRACKER_REGISTRY: Dict[str, Any] = {
     "KCF": KCFTracker,
     "CSRT": CSRTTracker,
     "MedianFlow": MedianFlowTracker,
+    "ScaleAdaptiveMOSSE": ScaleAdaptiveMOSSETracker,
 }
 
 

--- a/tests/test_scale_adaptive_mosse.py
+++ b/tests/test_scale_adaptive_mosse.py
@@ -1,0 +1,236 @@
+"""Tests for the ScaleAdaptiveMOSSETracker."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_frame(h: int = 120, w: int = 160, seed: int = 0) -> np.ndarray:
+    """Create a synthetic BGR frame with a coloured rectangle target."""
+    rng = np.random.default_rng(seed)
+    frame = rng.integers(20, 80, (h, w, 3), dtype=np.uint8)
+    return frame
+
+
+def _draw_target(frame: np.ndarray, x: int, y: int, tw: int, th: int) -> np.ndarray:
+    """Draw a bright rectangle at (x, y, tw, th) on a copy of frame."""
+    f = frame.copy()
+    y1, y2 = max(0, y), min(frame.shape[0], y + th)
+    x1, x2 = max(0, x), min(frame.shape[1], x + tw)
+    f[y1:y2, x1:x2] = [220, 180, 50]
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Initialisation tests
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_default_construction(self):
+        t = ScaleAdaptiveMOSSETracker()
+        assert t.name == "ScaleAdaptiveMOSSE"
+        assert t.n_scales == 5
+        assert t.scale_step == 1.05
+        assert len(t._scale_factors) == 5
+
+    def test_scale_factors_symmetric(self):
+        t = ScaleAdaptiveMOSSETracker(n_scales=5, scale_step=1.10)
+        factors = t._scale_factors
+        assert len(factors) == 5
+        # Middle factor must equal 1.0 (step^0)
+        assert abs(factors[2] - 1.0) < 1e-9
+        # Factors must be strictly increasing
+        for i in range(len(factors) - 1):
+            assert factors[i] < factors[i + 1]
+
+    def test_invalid_n_scales_even(self):
+        with pytest.raises(ValueError, match="odd"):
+            ScaleAdaptiveMOSSETracker(n_scales=4)
+
+    def test_invalid_n_scales_zero(self):
+        with pytest.raises(ValueError, match="odd"):
+            ScaleAdaptiveMOSSETracker(n_scales=0)
+
+    def test_invalid_scale_step(self):
+        with pytest.raises(ValueError, match="scale_step"):
+            ScaleAdaptiveMOSSETracker(scale_step=0.95)
+
+    def test_initialize_sets_internal_state(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _make_frame()
+        frame = _draw_target(frame, 50, 40, 20, 20)
+        t.initialize(frame, (50, 40, 20, 20))
+        assert t._H_conj is not None
+        assert t._pos == (60.0, 50.0)  # cx, cy
+        assert t._target_w == 20.0
+        assert t._target_h == 20.0
+
+    def test_invalid_bbox_raises(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _make_frame()
+        with pytest.raises(ValueError):
+            t.initialize(frame, (10, 10, 0, 20))
+
+    def test_initialize_on_grayscale(self):
+        t = ScaleAdaptiveMOSSETracker()
+        gray = np.ones((80, 80), dtype=np.uint8) * 128
+        gray[20:40, 20:40] = 200
+        t.initialize(gray, (20, 20, 20, 20))
+        assert t._H_conj is not None
+
+
+# ---------------------------------------------------------------------------
+# Update / tracking tests
+# ---------------------------------------------------------------------------
+
+class TestUpdate:
+    def test_update_returns_bbox_tuple(self):
+        t = ScaleAdaptiveMOSSETracker()
+        bg = _make_frame()
+        frame0 = _draw_target(bg, 60, 50, 20, 20)
+        t.initialize(frame0, (60, 50, 20, 20))
+        frame1 = _draw_target(bg, 62, 52, 20, 20)
+        bbox = t.update(frame1)
+        assert len(bbox) == 4
+        assert all(isinstance(v, float) for v in bbox)
+
+    def test_update_before_initialize_raises(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _make_frame()
+        with pytest.raises(RuntimeError, match="not initialised"):
+            t.update(frame)
+
+    def test_tracks_linear_motion(self):
+        """Tracker should stay close to a slowly-moving target."""
+        rng = np.random.default_rng(7)
+        bg = rng.integers(20, 80, (120, 160, 3), dtype=np.uint8)
+
+        t = ScaleAdaptiveMOSSETracker(n_scales=3, psr_threshold=0.0)
+        tw, th = 24, 24
+        x0, y0 = 60, 50
+        frame0 = _draw_target(bg, x0, y0, tw, th)
+        t.initialize(frame0, (x0, y0, tw, th))
+
+        errors = []
+        for step in range(1, 8):
+            x = x0 + step * 2
+            y = y0 + step
+            frame = _draw_target(bg, x, y, tw, th)
+            pred = t.update(frame)
+            cx_gt = x + tw / 2.0
+            cy_gt = y + th / 2.0
+            cx_pred = pred[0] + pred[2] / 2.0
+            cy_pred = pred[1] + pred[3] / 2.0
+            err = np.sqrt((cx_pred - cx_gt) ** 2 + (cy_pred - cy_gt) ** 2)
+            errors.append(err)
+
+        mean_err = np.mean(errors)
+        assert mean_err < 30.0, f"Mean tracking error {mean_err:.1f}px too large"
+
+    def test_bbox_w_h_positive(self):
+        """Predicted bounding boxes must have positive width and height."""
+        rng = np.random.default_rng(3)
+        bg = rng.integers(20, 80, (120, 160, 3), dtype=np.uint8)
+        t = ScaleAdaptiveMOSSETracker(n_scales=3)
+        frame0 = _draw_target(bg, 60, 50, 24, 24)
+        t.initialize(frame0, (60, 50, 24, 24))
+        for i in range(5):
+            frame = _draw_target(bg, 60 + i, 50 + i, 24, 24)
+            x, y, w, h = t.update(frame)
+            assert w > 0, "Width must be positive"
+            assert h > 0, "Height must be positive"
+
+
+# ---------------------------------------------------------------------------
+# Scale adaptation tests
+# ---------------------------------------------------------------------------
+
+class TestScaleAdaptation:
+    def test_scale_increases_on_growing_target(self):
+        """Running target size should increase when the object grows."""
+        rng = np.random.default_rng(11)
+        bg = rng.integers(20, 80, (200, 200, 3), dtype=np.uint8)
+
+        t = ScaleAdaptiveMOSSETracker(n_scales=5, scale_step=1.10, scale_lr=0.5)
+        tw0, th0 = 20, 20
+        cx, cy = 100, 100
+        frame0 = _draw_target(bg, int(cx - tw0 / 2), int(cy - th0 / 2), tw0, th0)
+        t.initialize(frame0, (cx - tw0 / 2, cy - th0 / 2, tw0, th0))
+
+        initial_w = t._target_w
+
+        # Grow the target over 10 frames.
+        for step in range(1, 11):
+            tw = tw0 + step * 3
+            th = th0 + step * 3
+            frame = _draw_target(bg, int(cx - tw / 2), int(cy - th / 2), tw, th)
+            t.update(frame)
+
+        final_w = t._target_w
+        # The tracker's internal size should have grown at least a little.
+        assert final_w >= initial_w, (
+            f"Expected scale adaptation (w: {initial_w:.1f} → {final_w:.1f})"
+        )
+
+    def test_n_scales_one_disables_pyramid(self):
+        """n_scales=1 means only the current scale is tested (no pyramid)."""
+        t = ScaleAdaptiveMOSSETracker(n_scales=1)
+        assert len(t._scale_factors) == 1
+        assert abs(t._scale_factors[0] - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Reset test
+# ---------------------------------------------------------------------------
+
+class TestReset:
+    def test_reset_clears_state(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _make_frame()
+        frame = _draw_target(frame, 50, 40, 20, 20)
+        t.initialize(frame, (50, 40, 20, 20))
+        assert t._H_conj is not None
+        t.reset()
+        assert t._H_conj is None
+        assert t._pos is None
+
+    def test_reinitialize_after_reset(self):
+        t = ScaleAdaptiveMOSSETracker()
+        frame = _make_frame()
+        frame = _draw_target(frame, 50, 40, 20, 20)
+        t.initialize(frame, (50, 40, 20, 20))
+        t.reset()
+        t.initialize(frame, (30, 30, 16, 16))
+        assert t._pos == (38.0, 38.0)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark engine integration
+# ---------------------------------------------------------------------------
+
+class TestBenchmarkIntegration:
+    def test_runs_with_benchmark_engine(self):
+        from eovot.benchmark.engine import BenchmarkEngine
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=2, num_frames=20, motion="linear", seed=1)
+        engine = BenchmarkEngine(verbose=False)
+        tracker = ScaleAdaptiveMOSSETracker(n_scales=3)
+        result = engine.run(tracker, ds, dataset_name="Synthetic")
+
+        assert result.tracker_name == "ScaleAdaptiveMOSSE"
+        assert len(result.sequence_results) == 2
+        assert result.mean_fps > 0
+        assert 0.0 <= result.mean_iou <= 1.0
+
+    def test_repr(self):
+        t = ScaleAdaptiveMOSSETracker()
+        assert "ScaleAdaptiveMOSSETracker" in repr(t)
+        assert "ScaleAdaptiveMOSSE" in t.name


### PR DESCRIPTION
## What was added

This PR introduces `ScaleAdaptiveMOSSETracker` — the first algorithmically novel tracker in the EOVOT codebase. All existing trackers (MOSSE, KCF, CSRT, MIL, MedianFlow) maintain a **fixed template size** throughout tracking. Scale change is a documented top-5 failure mode for correlation-filter trackers on OTB, LaSOT, and GOT-10k. This tracker closes that gap.

### Algorithm

At each frame the tracker evaluates MOSSE correlation responses at `n_scales` discrete scale levels (symmetric around 1.0) and selects the scale that yields the highest **Peak-to-Sidelobe Ratio (PSR)**:

```
PSR = (peak_val − μ_sidelobe) / σ_sidelobe
```

The running template size is updated via exponential moving average (`scale_lr`) so scale transitions are smooth rather than abrupt. The filter dimensions stay constant — scale pyramid patches are resized to the canonical template size before computing the DFT — keeping cost at `O(S·N log N)` per frame.

### Why it matters

- **Edge deployment**: Drones tracking vehicles, robots tracking approaching objects, surveillance cameras — all face scale change. A tracker that adapts its template is far more reliable.
- **Ablation baseline**: Enables direct MOSSE (fixed-scale) vs ScaleAdaptiveMOSSE (scale-adaptive) comparison.
- **Pure NumPy + OpenCV**: No deep learning framework required. Still viable on Raspberry Pi 4 / Jetson Nano class hardware.

### Files changed

| File | Change |
|------|--------|
| `eovot/trackers/scale_adaptive_mosse.py` | New tracker: PSR-based scale pyramid, EMA scale update, boundary-safe patch extraction |
| `eovot/trackers/__init__.py` | Register `ScaleAdaptiveMOSSETracker` |
| `eovot/experiment/runner.py` | Add `"ScaleAdaptiveMOSSE"` to tracker registry |
| `scripts/run_benchmark.py` | Expose tracker via CLI |
| `tests/test_scale_adaptive_mosse.py` | 18 unit + integration tests (all pass) |
| `configs/experiments/scale_adaptation_comparison.yaml` | Ready-to-run MOSSE vs ScaleAdaptiveMOSSE experiment |

### Example usage

```python
from eovot.trackers.scale_adaptive_mosse import ScaleAdaptiveMOSSETracker
from eovot.datasets.synthetic import SyntheticDataset
from eovot.benchmark.engine import BenchmarkEngine

tracker = ScaleAdaptiveMOSSETracker(n_scales=5, scale_step=1.05, scale_lr=0.35)
dataset = SyntheticDataset(num_sequences=10, num_frames=100, motion="linear")
result  = BenchmarkEngine(verbose=True).run(tracker, dataset, dataset_name="Synthetic")
print(result)
```

Or via the experiment runner:
```bash
python scripts/run_experiment.py \
    --config configs/experiments/scale_adaptation_comparison.yaml
```

### Test results

```
18 passed in 0.34s   (+ 438 existing tests continue to pass)
```

### Key parameters

| Parameter | Default | Effect |
|-----------|---------|--------|
| `n_scales` | 5 | Number of scale levels (must be odd) |
| `scale_step` | 1.05 | Multiplicative gap between adjacent scales |
| `scale_lr` | 0.35 | EMA weight for smooth scale adaptation |
| `psr_threshold` | 6.0 | Minimum PSR to accept a detection |

### References

- Bolme et al. "Visual Object Tracking using Adaptive Correlation Filters." CVPR 2010
- Danelljan et al. "Accurate Scale Estimation for Robust Visual Tracking." BMVC 2014

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyFajznDqvzhxNTkHzbG4h)_