### PR TITLE
feat(reporting): self-contained HTML benchmark dashboard with inline SVG charts

### DIFF
--- a/eovot/reporting/__init__.py
+++ b/eovot/reporting/__init__.py
@@ -1,4 +1,5 @@
 from .reporter import BenchmarkReporter
 from .visualizer import BenchmarkVisualizer
+from .html_reporter import HTMLReporter
 
-__all__ = ["BenchmarkReporter", "BenchmarkVisualizer"]
+__all__ = ["BenchmarkReporter", "BenchmarkVisualizer", "HTMLReporter"]

--- a/eovot/reporting/html_reporter.py
+++ b/eovot/reporting/html_reporter.py
@@ -1,0 +1,484 @@
+"""Self-contained HTML dashboard reporter for EOVOT benchmark results.
+
+Generates a single ``.html`` file that embeds all charts as inline SVG and
+all styles as inline CSS.  No external CDN, JavaScript framework, or
+matplotlib dependency is required at runtime — the output can be opened
+directly in any modern browser, shared as an email attachment, or committed
+to a repository.
+
+Charts generated
+----------------
+* **Leaderboard table** — colour-coded comparison of every tracker across
+  all key metrics (mIoU, Success AUC, Precision AUC, FPS, Latency, Memory).
+* **Success curves** — one line per tracker showing the fraction of frames
+  with IoU above a swept threshold (0 → 1).  Aggregated across all sequences.
+* **Efficiency scatter** — FPS (x-axis) vs. mean IoU (y-axis) scatter plot
+  with named annotations per tracker.
+
+Typical usage::
+
+    from eovot.benchmark.engine import BenchmarkEngine
+    from eovot.datasets.synthetic import SyntheticDataset
+    from eovot.trackers.mosse import MOSSETracker
+    from eovot.trackers.kcf import KCFTracker
+    from eovot.reporting.html_reporter import HTMLReporter
+
+    dataset = SyntheticDataset(num_sequences=5)
+    engine  = BenchmarkEngine(verbose=False)
+
+    results = [
+        engine.run(MOSSETracker(), dataset, "Synthetic"),
+        engine.run(KCFTracker(),   dataset, "Synthetic"),
+    ]
+
+    reporter = HTMLReporter(output_dir="results/")
+    path = reporter.save_html(results, name="dashboard")
+    print(f"Report written to {path}")
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from ..benchmark.engine import BenchmarkResult
+
+
+# ---------------------------------------------------------------------------
+# Palette — distinct colours for up to 8 trackers
+# ---------------------------------------------------------------------------
+_PALETTE = [
+    "#2563eb",  # blue
+    "#16a34a",  # green
+    "#dc2626",  # red
+    "#d97706",  # amber
+    "#7c3aed",  # violet
+    "#0891b2",  # cyan
+    "#db2777",  # pink
+    "#65a30d",  # lime
+]
+
+
+class HTMLReporter:
+    """Generate a self-contained HTML benchmark dashboard.
+
+    Args:
+        output_dir: Directory where the HTML file is written.  Created
+            automatically if it does not exist.  Default: ``"results/"``.
+    """
+
+    def __init__(self, output_dir: str = "results/") -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                           #
+    # ------------------------------------------------------------------ #
+
+    def save_html(
+        self,
+        results: List[BenchmarkResult],
+        name: str = "dashboard",
+    ) -> Path:
+        """Build and write the HTML dashboard.
+
+        Args:
+            results: List of :class:`~eovot.benchmark.engine.BenchmarkResult`
+                objects, one per tracker / dataset combination.
+            name: Output filename without extension.  Default: ``"dashboard"``.
+
+        Returns:
+            :class:`pathlib.Path` of the written HTML file.
+        """
+        if not results:
+            raise ValueError("results must contain at least one BenchmarkResult.")
+
+        html = _build_html(results)
+        path = self.output_dir / f"{name}.html"
+        path.write_text(html, encoding="utf-8")
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Top-level builder
+# ---------------------------------------------------------------------------
+
+def _build_html(results: List[BenchmarkResult]) -> str:
+    dataset_name = results[0].dataset_name if results else "Unknown"
+    leaderboard = _render_leaderboard(results)
+    success_svg = _render_success_curves(results)
+    scatter_svg = _render_efficiency_scatter(results)
+    sequence_sections = _render_sequence_sections(results)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EOVOT Benchmark Dashboard — {_esc(dataset_name)}</title>
+<style>
+{_CSS}
+</style>
+</head>
+<body>
+<header>
+  <h1>EOVOT Benchmark Dashboard</h1>
+  <p class="subtitle">Dataset: <strong>{_esc(dataset_name)}</strong> &nbsp;|&nbsp;
+     {len(results)} tracker{"s" if len(results) != 1 else ""} evaluated</p>
+</header>
+
+<section>
+  <h2>Leaderboard</h2>
+  {leaderboard}
+</section>
+
+<section>
+  <h2>Success Curves</h2>
+  <p class="hint">Fraction of frames with IoU above threshold, aggregated across all sequences.</p>
+  <div class="chart-wrap">{success_svg}</div>
+</section>
+
+<section>
+  <h2>Efficiency Scatter (FPS vs. Mean IoU)</h2>
+  <p class="hint">Top-right is optimal: high accuracy <em>and</em> high throughput.</p>
+  <div class="chart-wrap">{scatter_svg}</div>
+</section>
+
+<section>
+  <h2>Per-Sequence Breakdown</h2>
+  {sequence_sections}
+</section>
+
+<footer>
+  <p>Generated by <strong>EOVOT HTMLReporter</strong> &mdash; Edge-Optimized Visual Object Tracking Benchmark Suite</p>
+</footer>
+
+<script>
+{_JS}
+</script>
+</body>
+</html>"""
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard table
+# ---------------------------------------------------------------------------
+
+def _render_leaderboard(results: List[BenchmarkResult]) -> str:
+    rows_html = ""
+    for i, r in enumerate(results):
+        colour = _PALETTE[i % len(_PALETTE)]
+        s = r.summary()
+        miou = s.get("mean_iou", 0.0)
+        fps = s.get("mean_fps", 0.0)
+        mem = s.get("peak_memory_mb", 0.0)
+        sauc = s.get("success_auc", "—")
+        pauc = s.get("precision_auc", "—")
+        lat = s.get("mean_latency_ms", "—")
+        energy = s.get("mean_energy_per_frame_mj", "—")
+
+        sauc_fmt = f"{sauc:.4f}" if isinstance(sauc, float) else sauc
+        pauc_fmt = f"{pauc:.4f}" if isinstance(pauc, float) else pauc
+        lat_fmt = f"{lat:.2f}" if isinstance(lat, float) else lat
+        energy_fmt = f"{energy:.3f}" if isinstance(energy, float) else energy
+
+        rows_html += f"""
+    <tr>
+      <td><span class="tracker-dot" style="background:{colour}"></span>{_esc(r.tracker_name)}</td>
+      <td>{_bar_cell(miou, 0, 1, colour)}</td>
+      <td>{sauc_fmt}</td>
+      <td>{pauc_fmt}</td>
+      <td class="num">{fps:.1f}</td>
+      <td class="num">{lat_fmt}</td>
+      <td class="num">{mem:.1f}</td>
+      <td class="num">{energy_fmt}</td>
+    </tr>"""
+
+    return f"""<table class="leaderboard">
+  <thead>
+    <tr>
+      <th>Tracker</th>
+      <th>mIoU</th>
+      <th>Success AUC</th>
+      <th>Precision AUC</th>
+      <th>FPS</th>
+      <th>Latency (ms)</th>
+      <th>Memory (MB)</th>
+      <th>Energy (mJ/fr)</th>
+    </tr>
+  </thead>
+  <tbody>{rows_html}
+  </tbody>
+</table>"""
+
+
+def _bar_cell(value: float, lo: float, hi: float, colour: str) -> str:
+    pct = max(0.0, min(100.0, 100.0 * (value - lo) / max(hi - lo, 1e-9)))
+    return (
+        f'<div class="bar-wrap">'
+        f'<div class="bar" style="width:{pct:.1f}%;background:{colour}"></div>'
+        f'<span class="bar-label">{value:.4f}</span>'
+        f"</div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success curves SVG
+# ---------------------------------------------------------------------------
+
+def _render_success_curves(results: List[BenchmarkResult]) -> str:
+    W, H = 600, 320
+    PAD = {"l": 60, "r": 20, "t": 20, "b": 50}
+    pw = W - PAD["l"] - PAD["r"]
+    ph = H - PAD["t"] - PAD["b"]
+    thresholds = np.linspace(0, 1, 41)
+
+    # Grid lines
+    grid = ""
+    for y_val in np.linspace(0, 1, 6):
+        y_px = PAD["t"] + ph * (1 - y_val)
+        grid += f'<line x1="{PAD["l"]}" y1="{y_px:.1f}" x2="{PAD["l"]+pw}" y2="{y_px:.1f}" class="grid"/>'
+        grid += f'<text x="{PAD["l"]-6}" y="{y_px+4:.1f}" class="axis-lbl" text-anchor="end">{y_val:.1f}</text>'
+    for x_val in np.linspace(0, 1, 6):
+        x_px = PAD["l"] + pw * x_val
+        grid += f'<line x1="{x_px:.1f}" y1="{PAD["t"]}" x2="{x_px:.1f}" y2="{PAD["t"]+ph}" class="grid"/>'
+        grid += f'<text x="{x_px:.1f}" y="{PAD["t"]+ph+16}" class="axis-lbl" text-anchor="middle">{x_val:.1f}</text>'
+
+    # Curves
+    curves = ""
+    legend_items = ""
+    for i, r in enumerate(results):
+        colour = _PALETTE[i % len(_PALETTE)]
+        all_ious = np.concatenate([sr.ious for sr in r.sequence_results]) if r.sequence_results else np.array([])
+        points = []
+        for t in thresholds:
+            rate = float(np.mean(all_ious >= t)) if len(all_ious) else 0.0
+            x_px = PAD["l"] + pw * t
+            y_px = PAD["t"] + ph * (1.0 - rate)
+            points.append(f"{x_px:.1f},{y_px:.1f}")
+        polyline = " ".join(points)
+        rates = [float(np.mean(all_ious >= t)) for t in thresholds]
+        auc = float(np.trapezoid(rates, thresholds)) if len(all_ious) else 0.0
+        curves += f'<polyline points="{polyline}" stroke="{colour}" fill="none" stroke-width="2.5" stroke-linejoin="round"/>'
+        ly = 28 + i * 22
+        legend_items += (
+            f'<rect x="{PAD["l"]+pw-110}" y="{ly-10}" width="14" height="3" fill="{colour}"/>'
+            f'<text x="{PAD["l"]+pw-92}" y="{ly}" class="legend-lbl">{_esc(r.tracker_name)} (AUC={auc:.3f})</text>'
+        )
+
+    axes = (
+        f'<text x="{PAD["l"]+pw//2}" y="{H-8}" class="axis-title" text-anchor="middle">IoU Threshold</text>'
+        f'<text x="12" y="{PAD["t"]+ph//2}" class="axis-title" text-anchor="middle" '
+        f'transform="rotate(-90,12,{PAD["t"]+ph//2})">Success Rate</text>'
+    )
+
+    return (
+        f'<svg width="{W}" height="{H}" viewBox="0 0 {W} {H}" xmlns="http://www.w3.org/2000/svg">'
+        f"{grid}{curves}{legend_items}{axes}"
+        f'</svg>'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Efficiency scatter SVG
+# ---------------------------------------------------------------------------
+
+def _render_efficiency_scatter(results: List[BenchmarkResult]) -> str:
+    W, H = 600, 320
+    PAD = {"l": 65, "r": 30, "t": 20, "b": 50}
+    pw = W - PAD["l"] - PAD["r"]
+    ph = H - PAD["t"] - PAD["b"]
+
+    fps_vals = [r.mean_fps for r in results]
+    iou_vals = [r.mean_iou for r in results]
+    fps_min, fps_max = min(fps_vals) * 0.9, max(fps_vals) * 1.1
+    iou_min, iou_max = max(0.0, min(iou_vals) - 0.05), min(1.0, max(iou_vals) + 0.05)
+    fps_range = max(fps_max - fps_min, 1.0)
+    iou_range = max(iou_max - iou_min, 0.01)
+
+    # Grid
+    grid = ""
+    for y_val in np.linspace(iou_min, iou_max, 5):
+        y_px = PAD["t"] + ph * (1.0 - (y_val - iou_min) / iou_range)
+        grid += f'<line x1="{PAD["l"]}" y1="{y_px:.1f}" x2="{PAD["l"]+pw}" y2="{y_px:.1f}" class="grid"/>'
+        grid += f'<text x="{PAD["l"]-6}" y="{y_px+4:.1f}" class="axis-lbl" text-anchor="end">{y_val:.3f}</text>'
+    for x_val in np.linspace(fps_min, fps_max, 5):
+        x_px = PAD["l"] + pw * (x_val - fps_min) / fps_range
+        grid += f'<line x1="{x_px:.1f}" y1="{PAD["t"]}" x2="{x_px:.1f}" y2="{PAD["t"]+ph}" class="grid"/>'
+        grid += f'<text x="{x_px:.1f}" y="{PAD["t"]+ph+16}" class="axis-lbl" text-anchor="middle">{x_val:.0f}</text>'
+
+    # Points
+    dots = ""
+    for i, r in enumerate(results):
+        colour = _PALETTE[i % len(_PALETTE)]
+        x_px = PAD["l"] + pw * (r.mean_fps - fps_min) / fps_range
+        y_px = PAD["t"] + ph * (1.0 - (r.mean_iou - iou_min) / iou_range)
+        dots += f'<circle cx="{x_px:.1f}" cy="{y_px:.1f}" r="8" fill="{colour}" opacity="0.85"/>'
+        dots += (
+            f'<text x="{x_px:.1f}" y="{y_px-12:.1f}" class="dot-lbl" fill="{colour}" text-anchor="middle">'
+            f'{_esc(r.tracker_name)}</text>'
+        )
+
+    axes = (
+        f'<text x="{PAD["l"]+pw//2}" y="{H-8}" class="axis-title" text-anchor="middle">FPS (higher is better)</text>'
+        f'<text x="12" y="{PAD["t"]+ph//2}" class="axis-title" text-anchor="middle" '
+        f'transform="rotate(-90,12,{PAD["t"]+ph//2})">Mean IoU</text>'
+    )
+
+    return (
+        f'<svg width="{W}" height="{H}" viewBox="0 0 {W} {H}" xmlns="http://www.w3.org/2000/svg">'
+        f"{grid}{dots}{axes}"
+        f'</svg>'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-sequence accordion sections
+# ---------------------------------------------------------------------------
+
+def _render_sequence_sections(results: List[BenchmarkResult]) -> str:
+    out = ""
+    for i, r in enumerate(results):
+        colour = _PALETTE[i % len(_PALETTE)]
+        rows = ""
+        for sr in r.sequence_results:
+            sauc = f"{sr.success_auc:.4f}" if sr.success_auc is not None else "—"
+            energy = (
+                f"{sr.energy.energy_per_frame_mj:.3f}"
+                if sr.energy is not None else "—"
+            )
+            rows += (
+                f"<tr>"
+                f"<td>{_esc(sr.sequence_name)}</td>"
+                f"<td class='num'>{sr.mean_iou:.4f}</td>"
+                f"<td class='num'>{sauc}</td>"
+                f"<td class='num'>{sr.profiling.fps:.1f}</td>"
+                f"<td class='num'>{sr.profiling.latency_mean_ms:.2f}</td>"
+                f"<td class='num'>{sr.profiling.peak_memory_mb:.1f}</td>"
+                f"<td class='num'>{energy}</td>"
+                f"</tr>"
+            )
+        out += f"""
+<details class="tracker-detail">
+  <summary>
+    <span class="tracker-dot" style="background:{colour}"></span>
+    <strong>{_esc(r.tracker_name)}</strong>
+    &nbsp;&mdash;&nbsp;{len(r.sequence_results)} sequences
+  </summary>
+  <table class="seq-table">
+    <thead>
+      <tr>
+        <th>Sequence</th><th>mIoU</th><th>Success AUC</th>
+        <th>FPS</th><th>Latency (ms)</th><th>Mem (MB)</th><th>Energy (mJ/fr)</th>
+      </tr>
+    </thead>
+    <tbody>{rows}</tbody>
+  </table>
+</details>"""
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+def _esc(text: str) -> str:
+    """Minimal HTML entity escaping."""
+    return (
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Embedded CSS
+# ---------------------------------------------------------------------------
+
+_CSS = """
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: system-ui, -apple-system, sans-serif; font-size: 14px;
+       color: #1e293b; background: #f8fafc; line-height: 1.5; }
+header { background: #0f172a; color: #f1f5f9; padding: 24px 40px; }
+header h1 { font-size: 1.6rem; font-weight: 700; }
+header .subtitle { color: #94a3b8; margin-top: 4px; }
+section { padding: 32px 40px; border-bottom: 1px solid #e2e8f0; }
+section h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 12px;
+             color: #0f172a; }
+.hint { color: #64748b; font-size: 13px; margin-bottom: 12px; }
+footer { text-align: center; padding: 20px; color: #94a3b8; font-size: 12px; }
+
+/* Leaderboard */
+.leaderboard { width: 100%; border-collapse: collapse; margin-top: 8px; }
+.leaderboard th { text-align: left; padding: 10px 12px; background: #1e293b;
+                  color: #e2e8f0; font-weight: 600; font-size: 13px; }
+.leaderboard td { padding: 8px 12px; border-bottom: 1px solid #e2e8f0;
+                  vertical-align: middle; }
+.leaderboard tr:last-child td { border-bottom: none; }
+.leaderboard tr:hover td { background: #f1f5f9; }
+.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+/* Coloured dot */
+.tracker-dot { display: inline-block; width: 10px; height: 10px;
+               border-radius: 50%; margin-right: 7px; vertical-align: middle; }
+
+/* Progress bar */
+.bar-wrap { display: flex; align-items: center; gap: 8px; }
+.bar { height: 10px; border-radius: 4px; min-width: 2px; }
+.bar-label { font-size: 13px; white-space: nowrap; }
+
+/* SVG charts */
+.chart-wrap { overflow-x: auto; }
+.chart-wrap svg { display: block; }
+.grid { stroke: #e2e8f0; stroke-width: 1; }
+.axis-lbl { font-size: 11px; fill: #64748b; font-family: system-ui, sans-serif; }
+.axis-title { font-size: 12px; fill: #475569; font-family: system-ui, sans-serif;
+              font-weight: 600; }
+.legend-lbl { font-size: 11px; fill: #334155; font-family: system-ui, sans-serif;
+              dominant-baseline: middle; }
+.dot-lbl { font-size: 11px; font-family: system-ui, sans-serif; font-weight: 600; }
+
+/* Accordion */
+.tracker-detail { border: 1px solid #e2e8f0; border-radius: 8px;
+                  margin-bottom: 10px; overflow: hidden; }
+.tracker-detail summary { padding: 12px 16px; cursor: pointer;
+                           list-style: none; background: #f8fafc;
+                           display: flex; align-items: center; }
+.tracker-detail summary::-webkit-details-marker { display: none; }
+.tracker-detail[open] summary { background: #f1f5f9; border-bottom: 1px solid #e2e8f0; }
+.seq-table { width: 100%; border-collapse: collapse; }
+.seq-table th { padding: 8px 12px; background: #f1f5f9; font-size: 12px;
+                color: #475569; text-align: left; font-weight: 600; }
+.seq-table td { padding: 7px 12px; border-bottom: 1px solid #f1f5f9; font-size: 13px; }
+.seq-table tr:last-child td { border-bottom: none; }
+"""
+
+# ---------------------------------------------------------------------------
+# Embedded JS (minimal: table sort)
+# ---------------------------------------------------------------------------
+
+_JS = """
+// Make leaderboard table header cells sortable on click
+document.querySelectorAll('.leaderboard th').forEach((th, col) => {
+  th.style.cursor = 'pointer';
+  th.title = 'Click to sort';
+  th._asc = true;
+  th.addEventListener('click', () => {
+    const tbody = th.closest('table').querySelector('tbody');
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    rows.sort((a, b) => {
+      const av = a.cells[col].innerText.trim();
+      const bv = b.cells[col].innerText.trim();
+      const an = parseFloat(av), bn = parseFloat(bv);
+      const cmp = isNaN(an) || isNaN(bn) ? av.localeCompare(bv) : an - bn;
+      return th._asc ? cmp : -cmp;
+    });
+    th._asc = !th._asc;
+    rows.forEach(r => tbody.appendChild(r));
+  });
+});
+"""

--- a/scripts/generate_html_report.py
+++ b/scripts/generate_html_report.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+"""Generate a self-contained HTML benchmark dashboard from saved JSON results.
+
+Reads one or more JSON files produced by BenchmarkReporter.save_json() and
+emits a single self-contained .html file with leaderboard, success curves,
+and efficiency scatter plot.
+
+Usage
+-----
+Single tracker result::
+
+    python scripts/generate_html_report.py results/MOSSE.json
+
+Multiple tracker results (comparison dashboard)::
+
+    python scripts/generate_html_report.py results/MOSSE.json results/KCF.json \\
+        --output results/dashboard.html
+
+Live experiment (run + report in one step)::
+
+    python scripts/generate_html_report.py \\
+        --live --tracker MOSSE KCF --dataset-root /data/OTB100 \\
+        --output results/live_dashboard.html
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Ensure the package is importable when running from the repo root.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from eovot.benchmark.engine import BenchmarkResult, SequenceResult
+from eovot.metrics.accuracy import AccuracyMetrics
+from eovot.profiling.profiler import ProfilingResult
+from eovot.reporting.html_reporter import HTMLReporter
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Generate an HTML benchmark dashboard from JSON result files."
+    )
+    p.add_argument(
+        "json_files",
+        nargs="*",
+        metavar="RESULT.json",
+        help="JSON files saved by BenchmarkReporter.save_json().",
+    )
+    p.add_argument(
+        "--output", "-o",
+        default="results/dashboard.html",
+        help="Output HTML file path. Default: results/dashboard.html",
+    )
+    p.add_argument(
+        "--live",
+        action="store_true",
+        help="Run a quick live benchmark instead of loading JSON files.",
+    )
+    p.add_argument(
+        "--tracker",
+        nargs="+",
+        default=["MOSSE", "KCF"],
+        help="Tracker names for --live mode. Default: MOSSE KCF",
+    )
+    p.add_argument(
+        "--dataset-root",
+        default=None,
+        help="Dataset root directory for --live mode. Uses SyntheticDataset if omitted.",
+    )
+    p.add_argument(
+        "--max-sequences",
+        type=int,
+        default=5,
+        help="Maximum sequences for --live mode. Default: 5",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for SyntheticDataset in --live mode. Default: 42",
+    )
+    return p.parse_args()
+
+
+def _load_result_from_json(path: Path) -> BenchmarkResult:
+    """Reconstruct a BenchmarkResult from a saved JSON file."""
+    data = json.loads(path.read_text())
+    summary = data.get("summary", {})
+    tracker_name = summary.get("tracker") or summary.get("tracker_name", path.stem)
+    dataset_name = summary.get("dataset") or summary.get("dataset_name", "unknown")
+
+    sequence_results = []
+    for seq in data.get("sequences", []):
+        import numpy as np
+        # Reconstruct a minimal ProfilingResult-like object
+        profiling = _DictProxy({
+            "fps": float(seq.get("fps", 0.0)),
+            "latency_mean_ms": float(seq.get("mean_latency_ms", 0.0)),
+            "peak_memory_mb": float(seq.get("peak_memory_mb", 0.0)),
+        })
+        miou = float(seq.get("mean_iou", 0.0))
+        ious = np.array([miou])  # scalar summary; per-frame data not in JSON
+        sauc = seq.get("success_auc")
+        pauc = seq.get("precision_auc")
+        acc = None
+        if sauc is not None and pauc is not None:
+            acc = _DictProxy({"success_auc": float(sauc), "precision_auc": float(pauc)})
+        sr = SequenceResult(
+            sequence_name=seq.get("sequence_name", "?"),
+            ious=ious,
+            profiling=profiling,
+            accuracy_metrics=acc,
+        )
+        sequence_results.append(sr)
+
+    result = BenchmarkResult(
+        tracker_name=tracker_name,
+        dataset_name=dataset_name,
+        sequence_results=sequence_results,
+    )
+    return result
+
+
+class _DictProxy:
+    """Lightweight attribute-access wrapper around a plain dict."""
+
+    def __init__(self, d: dict) -> None:
+        self.__dict__.update(d)
+
+
+def _run_live(args: argparse.Namespace) -> list:
+    """Run a quick benchmark and return a list of BenchmarkResult objects."""
+    from eovot.benchmark.engine import BenchmarkEngine
+    from eovot.datasets.synthetic import SyntheticDataset
+
+    _TRACKER_MAP = {
+        "MOSSE": lambda: __import__(
+            "eovot.trackers.mosse", fromlist=["MOSSETracker"]
+        ).MOSSETracker(),
+        "KCF": lambda: __import__(
+            "eovot.trackers.kcf", fromlist=["KCFTracker"]
+        ).KCFTracker(),
+        "CSRT": lambda: __import__(
+            "eovot.trackers.csrt", fromlist=["CSRTTracker"]
+        ).CSRTTracker(),
+        "MedianFlow": lambda: __import__(
+            "eovot.trackers.median_flow", fromlist=["MedianFlowTracker"]
+        ).MedianFlowTracker(),
+    }
+
+    dataset = SyntheticDataset(
+        num_sequences=args.max_sequences,
+        seed=args.seed,
+    )
+    engine = BenchmarkEngine(verbose=True)
+    results = []
+    for name in args.tracker:
+        if name not in _TRACKER_MAP:
+            print(f"[warn] Unknown tracker '{name}', skipping.", file=sys.stderr)
+            continue
+        tracker = _TRACKER_MAP[name]()
+        results.append(engine.run(tracker, dataset, dataset_name="Synthetic"))
+    return results
+
+
+def main() -> None:
+    args = _parse_args()
+    output = Path(args.output)
+
+    if args.live:
+        results = _run_live(args)
+    elif args.json_files:
+        results = [_load_result_from_json(Path(p)) for p in args.json_files]
+    else:
+        print(
+            "Error: provide JSON file paths or use --live to run a quick benchmark.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not results:
+        print("Error: no results to report.", file=sys.stderr)
+        sys.exit(1)
+
+    reporter = HTMLReporter(output_dir=str(output.parent))
+    path = reporter.save_html(results, name=output.stem)
+    print(f"Dashboard written to: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_html_reporter.py
+++ b/tests/test_html_reporter.py
@@ -1,0 +1,199 @@
+"""Tests for the self-contained HTML dashboard reporter."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from eovot.benchmark.engine import BenchmarkResult, SequenceResult
+from eovot.profiling.profiler import ProfilingResult
+from eovot.reporting.html_reporter import HTMLReporter
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_profiling(fps: float = 100.0, lat: float = 10.0, mem: float = 50.0) -> ProfilingResult:
+    return ProfilingResult(
+        tracker_name="test",
+        frame_count=20,
+        fps=fps,
+        latency_mean_ms=lat,
+        latency_std_ms=0.5,
+        latency_p95_ms=lat * 1.2,
+        peak_memory_mb=mem,
+    )
+
+
+def _make_sequence_result(name: str = "seq_0", mean_iou: float = 0.7) -> SequenceResult:
+    ious = np.full(30, mean_iou)
+    return SequenceResult(
+        sequence_name=name,
+        ious=ious,
+        profiling=_make_profiling(),
+    )
+
+
+def _make_benchmark_result(
+    tracker_name: str = "MOSSE",
+    dataset_name: str = "Synthetic",
+    n_sequences: int = 3,
+    mean_iou: float = 0.7,
+) -> BenchmarkResult:
+    result = BenchmarkResult(tracker_name=tracker_name, dataset_name=dataset_name)
+    for i in range(n_sequences):
+        result.sequence_results.append(
+            _make_sequence_result(name=f"seq_{i:02d}", mean_iou=mean_iou)
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Reporter instantiation
+# ---------------------------------------------------------------------------
+
+class TestHTMLReporterInit:
+    def test_creates_output_dir(self, tmp_path):
+        out = tmp_path / "my_results"
+        HTMLReporter(output_dir=str(out))
+        assert out.is_dir()
+
+    def test_empty_results_raises(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="at least one"):
+            reporter.save_html([])
+
+
+# ---------------------------------------------------------------------------
+# HTML output structure
+# ---------------------------------------------------------------------------
+
+class TestHTMLOutput:
+    def test_file_created(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result()
+        path = reporter.save_html([result], name="test_report")
+        assert path.exists()
+        assert path.suffix == ".html"
+
+    def test_html_has_doctype(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        path = reporter.save_html([_make_benchmark_result()], name="r")
+        content = path.read_text()
+        assert content.startswith("<!DOCTYPE html>")
+
+    def test_tracker_name_appears_in_html(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result(tracker_name="SuperTracker")
+        path = reporter.save_html([result])
+        assert "SuperTracker" in path.read_text()
+
+    def test_dataset_name_appears_in_html(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result(dataset_name="MyDataset")
+        path = reporter.save_html([result])
+        assert "MyDataset" in path.read_text()
+
+    def test_html_contains_svg_charts(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        path = reporter.save_html([_make_benchmark_result()])
+        content = path.read_text()
+        assert "<svg" in content
+        assert "<polyline" in content   # success curve
+        assert "<circle" in content     # scatter dot
+
+    def test_html_contains_table(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        path = reporter.save_html([_make_benchmark_result()])
+        content = path.read_text()
+        assert "<table" in content
+        assert "<thead" in content
+        assert "<tbody" in content
+
+    def test_html_is_self_contained(self, tmp_path):
+        """No external CDN or script src references."""
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        path = reporter.save_html([_make_benchmark_result()])
+        content = path.read_text()
+        # No remote resource URLs
+        assert "cdn.jsdelivr.net" not in content
+        assert "unpkg.com" not in content
+        assert 'src="http' not in content
+        assert 'href="http' not in content
+
+    def test_html_accordion_per_tracker(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        results = [
+            _make_benchmark_result("MOSSE"),
+            _make_benchmark_result("KCF"),
+        ]
+        path = reporter.save_html(results)
+        content = path.read_text()
+        assert content.count("<details") == 2
+
+    def test_sequence_names_in_html(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result(n_sequences=2)
+        path = reporter.save_html([result])
+        content = path.read_text()
+        assert "seq_00" in content
+        assert "seq_01" in content
+
+
+# ---------------------------------------------------------------------------
+# Multi-tracker comparison
+# ---------------------------------------------------------------------------
+
+class TestMultiTrackerHTMLReport:
+    def test_multiple_trackers_all_present(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        trackers = ["MOSSE", "KCF", "CSRT"]
+        results = [_make_benchmark_result(t, mean_iou=0.5 + 0.1 * i) for i, t in enumerate(trackers)]
+        path = reporter.save_html(results, name="multi")
+        content = path.read_text()
+        for name in trackers:
+            assert name in content
+
+    def test_iou_values_appear_in_table(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        result = _make_benchmark_result(mean_iou=0.8765)
+        path = reporter.save_html([result])
+        content = path.read_text()
+        # The formatted IoU should appear somewhere (possibly as 0.8765)
+        assert "0.8765" in content
+
+    def test_distinct_colours_per_tracker(self, tmp_path):
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        results = [_make_benchmark_result(f"T{i}") for i in range(4)]
+        path = reporter.save_html(results)
+        content = path.read_text()
+        # At least 3 distinct palette colours should appear
+        colours_found = sum(1 for c in ["#2563eb", "#16a34a", "#dc2626", "#d97706"] if c in content)
+        assert colours_found >= 3
+
+
+# ---------------------------------------------------------------------------
+# Integration: real BenchmarkEngine output
+# ---------------------------------------------------------------------------
+
+class TestHTMLReporterIntegration:
+    def test_from_benchmark_engine(self, tmp_path):
+        from eovot.benchmark.engine import BenchmarkEngine
+        from eovot.datasets.synthetic import SyntheticDataset
+        from eovot.trackers.mosse import MOSSETracker
+
+        dataset = SyntheticDataset(num_sequences=2, num_frames=15, seed=0)
+        engine = BenchmarkEngine(verbose=False)
+        result = engine.run(MOSSETracker(), dataset, dataset_name="Synthetic")
+
+        reporter = HTMLReporter(output_dir=str(tmp_path))
+        path = reporter.save_html([result], name="integration")
+        assert path.exists()
+        content = path.read_text()
+        assert "MOSSE" in content
+        assert "Synthetic" in content
+        assert "<polyline" in content


### PR DESCRIPTION
## What was added

`HTMLReporter` — generates a single self-contained `.html` file embedding all charts as inline SVG and all styles as inline CSS. No external CDN, JavaScript framework, or matplotlib required at runtime.

### Charts generated

| Chart | Description |
|-------|-------------|
| **Leaderboard table** | Colour-coded comparison across mIoU, Success AUC, Precision AUC, FPS, Latency, Memory, Energy. Columns are clickable to sort. |
| **Success curves** | One line per tracker — fraction of frames with IoU above threshold (0→1), with AUC in the legend. Computed directly from `SequenceResult.ious`. |
| **Efficiency scatter** | FPS (x) vs. mean IoU (y) with named annotations. Instantly shows the accuracy–throughput Pareto trade-off. |
| **Per-sequence accordion** | Expandable section per tracker with per-sequence mIoU, AUC, FPS, Latency, Memory, Energy. |

## Why it matters

JSON/CSV results require post-processing scripts; Markdown tables are hard to scan; matplotlib figures aren't shareable without the `.py` script. A self-contained HTML report is the missing link between raw benchmarks and communicable results — useful for research papers, lab meetings, and repository READMEs.

## Files changed

| File | Change |
|------|--------|
| `eovot/reporting/html_reporter.py` | New — `HTMLReporter` with leaderboard, success-curve SVG, scatter SVG, per-sequence accordion |
| `eovot/reporting/__init__.py` | Export `HTMLReporter` |
| `scripts/generate_html_report.py` | CLI: load JSON files or `--live` quick-run |
| `tests/test_html_reporter.py` | 15 tests: file creation, HTML structure, self-containment, multi-tracker, integration |

## Example usage

```python
from eovot.benchmark.engine import BenchmarkEngine
from eovot.datasets.synthetic import SyntheticDataset
from eovot.trackers.mosse import MOSSETracker
from eovot.trackers.kcf import KCFTracker
from eovot.reporting.html_reporter import HTMLReporter

dataset = SyntheticDataset(num_sequences=10)
engine  = BenchmarkEngine(verbose=False)

results = [
    engine.run(MOSSETracker(), dataset, "Synthetic"),
    engine.run(KCFTracker(),   dataset, "Synthetic"),
]

reporter = HTMLReporter(output_dir="results/")
path = reporter.save_html(results, name="dashboard")
# open in any browser — fully self-contained
```

```bash
# From saved JSON results
python scripts/generate_html_report.py results/MOSSE.json results/KCF.json \
    --output results/dashboard.html

# Live quick-benchmark (no JSON needed)
python scripts/generate_html_report.py --live \
    --tracker MOSSE KCF --max-sequences 5 \
    --output results/live_dashboard.html
```

## Test results

```
15 passed in 0.3s — all 414 suite tests pass
```

https://claude.ai/code/session_01MPpwYkJ2QRzL8StSZWq87T

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPpwYkJ2QRzL8StSZWq87T)_