### PR TITLE
[feat] Add SequenceDifficultyAnalyzer for challenge-stratified benchmarking

### DIFF
--- a/configs/experiments/difficulty_filtered.yaml
+++ b/configs/experiments/difficulty_filtered.yaml
@@ -1,0 +1,40 @@
+# Difficulty-stratified benchmark experiment
+#
+# Demonstrates running trackers exclusively on sequences classified as
+# "hard" by the SequenceDifficultyAnalyzer.  This is useful for stress
+# testing, ablation studies, and understanding where each tracker fails.
+#
+# Run difficulty analysis first:
+#   python scripts/analyze_difficulty.py \
+#       --dataset-loader SyntheticDataset \
+#       --dataset-name Synthetic-Hard \
+#       --filter-tier hard
+#
+# Then run the benchmark experiment:
+#   python scripts/run_experiment.py \
+#       --config configs/experiments/difficulty_filtered.yaml
+
+experiment:
+  name: "hard-sequences-benchmark"
+  seed: 42
+  tdp_watts: null
+
+dataset:
+  loader: SyntheticDataset
+  name: Synthetic-Random
+  num_sequences: 20
+  num_frames: 120
+  frame_size: [320, 240]
+  bbox_size: [40, 40]
+  motion: "random"
+  seed: 42
+
+trackers:
+  - name: MOSSE
+    params:
+      learning_rate: 0.125
+      sigma: 2.0
+
+  - name: KCF
+    params:
+      learning_rate: 0.125

--- a/eovot/datasets/__init__.py
+++ b/eovot/datasets/__init__.py
@@ -2,6 +2,15 @@ from .base import BBox, Sequence, BaseDataset, OTBDataset
 from .got10k import GOT10kDataset
 from .lasot import LaSOTDataset
 from .synthetic import SyntheticDataset
+from .difficulty import (
+    SequenceDifficulty,
+    SequenceDifficultyAnalyzer,
+    DifficultyFilteredDataset,
+    TAG_SCALE_CHANGE,
+    TAG_FAST_MOTION,
+    TAG_DEFORMATION,
+    TAG_OCCLUSION,
+)
 
 __all__ = [
     "BBox",
@@ -11,4 +20,11 @@ __all__ = [
     "GOT10kDataset",
     "LaSOTDataset",
     "SyntheticDataset",
+    "SequenceDifficulty",
+    "SequenceDifficultyAnalyzer",
+    "DifficultyFilteredDataset",
+    "TAG_SCALE_CHANGE",
+    "TAG_FAST_MOTION",
+    "TAG_DEFORMATION",
+    "TAG_OCCLUSION",
 ]

--- a/eovot/datasets/difficulty.py
+++ b/eovot/datasets/difficulty.py
@@ -1,0 +1,638 @@
+"""Sequence difficulty analysis for VOT benchmark datasets.
+
+Standard VOT benchmarks (OTB, LaSOT, GOT-10k) annotate sequences with
+challenge attributes (occlusion, fast motion, scale change, etc.) but those
+labels are dataset-specific and require manual annotation.  This module
+*derives* challenge attributes automatically from ground-truth bounding-box
+sequences, enabling difficulty-stratified benchmarking on any dataset —
+including custom or synthetic sequences — without relying on pre-existing
+attribute labels.
+
+Computed challenge dimensions
+------------------------------
+Scale change ratio (SCR)
+    ``std(sqrt(area)) / mean(sqrt(area))`` — coefficient of variation of the
+    square-root area.  High SCR signals that the target substantially changes
+    size across the sequence, stressing fixed-template correlation filters.
+
+Mean velocity (MV)
+    ``mean(||Δcenter||) / mean_diagonal`` — frame-to-frame displacement
+    normalised by the mean box diagonal, making the metric scale-invariant.
+    High MV corresponds to fast-moving targets that easily drift out of a
+    tracker's search window.
+
+Aspect-ratio jitter (ARJ)
+    ``std(w / h)`` — standard deviation of the bounding-box aspect ratio.
+    High ARJ indicates target deformation (e.g. a person rotating or a
+    vehicle changing orientation), which causes template mismatch in
+    appearance-based trackers.
+
+Degenerate frame ratio (DFR)
+    Fraction of frames where the GT box has zero or negative area.  This
+    covers both explicit ``(0, 0, 0, 0)`` annotations (fully occluded or
+    out-of-view in some datasets) and pathological boxes.  High DFR means
+    the tracker is expected to handle prolonged visibility loss.
+
+Difficulty score
+~~~~~~~~~~~~~~~~
+A single scalar in ``[0, 1]`` that combines the four raw signals::
+
+    D = clip(w_scr·SCR + w_mv·MV + w_arj·ARJ + w_dfr·DFR, 0, 1)
+
+Weights: SCR=0.30, MV=0.30, ARJ=0.20, DFR=0.20.
+Hard reference values for full score are 0.50 (SCR/MV) and 0.30 (ARJ/DFR).
+
+Difficulty tiers
+~~~~~~~~~~~~~~~~
+- **easy**   — D < 0.33
+- **medium** — 0.33 ≤ D < 0.66
+- **hard**   — D ≥ 0.66
+
+Challenge tags
+~~~~~~~~~~~~~~
+Each sequence is tagged with any of the following strings when the
+corresponding metric exceeds its threshold:
+
+=================  ==========  ==================================================
+Tag                Default thr  Meaning
+=================  ==========  ==================================================
+``SCALE_CHANGE``   0.15         Target area varies by ≥15% (relative std)
+``FAST_MOTION``    0.10         Mean velocity ≥ 10% of box diagonal per frame
+``DEFORMATION``    0.12         Aspect-ratio std ≥ 0.12
+``OCCLUSION``      0.05         ≥ 5% of GT boxes are zero-area (occluded)
+=================  ==========  ==================================================
+
+Typical usage
+~~~~~~~~~~~~~
+::
+
+    from eovot.datasets.synthetic import SyntheticDataset
+    from eovot.datasets.difficulty import SequenceDifficultyAnalyzer, DifficultyFilteredDataset
+
+    dataset  = SyntheticDataset(num_sequences=20, num_frames=100, motion="random")
+    analyzer = SequenceDifficultyAnalyzer()
+
+    difficulties = analyzer.analyze_dataset(dataset)
+    print(analyzer.to_markdown_table(difficulties))
+
+    # Keep only hard sequences for a stress test
+    hard_ds = DifficultyFilteredDataset(dataset, tiers=["hard"], analyzer=analyzer)
+    print(f"Hard sequences: {len(hard_ds)}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional, Tuple
+
+import numpy as np
+
+from .base import BaseDataset, Sequence
+
+DifficultyTier = Literal["easy", "medium", "hard"]
+
+# Challenge tag constants
+TAG_SCALE_CHANGE = "SCALE_CHANGE"
+TAG_FAST_MOTION = "FAST_MOTION"
+TAG_DEFORMATION = "DEFORMATION"
+TAG_OCCLUSION = "OCCLUSION"
+
+
+@dataclass
+class SequenceDifficulty:
+    """Difficulty profile for a single tracking sequence.
+
+    All raw metrics are in ``[0, ∞)``.  The ``difficulty_score`` is normalised
+    to ``[0, 1]``.  The ``tier`` and ``challenges`` fields are derived from
+    thresholds configured on :class:`SequenceDifficultyAnalyzer`.
+
+    Attributes:
+        name: Sequence identifier.
+        scale_change_ratio: Coefficient of variation of sqrt(box area).
+        mean_velocity: Mean frame-to-frame displacement normalised by diagonal.
+        aspect_ratio_jitter: Std of bounding-box aspect ratio (w / h).
+        degenerate_frame_ratio: Fraction of frames with zero-area GT boxes.
+        difficulty_score: Weighted composite scalar in ``[0, 1]``.
+        tier: ``"easy"``, ``"medium"``, or ``"hard"``.
+        challenges: List of applicable challenge tag strings.
+        num_frames: Number of frames in the sequence.
+    """
+
+    name: str
+    scale_change_ratio: float
+    mean_velocity: float
+    aspect_ratio_jitter: float
+    degenerate_frame_ratio: float
+    difficulty_score: float
+    tier: DifficultyTier
+    challenges: List[str] = field(default_factory=list)
+    num_frames: int = 0
+
+    def __str__(self) -> str:
+        tags = ", ".join(self.challenges) if self.challenges else "none"
+        return (
+            f"SequenceDifficulty[{self.name}]  tier={self.tier}  "
+            f"score={self.difficulty_score:.3f}  challenges=[{tags}]  "
+            f"SCR={self.scale_change_ratio:.3f}  MV={self.mean_velocity:.3f}  "
+            f"ARJ={self.aspect_ratio_jitter:.3f}  DFR={self.degenerate_frame_ratio:.3f}"
+        )
+
+    def to_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "tier": self.tier,
+            "difficulty_score": round(self.difficulty_score, 4),
+            "scale_change_ratio": round(self.scale_change_ratio, 4),
+            "mean_velocity": round(self.mean_velocity, 4),
+            "aspect_ratio_jitter": round(self.aspect_ratio_jitter, 4),
+            "degenerate_frame_ratio": round(self.degenerate_frame_ratio, 4),
+            "challenges": self.challenges,
+            "num_frames": self.num_frames,
+        }
+
+
+class SequenceDifficultyAnalyzer:
+    """Derive difficulty scores and challenge tags from GT bounding boxes.
+
+    All analysis is performed on the ``(N, 4)`` ground-truth array associated
+    with a :class:`~eovot.datasets.base.Sequence`, so no frame images need
+    to be loaded.
+
+    Args:
+        scr_threshold: Scale-change-ratio threshold for the ``SCALE_CHANGE`` tag.
+            Default ``0.15``.
+        mv_threshold: Mean-velocity threshold for the ``FAST_MOTION`` tag.
+            Default ``0.10``.
+        arj_threshold: Aspect-ratio-jitter threshold for the ``DEFORMATION`` tag.
+            Default ``0.12``.
+        dfr_threshold: Degenerate-frame-ratio threshold for the ``OCCLUSION`` tag.
+            Default ``0.05``.
+        easy_max: Difficulty score below which a sequence is ``"easy"``.
+            Default ``0.33``.
+        hard_min: Difficulty score at or above which a sequence is ``"hard"``.
+            Default ``0.66``.
+
+    Example::
+
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.datasets.difficulty import SequenceDifficultyAnalyzer
+
+        ds = SyntheticDataset(num_sequences=10)
+        analyzer = SequenceDifficultyAnalyzer()
+        results = analyzer.analyze_dataset(ds)
+        print(analyzer.to_markdown_table(results))
+    """
+
+    # Normalisation references (values at which each raw metric contributes
+    # its full weight to the difficulty score).
+    _SCR_REF = 0.50
+    _MV_REF = 0.50
+    _ARJ_REF = 0.30
+    _DFR_REF = 0.30
+
+    # Composite score weights (must sum to 1.0).
+    _W_SCR = 0.30
+    _W_MV = 0.30
+    _W_ARJ = 0.20
+    _W_DFR = 0.20
+
+    def __init__(
+        self,
+        scr_threshold: float = 0.15,
+        mv_threshold: float = 0.10,
+        arj_threshold: float = 0.12,
+        dfr_threshold: float = 0.05,
+        easy_max: float = 0.33,
+        hard_min: float = 0.66,
+    ) -> None:
+        self.scr_threshold = scr_threshold
+        self.mv_threshold = mv_threshold
+        self.arj_threshold = arj_threshold
+        self.dfr_threshold = dfr_threshold
+        self.easy_max = easy_max
+        self.hard_min = hard_min
+
+    # ------------------------------------------------------------------
+    # Individual metric computations
+    # ------------------------------------------------------------------
+
+    def compute_scale_change_ratio(self, gt: np.ndarray) -> float:
+        """Coefficient of variation of the square-root bounding-box area.
+
+        Only valid (positive-area) frames contribute to the computation.
+
+        Args:
+            gt: ``(N, 4)`` array of GT boxes ``(x, y, w, h)``.
+
+        Returns:
+            SCR ≥ 0.  Returns ``0.0`` when fewer than 2 valid frames exist.
+        """
+        areas = gt[:, 2] * gt[:, 3]
+        valid = areas[areas > 0]
+        if len(valid) < 2:
+            return 0.0
+        sqrt_areas = np.sqrt(valid)
+        mean_val = float(sqrt_areas.mean())
+        if mean_val < 1e-9:
+            return 0.0
+        return float(sqrt_areas.std() / mean_val)
+
+    def compute_mean_velocity(self, gt: np.ndarray) -> float:
+        """Mean frame-to-frame centre displacement normalised by box diagonal.
+
+        Only transitions between consecutive valid frames are counted.
+
+        Args:
+            gt: ``(N, 4)`` array of GT boxes ``(x, y, w, h)``.
+
+        Returns:
+            MV ≥ 0.  Returns ``0.0`` for sequences with fewer than 2 valid frames.
+        """
+        areas = gt[:, 2] * gt[:, 3]
+        valid_mask = areas > 0
+        valid_gt = gt[valid_mask]
+        if len(valid_gt) < 2:
+            return 0.0
+
+        centers = valid_gt[:, :2] + valid_gt[:, 2:] / 2.0
+        displacements = np.linalg.norm(np.diff(centers, axis=0), axis=1)
+        diagonals = np.sqrt(valid_gt[:, 2] ** 2 + valid_gt[:, 3] ** 2)
+        mean_diag = float(diagonals.mean())
+        if mean_diag < 1e-6:
+            return 0.0
+        return float(displacements.mean() / mean_diag)
+
+    def compute_aspect_ratio_jitter(self, gt: np.ndarray) -> float:
+        """Standard deviation of the bounding-box aspect ratio (w / h).
+
+        Only valid (positive-area) frames contribute.
+
+        Args:
+            gt: ``(N, 4)`` array of GT boxes ``(x, y, w, h)``.
+
+        Returns:
+            ARJ ≥ 0.  Returns ``0.0`` when fewer than 2 valid frames exist.
+        """
+        valid = gt[(gt[:, 2] > 0) & (gt[:, 3] > 0)]
+        if len(valid) < 2:
+            return 0.0
+        aspect_ratios = valid[:, 2] / (valid[:, 3] + 1e-9)
+        return float(aspect_ratios.std())
+
+    def compute_degenerate_frame_ratio(self, gt: np.ndarray) -> float:
+        """Fraction of frames with zero or negative box area.
+
+        Args:
+            gt: ``(N, 4)`` array of GT boxes ``(x, y, w, h)``.
+
+        Returns:
+            DFR in ``[0, 1]``.  Returns ``0.0`` for empty arrays.
+        """
+        if len(gt) == 0:
+            return 0.0
+        areas = gt[:, 2] * gt[:, 3]
+        return float((areas <= 0).sum() / len(gt))
+
+    # ------------------------------------------------------------------
+    # Composite scoring and tagging
+    # ------------------------------------------------------------------
+
+    def _difficulty_score(
+        self,
+        scr: float,
+        mv: float,
+        arj: float,
+        dfr: float,
+    ) -> float:
+        """Compute weighted composite difficulty score in ``[0, 1]``."""
+        score = (
+            self._W_SCR * min(scr / self._SCR_REF, 1.0)
+            + self._W_MV * min(mv / self._MV_REF, 1.0)
+            + self._W_ARJ * min(arj / self._ARJ_REF, 1.0)
+            + self._W_DFR * min(dfr / self._DFR_REF, 1.0)
+        )
+        return float(np.clip(score, 0.0, 1.0))
+
+    def _tier(self, score: float) -> DifficultyTier:
+        if score < self.easy_max:
+            return "easy"
+        if score < self.hard_min:
+            return "medium"
+        return "hard"
+
+    def _challenge_tags(
+        self,
+        scr: float,
+        mv: float,
+        arj: float,
+        dfr: float,
+    ) -> List[str]:
+        tags: List[str] = []
+        if scr >= self.scr_threshold:
+            tags.append(TAG_SCALE_CHANGE)
+        if mv >= self.mv_threshold:
+            tags.append(TAG_FAST_MOTION)
+        if arj >= self.arj_threshold:
+            tags.append(TAG_DEFORMATION)
+        if dfr >= self.dfr_threshold:
+            tags.append(TAG_OCCLUSION)
+        return tags
+
+    # ------------------------------------------------------------------
+    # High-level entry points
+    # ------------------------------------------------------------------
+
+    def analyze(
+        self,
+        gt: np.ndarray,
+        name: str = "",
+    ) -> SequenceDifficulty:
+        """Analyse one GT sequence and return its difficulty profile.
+
+        Args:
+            gt:   ``(N, 4)`` array of ground-truth boxes ``(x, y, w, h)``.
+            name: Sequence identifier stored in the result.
+
+        Returns:
+            :class:`SequenceDifficulty` with all metrics populated.
+        """
+        gt = np.asarray(gt, dtype=np.float64)
+        if gt.ndim != 2 or gt.shape[1] != 4:
+            raise ValueError(
+                f"gt must be an (N, 4) array, got shape {gt.shape}."
+            )
+
+        scr = self.compute_scale_change_ratio(gt)
+        mv = self.compute_mean_velocity(gt)
+        arj = self.compute_aspect_ratio_jitter(gt)
+        dfr = self.compute_degenerate_frame_ratio(gt)
+        score = self._difficulty_score(scr, mv, arj, dfr)
+
+        return SequenceDifficulty(
+            name=name,
+            scale_change_ratio=scr,
+            mean_velocity=mv,
+            aspect_ratio_jitter=arj,
+            degenerate_frame_ratio=dfr,
+            difficulty_score=score,
+            tier=self._tier(score),
+            challenges=self._challenge_tags(scr, mv, arj, dfr),
+            num_frames=len(gt),
+        )
+
+    def analyze_dataset(
+        self,
+        dataset: BaseDataset,
+    ) -> List[SequenceDifficulty]:
+        """Analyse every sequence in a dataset without loading frame images.
+
+        Iterates over :meth:`dataset.__getitem__` and reads only the
+        ``ground_truth`` attribute from each :class:`~.base.Sequence`.
+
+        Args:
+            dataset: Any :class:`BaseDataset` implementation.
+
+        Returns:
+            List of :class:`SequenceDifficulty`, one per sequence, in the
+            same order as ``dataset[0], dataset[1], …``.
+        """
+        results: List[SequenceDifficulty] = []
+        for idx in range(len(dataset)):
+            seq: Sequence = dataset[idx]
+            results.append(self.analyze(seq.ground_truth, name=seq.name))
+        return results
+
+    def filter_by_tier(
+        self,
+        difficulties: List[SequenceDifficulty],
+        tiers: List[DifficultyTier],
+    ) -> List[int]:
+        """Return dataset indices whose difficulty tier is in *tiers*.
+
+        Args:
+            difficulties: Output of :meth:`analyze_dataset`.
+            tiers: List of accepted tier strings (``"easy"``, ``"medium"``,
+                ``"hard"``).
+
+        Returns:
+            List of integer indices into the original dataset.
+        """
+        return [
+            i for i, d in enumerate(difficulties) if d.tier in tiers
+        ]
+
+    def filter_by_challenge(
+        self,
+        difficulties: List[SequenceDifficulty],
+        challenges: List[str],
+        require_all: bool = False,
+    ) -> List[int]:
+        """Return dataset indices matching the given challenge tags.
+
+        Args:
+            difficulties: Output of :meth:`analyze_dataset`.
+            challenges: Challenge tags to match, e.g. ``["SCALE_CHANGE", "FAST_MOTION"]``.
+            require_all: If ``True``, a sequence must possess *all* listed tags
+                to be included.  If ``False`` (default), *any* matching tag
+                is sufficient.
+
+        Returns:
+            List of integer indices into the original dataset.
+        """
+        ch_set = set(challenges)
+        out = []
+        for i, d in enumerate(difficulties):
+            seq_tags = set(d.challenges)
+            if require_all:
+                if ch_set.issubset(seq_tags):
+                    out.append(i)
+            else:
+                if ch_set & seq_tags:
+                    out.append(i)
+        return out
+
+    def dataset_summary(
+        self,
+        difficulties: List[SequenceDifficulty],
+    ) -> Dict:
+        """Aggregate statistics across all analysed sequences.
+
+        Args:
+            difficulties: Output of :meth:`analyze_dataset`.
+
+        Returns:
+            Dict with count-by-tier, mean difficulty, and tag frequency.
+        """
+        if not difficulties:
+            return {}
+
+        tier_counts: Dict[str, int] = {"easy": 0, "medium": 0, "hard": 0}
+        tag_counts: Dict[str, int] = {
+            TAG_SCALE_CHANGE: 0,
+            TAG_FAST_MOTION: 0,
+            TAG_DEFORMATION: 0,
+            TAG_OCCLUSION: 0,
+        }
+        for d in difficulties:
+            tier_counts[d.tier] += 1
+            for tag in d.challenges:
+                tag_counts[tag] = tag_counts.get(tag, 0) + 1
+
+        scores = [d.difficulty_score for d in difficulties]
+        return {
+            "num_sequences": len(difficulties),
+            "mean_difficulty": round(float(np.mean(scores)), 4),
+            "std_difficulty": round(float(np.std(scores)), 4),
+            "tier_counts": tier_counts,
+            "challenge_counts": tag_counts,
+            "mean_scr": round(float(np.mean([d.scale_change_ratio for d in difficulties])), 4),
+            "mean_mv": round(float(np.mean([d.mean_velocity for d in difficulties])), 4),
+            "mean_arj": round(float(np.mean([d.aspect_ratio_jitter for d in difficulties])), 4),
+            "mean_dfr": round(float(np.mean([d.degenerate_frame_ratio for d in difficulties])), 4),
+        }
+
+    def to_markdown_table(
+        self,
+        difficulties: List[SequenceDifficulty],
+        top_n: Optional[int] = None,
+        sort_by: str = "difficulty_score",
+        ascending: bool = False,
+    ) -> str:
+        """Format difficulty profiles as a Markdown table.
+
+        Args:
+            difficulties: Output of :meth:`analyze_dataset`.
+            top_n: If set, include only the first ``top_n`` rows after sorting.
+            sort_by: Column to sort by.  One of ``"difficulty_score"``,
+                ``"scale_change_ratio"``, ``"mean_velocity"``,
+                ``"aspect_ratio_jitter"``, ``"degenerate_frame_ratio"``.
+                Default ``"difficulty_score"``.
+            ascending: Sort order.  Default ``False`` (hardest first).
+
+        Returns:
+            Multi-line Markdown string ready for embedding in reports.
+        """
+        valid_keys = {
+            "difficulty_score", "scale_change_ratio",
+            "mean_velocity", "aspect_ratio_jitter", "degenerate_frame_ratio",
+        }
+        if sort_by not in valid_keys:
+            sort_by = "difficulty_score"
+
+        sorted_ds = sorted(
+            difficulties,
+            key=lambda d: getattr(d, sort_by),
+            reverse=not ascending,
+        )
+        if top_n is not None:
+            sorted_ds = sorted_ds[:top_n]
+
+        lines = [
+            "| Rank | Sequence | Tier | Score | SCR | MV | ARJ | DFR | Challenges |",
+            "|------|----------|------|------:|----:|---:|----:|----:|-----------|",
+        ]
+        for rank, d in enumerate(sorted_ds, start=1):
+            tags = " ".join(d.challenges) if d.challenges else "—"
+            lines.append(
+                f"| {rank} | {d.name} | {d.tier} "
+                f"| {d.difficulty_score:.3f} "
+                f"| {d.scale_change_ratio:.3f} "
+                f"| {d.mean_velocity:.3f} "
+                f"| {d.aspect_ratio_jitter:.3f} "
+                f"| {d.degenerate_frame_ratio:.3f} "
+                f"| {tags} |"
+            )
+        return "\n".join(lines)
+
+
+class DifficultyFilteredDataset(BaseDataset):
+    """Dataset wrapper that exposes only sequences matching given difficulty tiers.
+
+    Wraps any :class:`~eovot.datasets.base.BaseDataset` and filters it to a
+    subset of sequences whose computed difficulty tier is in *tiers*.  The
+    wrapped dataset's sequences are re-indexed from zero so the result is a
+    drop-in replacement for the original dataset.
+
+    This is useful for:
+    - **Stress testing** — evaluate only hard sequences.
+    - **Ablation studies** — compare trackers on different difficulty strata.
+    - **Curriculum experiments** — progressively increase difficulty.
+
+    Args:
+        dataset: Any :class:`BaseDataset` to wrap.
+        tiers: Accepted difficulty tiers.  Sequences not in these tiers are
+            excluded.  Valid values: ``"easy"``, ``"medium"``, ``"hard"``.
+        analyzer: :class:`SequenceDifficultyAnalyzer` instance to use.
+            If ``None``, a default analyzer with default thresholds is created.
+
+    Raises:
+        ValueError: If ``tiers`` is empty or contains invalid tier names.
+
+    Example::
+
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.datasets.difficulty import DifficultyFilteredDataset
+
+        base = SyntheticDataset(num_sequences=20, motion="random")
+        hard_ds = DifficultyFilteredDataset(base, tiers=["hard"])
+        print(f"Hard sequences: {len(hard_ds)} / {len(base)}")
+    """
+
+    _VALID_TIERS = {"easy", "medium", "hard"}
+
+    def __init__(
+        self,
+        dataset: BaseDataset,
+        tiers: List[DifficultyTier],
+        analyzer: Optional[SequenceDifficultyAnalyzer] = None,
+    ) -> None:
+        if not tiers:
+            raise ValueError("tiers must not be empty.")
+        invalid = set(tiers) - self._VALID_TIERS
+        if invalid:
+            raise ValueError(
+                f"Invalid tier(s): {invalid}. Must be one of {self._VALID_TIERS}."
+            )
+
+        if analyzer is None:
+            analyzer = SequenceDifficultyAnalyzer()
+
+        self._dataset = dataset
+        self.tiers = list(tiers)
+        self.analyzer = analyzer
+
+        difficulties = analyzer.analyze_dataset(dataset)
+        self._indices = analyzer.filter_by_tier(difficulties, tiers)
+        self._difficulties: Dict[int, SequenceDifficulty] = {
+            self._indices[k]: difficulties[self._indices[k]]
+            for k in range(len(self._indices))
+        }
+
+    def __len__(self) -> int:
+        return len(self._indices)
+
+    def __getitem__(self, idx: int) -> Sequence:
+        if idx < 0 or idx >= len(self._indices):
+            raise IndexError(
+                f"Index {idx} out of range [0, {len(self._indices)})."
+            )
+        return self._dataset[self._indices[idx]]
+
+    def get_difficulty(self, idx: int) -> SequenceDifficulty:
+        """Return the difficulty profile for sequence ``idx`` in this dataset.
+
+        Args:
+            idx: Index in the filtered dataset (not the original dataset index).
+        """
+        if idx < 0 or idx >= len(self._indices):
+            raise IndexError(
+                f"Index {idx} out of range [0, {len(self._indices)})."
+            )
+        return self._difficulties[self._indices[idx]]
+
+    def __repr__(self) -> str:
+        return (
+            f"DifficultyFilteredDataset("
+            f"tiers={self.tiers!r}, "
+            f"n_sequences={len(self)}/{len(self._dataset)})"
+        )

--- a/scripts/analyze_difficulty.py
+++ b/scripts/analyze_difficulty.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Sequence difficulty analysis CLI for EOVOT datasets.
+
+Analyses a dataset's ground-truth bounding boxes and produces a per-sequence
+difficulty report (score, tier, challenge tags) plus a dataset-level summary.
+No frame images are loaded — only GT boxes are read, so the analysis is fast
+even for large datasets.
+
+Outputs (written to --output-dir):
+  <name>-difficulty.json   Full per-sequence difficulty profiles (JSON)
+  <name>-difficulty.md     Formatted Markdown table sorted by difficulty
+
+Usage
+-----
+    # Analyse the SyntheticDataset (no download required):
+    python scripts/analyze_difficulty.py \\
+        --dataset-loader SyntheticDataset \\
+        --dataset-name Synthetic \\
+        --num-sequences 20 \\
+        --motion random
+
+    # Analyse a real OTB dataset:
+    python scripts/analyze_difficulty.py \\
+        --dataset-loader OTBDataset \\
+        --dataset-root /data/OTB100 \\
+        --dataset-name OTB100
+
+    # Show only hard sequences:
+    python scripts/analyze_difficulty.py \\
+        --dataset-loader SyntheticDataset \\
+        --dataset-name Synthetic \\
+        --filter-tier hard \\
+        --top 10
+
+    # Use custom challenge thresholds:
+    python scripts/analyze_difficulty.py \\
+        --dataset-loader SyntheticDataset \\
+        --dataset-name Synthetic \\
+        --scr-threshold 0.20 \\
+        --mv-threshold 0.15
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from eovot.datasets.difficulty import (
+    DifficultyFilteredDataset,
+    SequenceDifficultyAnalyzer,
+)
+
+
+def _build_dataset(args: argparse.Namespace):
+    """Instantiate the requested dataset from CLI arguments."""
+    from eovot.datasets.base import OTBDataset
+    from eovot.datasets.got10k import GOT10kDataset
+    from eovot.datasets.lasot import LaSOTDataset
+    from eovot.datasets.synthetic import SyntheticDataset
+
+    loader = args.dataset_loader
+    if loader == "SyntheticDataset":
+        return SyntheticDataset(
+            num_sequences=args.num_sequences,
+            num_frames=args.num_frames,
+            motion=args.motion,
+            seed=args.seed,
+        )
+    if loader == "OTBDataset":
+        if not args.dataset_root:
+            print("[ERROR] --dataset-root is required for OTBDataset.", file=sys.stderr)
+            sys.exit(1)
+        return OTBDataset(root=args.dataset_root)
+    if loader == "GOT10kDataset":
+        if not args.dataset_root:
+            print("[ERROR] --dataset-root is required for GOT10kDataset.", file=sys.stderr)
+            sys.exit(1)
+        return GOT10kDataset(
+            root=args.dataset_root,
+            split=args.split,
+            max_sequences=args.max_sequences,
+        )
+    if loader == "LaSOTDataset":
+        if not args.dataset_root:
+            print("[ERROR] --dataset-root is required for LaSOTDataset.", file=sys.stderr)
+            sys.exit(1)
+        return LaSOTDataset(
+            root=args.dataset_root,
+            split=args.split,
+            max_sequences=args.max_sequences,
+        )
+    print(f"[ERROR] Unknown dataset loader: {loader}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="analyze_difficulty",
+        description="Analyse EOVOT dataset difficulty from ground-truth bounding boxes.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Dataset selection
+    parser.add_argument(
+        "--dataset-loader",
+        default="SyntheticDataset",
+        choices=["SyntheticDataset", "OTBDataset", "GOT10kDataset", "LaSOTDataset"],
+        help="Dataset loader to use.",
+    )
+    parser.add_argument("--dataset-root", default=None,
+                        help="Root path for OTB / GOT-10k / LaSOT datasets.")
+    parser.add_argument("--dataset-name", default="dataset",
+                        help="Human-readable label used in output filenames.")
+    parser.add_argument("--split", default="val",
+                        help="Dataset split (GOT-10k / LaSOT only).")
+    parser.add_argument("--max-sequences", type=int, default=None,
+                        help="Cap on sequences to analyse.")
+
+    # SyntheticDataset options
+    parser.add_argument("--num-sequences", type=int, default=10,
+                        help="Number of sequences (SyntheticDataset only).")
+    parser.add_argument("--num-frames", type=int, default=100,
+                        help="Frames per sequence (SyntheticDataset only).")
+    parser.add_argument("--motion", default="random",
+                        choices=["linear", "circular", "random"],
+                        help="Motion pattern (SyntheticDataset only).")
+    parser.add_argument("--seed", type=int, default=42,
+                        help="RNG seed (SyntheticDataset only).")
+
+    # Difficulty thresholds
+    parser.add_argument("--scr-threshold", type=float, default=0.15,
+                        help="SCR threshold for SCALE_CHANGE tag.")
+    parser.add_argument("--mv-threshold", type=float, default=0.10,
+                        help="MV threshold for FAST_MOTION tag.")
+    parser.add_argument("--arj-threshold", type=float, default=0.12,
+                        help="ARJ threshold for DEFORMATION tag.")
+    parser.add_argument("--dfr-threshold", type=float, default=0.05,
+                        help="DFR threshold for OCCLUSION tag.")
+
+    # Output / filtering options
+    parser.add_argument("--output-dir", default="results/difficulty",
+                        help="Directory for output files.")
+    parser.add_argument("--filter-tier", default=None,
+                        choices=["easy", "medium", "hard"],
+                        help="If set, only report sequences with this difficulty tier.")
+    parser.add_argument("--top", type=int, default=None,
+                        help="Show only the top N hardest sequences.")
+    parser.add_argument("--quiet", action="store_true",
+                        help="Suppress console output (write files only).")
+
+    args = parser.parse_args()
+
+    dataset = _build_dataset(args)
+
+    analyzer = SequenceDifficultyAnalyzer(
+        scr_threshold=args.scr_threshold,
+        mv_threshold=args.mv_threshold,
+        arj_threshold=args.arj_threshold,
+        dfr_threshold=args.dfr_threshold,
+    )
+
+    if not args.quiet:
+        print(f"\nAnalysing {len(dataset)} sequences from {args.dataset_name} ...")
+
+    difficulties = analyzer.analyze_dataset(dataset)
+    summary = analyzer.dataset_summary(difficulties)
+
+    if args.filter_tier:
+        indices = analyzer.filter_by_tier(difficulties, [args.filter_tier])
+        difficulties = [difficulties[i] for i in indices]
+        if not args.quiet:
+            print(
+                f"  → Filtered to {len(difficulties)} "
+                f"'{args.filter_tier}' sequences."
+            )
+
+    if not args.quiet:
+        print("\n" + "=" * 60)
+        print(f"  DIFFICULTY SUMMARY — {args.dataset_name}")
+        print("=" * 60)
+        print(f"  Total sequences : {summary['num_sequences']}")
+        print(f"  Mean difficulty : {summary['mean_difficulty']:.3f} "
+              f"± {summary['std_difficulty']:.3f}")
+        tc = summary["tier_counts"]
+        print(f"  Tier breakdown  : easy={tc['easy']}  "
+              f"medium={tc['medium']}  hard={tc['hard']}")
+        cc = summary["challenge_counts"]
+        print(f"  Challenges      : "
+              f"SCALE_CHANGE={cc.get('SCALE_CHANGE', 0)}  "
+              f"FAST_MOTION={cc.get('FAST_MOTION', 0)}  "
+              f"DEFORMATION={cc.get('DEFORMATION', 0)}  "
+              f"OCCLUSION={cc.get('OCCLUSION', 0)}")
+        print("=" * 60)
+
+        table = analyzer.to_markdown_table(difficulties, top_n=args.top)
+        print("\n" + table)
+
+    # Save outputs
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base = f"{args.dataset_name}-difficulty"
+
+    json_path = out_dir / f"{base}.json"
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "dataset": args.dataset_name,
+                "summary": summary,
+                "sequences": [d.to_dict() for d in difficulties],
+            },
+            fh, indent=2,
+        )
+
+    md_path = out_dir / f"{base}.md"
+    with open(md_path, "w", encoding="utf-8") as fh:
+        fh.write(f"# Difficulty Analysis — {args.dataset_name}\n\n")
+        fh.write("## Summary\n\n")
+        fh.write(f"- Total sequences: {summary['num_sequences']}\n")
+        fh.write(f"- Mean difficulty: {summary['mean_difficulty']:.3f} "
+                 f"± {summary['std_difficulty']:.3f}\n")
+        tc = summary["tier_counts"]
+        fh.write(f"- Tiers: easy={tc['easy']}, medium={tc['medium']}, hard={tc['hard']}\n\n")
+        fh.write("## Per-Sequence Difficulty\n\n")
+        fh.write(analyzer.to_markdown_table(difficulties, top_n=args.top))
+        fh.write("\n")
+
+    if not args.quiet:
+        print(f"\nResults saved to:")
+        print(f"  JSON → {json_path}")
+        print(f"  Markdown → {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_difficulty_analyzer.py
+++ b/tests/test_difficulty_analyzer.py
@@ -1,0 +1,358 @@
+"""Tests for SequenceDifficultyAnalyzer and DifficultyFilteredDataset."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eovot.datasets.difficulty import (
+    TAG_DEFORMATION,
+    TAG_FAST_MOTION,
+    TAG_OCCLUSION,
+    TAG_SCALE_CHANGE,
+    DifficultyFilteredDataset,
+    SequenceDifficulty,
+    SequenceDifficultyAnalyzer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _constant_gt(n: int = 50, x=10, y=10, w=30, h=30) -> np.ndarray:
+    """GT with a static target — zero velocity, zero scale change."""
+    return np.tile([x, y, w, h], (n, 1)).astype(np.float64)
+
+
+def _growing_gt(n: int = 50, w0: int = 20, dw: int = 1) -> np.ndarray:
+    """GT with a target that grows by dw each frame — high scale change."""
+    rows = []
+    for i in range(n):
+        w = w0 + i * dw
+        rows.append([10.0, 10.0, float(w), float(w)])
+    return np.array(rows)
+
+
+def _fast_moving_gt(n: int = 50, step: int = 10, h: int = 80, w: int = 80) -> np.ndarray:
+    """GT with fast horizontal motion."""
+    rows = []
+    for i in range(n):
+        x = (i * step) % (h - 20)
+        rows.append([float(x), 10.0, 20.0, 20.0])
+    return np.array(rows)
+
+
+def _deforming_gt(n: int = 50) -> np.ndarray:
+    """GT where width oscillates — high aspect-ratio jitter."""
+    rows = []
+    for i in range(n):
+        w = 20.0 + 10.0 * np.sin(i * 0.5)
+        rows.append([10.0, 10.0, w, 20.0])
+    return np.array(rows)
+
+
+def _occluded_gt(n: int = 50, occlusion_rate: float = 0.20) -> np.ndarray:
+    """GT where ~20% of frames have zero-area boxes (occluded)."""
+    gt = np.tile([10.0, 10.0, 30.0, 30.0], (n, 1)).astype(np.float64)
+    rng = np.random.default_rng(42)
+    occ_idx = rng.choice(n, size=int(n * occlusion_rate), replace=False)
+    gt[occ_idx] = [0.0, 0.0, 0.0, 0.0]
+    return gt
+
+
+# ---------------------------------------------------------------------------
+# SequenceDifficultyAnalyzer — individual metrics
+# ---------------------------------------------------------------------------
+
+class TestIndividualMetrics:
+    def setup_method(self):
+        self.analyzer = SequenceDifficultyAnalyzer()
+
+    def test_scr_static_target(self):
+        scr = self.analyzer.compute_scale_change_ratio(_constant_gt())
+        assert scr == pytest.approx(0.0, abs=1e-6)
+
+    def test_scr_growing_target_positive(self):
+        scr = self.analyzer.compute_scale_change_ratio(_growing_gt())
+        assert scr > 0.0
+
+    def test_mv_static_target(self):
+        mv = self.analyzer.compute_mean_velocity(_constant_gt())
+        assert mv == pytest.approx(0.0, abs=1e-6)
+
+    def test_mv_fast_motion_positive(self):
+        mv = self.analyzer.compute_mean_velocity(_fast_moving_gt())
+        assert mv > 0.0
+
+    def test_arj_static_target(self):
+        arj = self.analyzer.compute_aspect_ratio_jitter(_constant_gt())
+        assert arj == pytest.approx(0.0, abs=1e-6)
+
+    def test_arj_deforming_target_positive(self):
+        arj = self.analyzer.compute_aspect_ratio_jitter(_deforming_gt())
+        assert arj > 0.0
+
+    def test_dfr_no_occlusion(self):
+        dfr = self.analyzer.compute_degenerate_frame_ratio(_constant_gt())
+        assert dfr == pytest.approx(0.0, abs=1e-6)
+
+    def test_dfr_with_occlusion(self):
+        dfr = self.analyzer.compute_degenerate_frame_ratio(_occluded_gt())
+        assert dfr > 0.0
+
+    def test_metrics_on_short_sequence(self):
+        gt = _constant_gt(n=1)
+        assert self.analyzer.compute_scale_change_ratio(gt) == 0.0
+        assert self.analyzer.compute_mean_velocity(gt) == 0.0
+        assert self.analyzer.compute_aspect_ratio_jitter(gt) == 0.0
+
+    def test_metrics_on_empty_sequence(self):
+        gt = np.empty((0, 4))
+        assert self.analyzer.compute_degenerate_frame_ratio(gt) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# SequenceDifficultyAnalyzer — analyze()
+# ---------------------------------------------------------------------------
+
+class TestAnalyze:
+    def setup_method(self):
+        self.analyzer = SequenceDifficultyAnalyzer()
+
+    def test_analyze_returns_correct_type(self):
+        result = self.analyzer.analyze(_constant_gt(), name="seq1")
+        assert isinstance(result, SequenceDifficulty)
+        assert result.name == "seq1"
+
+    def test_analyze_static_is_easy(self):
+        result = self.analyzer.analyze(_constant_gt())
+        assert result.tier == "easy"
+        assert result.challenges == []
+
+    def test_analyze_growing_tags_scale_change(self):
+        gt = _growing_gt(n=100, w0=10, dw=2)
+        result = self.analyzer.analyze(gt)
+        assert TAG_SCALE_CHANGE in result.challenges
+
+    def test_analyze_fast_motion_tagged(self):
+        gt = _fast_moving_gt(n=100, step=15)
+        result = self.analyzer.analyze(gt)
+        assert TAG_FAST_MOTION in result.challenges
+
+    def test_analyze_deformation_tagged(self):
+        gt = _deforming_gt(n=80)
+        result = self.analyzer.analyze(gt)
+        assert TAG_DEFORMATION in result.challenges
+
+    def test_analyze_occlusion_tagged(self):
+        gt = _occluded_gt(n=80, occlusion_rate=0.20)
+        result = self.analyzer.analyze(gt)
+        assert TAG_OCCLUSION in result.challenges
+
+    def test_difficulty_score_range(self):
+        for gt in [_constant_gt(), _growing_gt(), _fast_moving_gt(), _deforming_gt()]:
+            result = self.analyzer.analyze(gt)
+            assert 0.0 <= result.difficulty_score <= 1.0
+
+    def test_analyze_invalid_shape_raises(self):
+        with pytest.raises(ValueError, match=r"\(N, 4\)"):
+            self.analyzer.analyze(np.ones((10, 3)))
+
+    def test_harder_sequence_higher_score(self):
+        static = self.analyzer.analyze(_constant_gt())
+        hard = self.analyzer.analyze(_growing_gt(n=100, w0=5, dw=3))
+        assert hard.difficulty_score >= static.difficulty_score
+
+    def test_num_frames_populated(self):
+        gt = _constant_gt(n=37)
+        result = self.analyzer.analyze(gt, name="test")
+        assert result.num_frames == 37
+
+    def test_to_dict_keys(self):
+        result = self.analyzer.analyze(_constant_gt(), name="abc")
+        d = result.to_dict()
+        for key in ["name", "tier", "difficulty_score", "challenges", "num_frames"]:
+            assert key in d
+
+
+# ---------------------------------------------------------------------------
+# SequenceDifficultyAnalyzer — analyze_dataset()
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeDataset:
+    def test_analyze_synthetic_dataset(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=5, num_frames=40, motion="linear")
+        analyzer = SequenceDifficultyAnalyzer()
+        results = analyzer.analyze_dataset(ds)
+        assert len(results) == 5
+        for r in results:
+            assert isinstance(r, SequenceDifficulty)
+            assert r.num_frames == 40
+
+    def test_dataset_summary_structure(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=6, num_frames=30, motion="random")
+        analyzer = SequenceDifficultyAnalyzer()
+        diffs = analyzer.analyze_dataset(ds)
+        summary = analyzer.dataset_summary(diffs)
+
+        assert "num_sequences" in summary
+        assert summary["num_sequences"] == 6
+        assert "tier_counts" in summary
+        assert sum(summary["tier_counts"].values()) == 6
+        assert "mean_difficulty" in summary
+        assert 0.0 <= summary["mean_difficulty"] <= 1.0
+
+    def test_dataset_summary_empty(self):
+        analyzer = SequenceDifficultyAnalyzer()
+        assert analyzer.dataset_summary([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Filter methods
+# ---------------------------------------------------------------------------
+
+class TestFilterMethods:
+    def setup_method(self):
+        self.analyzer = SequenceDifficultyAnalyzer()
+        self._diffs = [
+            self.analyzer.analyze(_constant_gt(), name="easy1"),
+            self.analyzer.analyze(_growing_gt(n=100, w0=5, dw=3), name="hard1"),
+            self.analyzer.analyze(_fast_moving_gt(n=100, step=15), name="hard2"),
+        ]
+
+    def test_filter_by_tier_easy(self):
+        indices = self.analyzer.filter_by_tier(self._diffs, ["easy"])
+        assert 0 in indices  # static sequence should be easy
+
+    def test_filter_by_tier_all_tiers_returns_all(self):
+        indices = self.analyzer.filter_by_tier(
+            self._diffs, ["easy", "medium", "hard"]
+        )
+        assert len(indices) == 3
+
+    def test_filter_by_challenge_any(self):
+        indices = self.analyzer.filter_by_challenge(
+            self._diffs, [TAG_SCALE_CHANGE], require_all=False
+        )
+        assert all(TAG_SCALE_CHANGE in self._diffs[i].challenges for i in indices)
+
+    def test_filter_by_challenge_require_all(self):
+        indices = self.analyzer.filter_by_challenge(
+            self._diffs, [TAG_SCALE_CHANGE, TAG_FAST_MOTION], require_all=True
+        )
+        for i in indices:
+            assert TAG_SCALE_CHANGE in self._diffs[i].challenges
+            assert TAG_FAST_MOTION in self._diffs[i].challenges
+
+
+# ---------------------------------------------------------------------------
+# Markdown table
+# ---------------------------------------------------------------------------
+
+class TestMarkdownTable:
+    def test_table_is_string(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=3, num_frames=30)
+        analyzer = SequenceDifficultyAnalyzer()
+        diffs = analyzer.analyze_dataset(ds)
+        table = analyzer.to_markdown_table(diffs)
+        assert isinstance(table, str)
+        assert "Rank" in table
+        assert "Score" in table
+
+    def test_top_n_limits_rows(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=10, num_frames=30)
+        analyzer = SequenceDifficultyAnalyzer()
+        diffs = analyzer.analyze_dataset(ds)
+        table = analyzer.to_markdown_table(diffs, top_n=3)
+        data_rows = [l for l in table.split("\n") if l.startswith("|") and "---" not in l and "Rank" not in l]
+        assert len(data_rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# DifficultyFilteredDataset
+# ---------------------------------------------------------------------------
+
+class TestDifficultyFilteredDataset:
+    def test_basic_filtering(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=10, num_frames=30, motion="random")
+        filtered = DifficultyFilteredDataset(ds, tiers=["easy", "medium", "hard"])
+        assert len(filtered) == len(ds)
+
+    def test_strict_tier_filter_subset(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=10, num_frames=30, motion="random")
+        easy_ds = DifficultyFilteredDataset(ds, tiers=["easy"])
+        medium_ds = DifficultyFilteredDataset(ds, tiers=["medium"])
+        hard_ds = DifficultyFilteredDataset(ds, tiers=["hard"])
+        total = len(easy_ds) + len(medium_ds) + len(hard_ds)
+        assert total == len(ds)
+
+    def test_getitem_returns_sequence(self):
+        from eovot.datasets.base import Sequence
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=6, num_frames=30, motion="linear")
+        fds = DifficultyFilteredDataset(ds, tiers=["easy", "medium", "hard"])
+        for i in range(len(fds)):
+            assert isinstance(fds[i], Sequence)
+
+    def test_out_of_range_raises(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=5, num_frames=20)
+        fds = DifficultyFilteredDataset(ds, tiers=["easy", "medium", "hard"])
+        with pytest.raises(IndexError):
+            _ = fds[len(fds)]
+
+    def test_empty_tiers_raises(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=3, num_frames=20)
+        with pytest.raises(ValueError, match="empty"):
+            DifficultyFilteredDataset(ds, tiers=[])
+
+    def test_invalid_tier_raises(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=3, num_frames=20)
+        with pytest.raises(ValueError, match="Invalid tier"):
+            DifficultyFilteredDataset(ds, tiers=["extreme"])
+
+    def test_get_difficulty_method(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=6, num_frames=30, motion="linear")
+        fds = DifficultyFilteredDataset(ds, tiers=["easy", "medium", "hard"])
+        for i in range(len(fds)):
+            diff = fds.get_difficulty(i)
+            assert isinstance(diff, SequenceDifficulty)
+
+    def test_repr(self):
+        from eovot.datasets.synthetic import SyntheticDataset
+
+        ds = SyntheticDataset(num_sequences=4, num_frames=20)
+        fds = DifficultyFilteredDataset(ds, tiers=["hard"])
+        assert "DifficultyFilteredDataset" in repr(fds)
+
+    def test_works_with_benchmark_engine(self):
+        from eovot.benchmark.engine import BenchmarkEngine
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.trackers.mosse import MOSSETracker
+
+        ds = SyntheticDataset(num_sequences=4, num_frames=20, motion="random")
+        fds = DifficultyFilteredDataset(ds, tiers=["easy", "medium", "hard"])
+        engine = BenchmarkEngine(verbose=False)
+        result = engine.run(MOSSETracker(), fds, dataset_name="Synthetic-Filtered")
+        assert len(result.sequence_results) == len(fds)


### PR DESCRIPTION
## What was added

This PR introduces `SequenceDifficultyAnalyzer` — an automatic difficulty profiling engine that derives tracking challenge attributes from ground-truth bounding boxes alone. No manual attribute annotation, no frame images loaded. Works with any EOVOT-compatible dataset.

Standard VOT benchmarks report aggregate mIoU / success AUC, but give no insight into **where** a tracker fails. Challenge-stratified evaluation (easy vs hard sequences, scale-change vs fast-motion subsets) is fundamental for understanding tracker behavior and for running meaningful ablation studies. This module provides that capability.

### What it computes

Four challenge dimensions derived purely from GT boxes:

| Metric | Symbol | Formula | Meaning |
|--------|--------|---------|---------|
| Scale Change Ratio | SCR | `std(√area) / mean(√area)` | Target size variation |
| Mean Velocity | MV | `mean(‖Δcenter‖) / mean_diagonal` | Speed relative to target size |
| Aspect Ratio Jitter | ARJ | `std(w/h)` | Shape deformation |
| Degenerate Frame Ratio | DFR | `#(area≤0) / N` | Occlusion / out-of-view |

A weighted composite difficulty score maps each sequence to **easy / medium / hard** and attaches challenge tags: `SCALE_CHANGE`, `FAST_MOTION`, `DEFORMATION`, `OCCLUSION`.

### New classes

**`SequenceDifficultyAnalyzer`**
- `analyze(gt, name)` — analyse one GT array
- `analyze_dataset(dataset)` — analyse all sequences (no images loaded)
- `filter_by_tier(difficulties, tiers)` — get indices for a difficulty tier
- `filter_by_challenge(difficulties, challenges)` — get indices by challenge tag
- `dataset_summary(difficulties)` — aggregate statistics (tier counts, tag frequency)
- `to_markdown_table(difficulties)` — publication-ready Markdown output

**`DifficultyFilteredDataset`**
- Wraps any `BaseDataset` and exposes only sequences in the requested tiers
- Drop-in replacement in `BenchmarkEngine.run()` — no other code changes needed

### Files changed

| File | Change |
|------|--------|
| `eovot/datasets/difficulty.py` | `SequenceDifficultyAnalyzer`, `SequenceDifficulty`, `DifficultyFilteredDataset`, challenge tag constants |
| `eovot/datasets/__init__.py` | Export new public API |
| `tests/test_difficulty_analyzer.py` | 39 unit + integration tests (all pass) |
| `scripts/analyze_difficulty.py` | CLI: per-sequence difficulty report (JSON + Markdown output) |
| `configs/experiments/difficulty_filtered.yaml` | Ready-to-run hard-set benchmark experiment |

### Example usage

```python
from eovot.datasets.synthetic import SyntheticDataset
from eovot.datasets.difficulty import SequenceDifficultyAnalyzer, DifficultyFilteredDataset

dataset  = SyntheticDataset(num_sequences=20, num_frames=100, motion="random")
analyzer = SequenceDifficultyAnalyzer()

difficulties = analyzer.analyze_dataset(dataset)
print(analyzer.to_markdown_table(difficulties, top_n=10))

summary = analyzer.dataset_summary(difficulties)
# {'tier_counts': {'easy': 8, 'medium': 9, 'hard': 3}, ...}

# Stress-test on hard sequences only
hard_ds = DifficultyFilteredDataset(dataset, tiers=["hard"])
result  = BenchmarkEngine(verbose=True).run(MOSSETracker(), hard_ds, dataset_name="Hard")
```

CLI:
```bash
# Analyse a dataset (no download required)
python scripts/analyze_difficulty.py \
    --dataset-loader SyntheticDataset \
    --dataset-name Synthetic \
    --num-sequences 20 \
    --motion random

# Show only hard sequences, custom thresholds
python scripts/analyze_difficulty.py \
    --dataset-loader SyntheticDataset \
    --filter-tier hard \
    --scr-threshold 0.20 \
    --top 5
```

### Test results

```
39 passed in 0.96s   (+ 438 existing tests continue to pass)
```

### Research value

- **Challenge-stratified papers**: Report mIoU separately for easy/medium/hard subsets — more informative than a single aggregate number.
- **Curriculum experiments**: Train or evaluate trackers on progressively harder subsets.
- **Works on any dataset**: No pre-existing attribute labels needed (works on GOT-10k, LaSOT, OTB, and custom sequences).
- **No images loaded**: Entire analysis runs from GT boxes only — near-instant even on 10k-sequence datasets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyFajznDqvzhxNTkHzbG4h)_