### PR TITLE
feat(experiment): integrate edge device fleet simulation into benchmark pipeline

### DIFF
--- a/configs/experiments/device_aware.yaml
+++ b/configs/experiments/device_aware.yaml
@@ -1,0 +1,60 @@
+# EOVOT — Device-Aware Deployment Analysis
+# -----------------------------------------
+# Benchmarks classical trackers on synthetic sequences and projects results
+# onto a fleet of common edge devices using DeviceSimulator.
+#
+# Output: results/experiments/device-deployment-analysis/
+#   ├── leaderboard.md          — standard accuracy + FPS ranking
+#   ├── device_report.md        — per-tracker, per-device projection table
+#   ├── device_report.json      — machine-readable version of the above
+#   └── <tracker>-Synthetic-100.{json,csv}   — full per-sequence data
+#
+# Usage:
+#   python scripts/run_experiment.py --config configs/experiments/device_aware.yaml
+
+experiment:
+  name: "device-deployment-analysis"
+  seed: 42
+  tdp_watts: 15.0           # host TDP for on-machine energy profiling
+
+  device_simulation:
+    enabled: true
+    # Subset of built-in profiles to project onto.
+    # Remove entries or set to null to use all six built-in devices.
+    devices:
+      - rpi4
+      - rpi5
+      - jetson_nano
+      - jetson_xnx
+      - coral_board
+    # Seconds of continuous tracking assumed on the target device.
+    # Controls thermal-throttling depth (0 = cold-start / burst scenario).
+    sustained_seconds: 60.0
+    # Set > 1.0 if your benchmark host is faster than a stock i7-10750H.
+    host_calibration_factor: 1.0
+
+dataset:
+  loader: SyntheticDataset
+  name: Synthetic-100
+  num_sequences: 5
+  num_frames: 100
+  frame_size: [320, 240]
+  bbox_size: [40, 40]
+  motion: linear
+  seed: 42
+
+trackers:
+  - name: MOSSE
+    params: {}
+
+  - name: KCF
+    params: {}
+
+  - name: MedianFlow
+    params: {}
+
+  - name: MIL
+    params: {}
+
+  - name: CSRT
+    params: {}

--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -158,6 +158,54 @@ class BenchmarkResult:
             sequences.append(entry)
         return {"summary": self.summary(), "sequences": sequences}
 
+    def to_profiling_result(self) -> "ProfilingResult":
+        """Synthesize a representative ProfilingResult for device-fleet simulation.
+
+        Aggregates per-sequence profiling stats using a frame-count-weighted
+        mean for latency and the cross-sequence maximum for peak memory.
+        This is the format required by :class:`~eovot.profiling.device_sim.DeviceSimulator`.
+
+        Returns:
+            A single :class:`~eovot.profiling.profiler.ProfilingResult` that
+            represents the tracker's average hardware footprint across all
+            benchmarked sequences.
+
+        Raises:
+            ValueError: If there are no sequence results or no profiled frames.
+        """
+        if not self.sequence_results:
+            raise ValueError(
+                f"Cannot synthesize ProfilingResult for '{self.tracker_name}': "
+                "no sequence results."
+            )
+        total_frames = sum(r.profiling.frame_count for r in self.sequence_results)
+        if total_frames == 0:
+            raise ValueError(
+                f"Cannot synthesize ProfilingResult for '{self.tracker_name}': "
+                "zero profiled frames across all sequences."
+            )
+        # Frame-count-weighted mean latency gives a stable cross-sequence estimate.
+        weighted_latency_ms = (
+            sum(
+                r.profiling.latency_mean_ms * r.profiling.frame_count
+                for r in self.sequence_results
+            )
+            / total_frames
+        )
+        return ProfilingResult(
+            tracker_name=self.tracker_name,
+            frame_count=total_frames,
+            fps=1_000.0 / weighted_latency_ms if weighted_latency_ms > 0 else 0.0,
+            latency_mean_ms=weighted_latency_ms,
+            latency_std_ms=float(
+                np.mean([r.profiling.latency_std_ms for r in self.sequence_results])
+            ),
+            latency_p95_ms=float(
+                np.mean([r.profiling.latency_p95_ms for r in self.sequence_results])
+            ),
+            peak_memory_mb=self.peak_memory_mb,
+        )
+
     def __str__(self) -> str:
         s = self.summary()
         base = (

--- a/eovot/experiment/__init__.py
+++ b/eovot/experiment/__init__.py
@@ -1,6 +1,7 @@
 """Experiment sub-package — reproducible multi-tracker experiment management."""
 
+from .device_report import DeviceReport
 from .runner import ExperimentRunner
 from .snapshot import ReproducibilitySnapshot
 
-__all__ = ["ExperimentRunner", "ReproducibilitySnapshot"]
+__all__ = ["DeviceReport", "ExperimentRunner", "ReproducibilitySnapshot"]

--- a/eovot/experiment/device_report.py
+++ b/eovot/experiment/device_report.py
@@ -1,0 +1,110 @@
+"""Device deployment analysis layer for EOVOT experiments.
+
+After benchmarking trackers on the host machine, this module projects each
+tracker's ProfilingResult onto all (or a selected subset of) edge devices
+using DeviceSimulator, producing per-device FPS, latency, energy, and OOM
+estimates in a single pass.
+
+Typical usage — called automatically by ExperimentRunner when
+``experiment.device_simulation.enabled: true`` is set in the config, but
+also usable standalone::
+
+    from eovot.experiment.device_report import DeviceReport
+    from eovot.profiling.profiler import ProfilingResult
+
+    # prof_map: dict of tracker_name → ProfilingResult
+    report = DeviceReport(devices=["rpi4", "jetson_nano"], sustained_seconds=60.0)
+    sim_results = report.run(prof_map)
+
+    print(report.to_markdown(sim_results))
+    json_data = report.to_summary_dicts(sim_results)
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from ..profiling.device_sim import DeviceSimResult, DeviceSimulator
+from ..profiling.profiler import ProfilingResult
+
+
+class DeviceReport:
+    """Project multiple trackers' ProfilingResults onto an edge device fleet.
+
+    Args:
+        devices: Device keys to simulate (e.g. ``["rpi4", "jetson_nano"]``).
+            ``None`` (default) uses all built-in profiles.
+        sustained_seconds: Duration of continuous tracking in seconds, used
+            for thermal-throttling modelling.  ``0.0`` = cold-start burst.
+        host_calibration_factor: Correction factor for non-reference hosts.
+            Values > 1.0 mean the benchmark host is faster than the i7
+            reference used to calibrate the built-in speed factors.
+    """
+
+    def __init__(
+        self,
+        devices: Optional[List[str]] = None,
+        sustained_seconds: float = 0.0,
+        host_calibration_factor: float = 1.0,
+    ) -> None:
+        self._sim = DeviceSimulator(host_calibration_factor=host_calibration_factor)
+        self._devices = devices
+        self._sustained = sustained_seconds
+
+    def run(
+        self,
+        profiling_by_tracker: Dict[str, ProfilingResult],
+    ) -> Dict[str, List[DeviceSimResult]]:
+        """Simulate all trackers across the device fleet.
+
+        Args:
+            profiling_by_tracker: Mapping of tracker name → ProfilingResult.
+
+        Returns:
+            Mapping of tracker name → list of DeviceSimResult, sorted by
+            estimated FPS (highest first) for each tracker.
+        """
+        return {
+            name: self._sim.simulate_all(
+                prof,
+                sustained_seconds=self._sustained,
+                device_names=self._devices,
+            )
+            for name, prof in profiling_by_tracker.items()
+        }
+
+    def to_markdown(
+        self,
+        sim_results: Dict[str, List[DeviceSimResult]],
+    ) -> str:
+        """Render per-tracker device deployment tables as Markdown.
+
+        Args:
+            sim_results: Output of :meth:`run`.
+
+        Returns:
+            Multi-section Markdown string ready to write to ``device_report.md``.
+        """
+        sections: List[str] = ["# EOVOT Device Deployment Report\n"]
+        for tracker_name, results in sim_results.items():
+            sections.append(f"## {tracker_name}\n")
+            sections.append(self._sim.to_markdown_table(results))
+            sections.append("")
+        return "\n".join(sections)
+
+    def to_summary_dicts(
+        self,
+        sim_results: Dict[str, List[DeviceSimResult]],
+    ) -> Dict[str, List[dict]]:
+        """Convert all simulation results to plain dicts for JSON export.
+
+        Args:
+            sim_results: Output of :meth:`run`.
+
+        Returns:
+            Same structure with each DeviceSimResult replaced by a plain dict.
+        """
+        return {
+            tracker: self._sim.to_summary_dict(results)
+            for tracker, results in sim_results.items()
+        }

--- a/eovot/experiment/runner.py
+++ b/eovot/experiment/runner.py
@@ -46,7 +46,10 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from ..benchmark.engine import BenchmarkEngine
+import numpy as np
+
+from ..benchmark.engine import BenchmarkEngine, BenchmarkResult
+from ..profiling.profiler import ProfilingResult
 from ..reporting.reporter import BenchmarkReporter
 from .snapshot import ReproducibilitySnapshot
 
@@ -112,6 +115,7 @@ class ExperimentRunner:
         reporter = BenchmarkReporter(output_dir=str(exp_dir))
 
         all_results: List[Dict] = []
+        benchmark_results: Dict[str, BenchmarkResult] = {}
         run_timings: Dict[str, float] = {}
 
         for tracker_cfg in tracker_cfgs:
@@ -140,10 +144,21 @@ class ExperimentRunner:
             result_dict = result.to_dict()
             reporter.save_all(result_dict, name=f"{tracker_name}-{dataset_name}")
             all_results.append(result_dict)
+            benchmark_results[tracker_name] = result
 
         leaderboard = self._build_leaderboard(all_results)
         leaderboard_path = exp_dir / "leaderboard.md"
         leaderboard_path.write_text(leaderboard, encoding="utf-8")
+
+        device_report_output: Optional[Dict] = None
+        device_sim_cfg = exp_cfg.get("device_simulation", {})
+        if device_sim_cfg.get("enabled", False):
+            device_report_output = self._run_device_report(
+                all_results=all_results,
+                benchmark_results=benchmark_results,
+                device_sim_cfg=device_sim_cfg,
+                exp_dir=exp_dir,
+            )
 
         metadata: Dict[str, Any] = {
             "experiment": exp_name,
@@ -160,11 +175,124 @@ class ExperimentRunner:
             print(f"{'=' * 60}")
             print(leaderboard)
 
-        return {
+        output: Dict[str, Any] = {
             "metadata": metadata,
             "results": all_results,
             "leaderboard": leaderboard,
         }
+        if device_report_output is not None:
+            output["device_report"] = device_report_output
+        return output
+
+    # ------------------------------------------------------------------
+    # Device deployment report
+    # ------------------------------------------------------------------
+
+    def _run_device_report(
+        self,
+        all_results: List[Dict],
+        benchmark_results: Dict[str, BenchmarkResult],
+        device_sim_cfg: Dict[str, Any],
+        exp_dir: Path,
+    ) -> Dict[str, Any]:
+        """Project tracker profiling results onto an edge device fleet.
+
+        Uses live BenchmarkResult objects when available (trackers that ran
+        in this session) and reconstructs ProfilingResult from saved JSON for
+        any resumed tracker.
+
+        Args:
+            all_results: List of result dicts (may include resumed trackers).
+            benchmark_results: Live BenchmarkResult objects for this session.
+            device_sim_cfg: ``experiment.device_simulation`` config sub-dict.
+            exp_dir: Experiment output directory for writing report files.
+
+        Returns:
+            Dict with ``"markdown_path"`` and ``"json_path"`` keys.
+        """
+        from .device_report import DeviceReport
+
+        dr = DeviceReport(
+            devices=device_sim_cfg.get("devices"),
+            sustained_seconds=float(device_sim_cfg.get("sustained_seconds", 0.0)),
+            host_calibration_factor=float(
+                device_sim_cfg.get("host_calibration_factor", 1.0)
+            ),
+        )
+
+        # Build profiling map — prefer live objects, fall back to JSON reconstruction.
+        profiling_map: Dict[str, ProfilingResult] = {}
+        for r in all_results:
+            name = r.get("summary", {}).get("tracker", "")
+            if not name:
+                continue
+            if name in benchmark_results:
+                try:
+                    profiling_map[name] = benchmark_results[name].to_profiling_result()
+                except ValueError:
+                    pass
+            else:
+                prof = self._profiling_from_dict(r, name)
+                if prof is not None:
+                    profiling_map[name] = prof
+
+        if not profiling_map:
+            return {}
+
+        sim_results = dr.run(profiling_map)
+
+        md_path = exp_dir / "device_report.md"
+        md_path.write_text(dr.to_markdown(sim_results), encoding="utf-8")
+
+        json_path = exp_dir / "device_report.json"
+        with open(json_path, "w") as fh:
+            json.dump(dr.to_summary_dicts(sim_results), fh, indent=2)
+
+        if self.verbose:
+            print(f"\n  Device report → {md_path}")
+
+        return {
+            "markdown_path": str(md_path),
+            "json_path": str(json_path),
+        }
+
+    @staticmethod
+    def _profiling_from_dict(
+        result_dict: Dict, tracker_name: str
+    ) -> Optional[ProfilingResult]:
+        """Reconstruct an approximate ProfilingResult from a saved JSON dict.
+
+        Used for resumed trackers whose live BenchmarkResult is unavailable.
+        Latency is estimated from the per-sequence mean_latency_ms values
+        stored in the JSON.
+
+        Args:
+            result_dict: Dict in the format produced by BenchmarkResult.to_dict().
+            tracker_name: Name to embed in the returned ProfilingResult.
+
+        Returns:
+            Reconstructed ProfilingResult, or None if the dict lacks the
+            required fields.
+        """
+        summary = result_dict.get("summary", {})
+        seqs = result_dict.get("sequences", [])
+        if not seqs:
+            return None
+        latencies = [
+            float(s["mean_latency_ms"]) for s in seqs if "mean_latency_ms" in s
+        ]
+        if not latencies:
+            return None
+        mean_lat = float(np.mean(latencies))
+        return ProfilingResult(
+            tracker_name=tracker_name,
+            frame_count=len(seqs) * 100,  # rough estimate; frame_count not in summary
+            fps=1_000.0 / mean_lat if mean_lat > 0 else 0.0,
+            latency_mean_ms=mean_lat,
+            latency_std_ms=float(np.std(latencies)),
+            latency_p95_ms=float(np.percentile(latencies, 95)),
+            peak_memory_mb=float(summary.get("peak_memory_mb", 0.0)),
+        )
 
     # ------------------------------------------------------------------
     # Leaderboard generation

--- a/eovot/trackers/__init__.py
+++ b/eovot/trackers/__init__.py
@@ -3,6 +3,7 @@ from .mosse import MOSSETracker
 from .kcf import KCFTracker
 from .csrt import CSRTTracker
 from .median_flow import MedianFlowTracker
+from .mil import MILTracker
 
 __all__ = [
     "BaseTracker",
@@ -11,4 +12,5 @@ __all__ = [
     "KCFTracker",
     "CSRTTracker",
     "MedianFlowTracker",
+    "MILTracker",
 ]


### PR DESCRIPTION
## What was added

The `DeviceSimulator` module (`eovot/profiling/device_sim.py`) has been fully implemented since PR #118 but was never wired into the experiment pipeline — trackers could be benchmarked on the host machine but their results were never projected onto edge targets. This PR closes that gap.

### New: `DeviceReport` orchestrator (`eovot/experiment/device_report.py`)

A thin coordination layer that accepts a `Dict[tracker_name → ProfilingResult]` and calls `DeviceSimulator.simulate_all()` for each tracker, producing:

- A ranked per-tracker Markdown table (FPS, latency, memory fit, thermal state, mJ/frame)
- A JSON export of the same data

### Extended: `BenchmarkResult.to_profiling_result()` (`eovot/benchmark/engine.py`)

New method that synthesizes a representative `ProfilingResult` from all per-sequence profiling stats using a **frame-count-weighted mean latency** and cross-sequence peak memory. This is the required input format for `DeviceSimulator`.

### Extended: `ExperimentRunner` (`eovot/experiment/runner.py`)

When `experiment.device_simulation.enabled: true` is set in the config, the runner automatically:
1. Collects live `BenchmarkResult` objects as trackers are evaluated
2. Calls `DeviceReport.run()` after all trackers complete
3. Writes `device_report.md` and `device_report.json` to the experiment directory
4. Includes `"device_report"` in the returned output dict

Resumed trackers (loaded from saved JSON) are handled via `_profiling_from_dict()`, which reconstructs a `ProfilingResult` from stored per-sequence latency values.

### New: `configs/experiments/device_aware.yaml`

Example config that runs all five classical trackers on synthetic sequences and projects results onto RPi 4, RPi 5, Jetson Nano, Jetson Xavier NX, and Google Coral.

### Fix: `MILTracker` missing from `eovot/trackers/__init__.py`

`MILTracker` was implemented and supported by `ExperimentRunner._build_tracker()` but omitted from the package's public `__all__` exports. Fixed.

---

## Why it matters

The "E" in EOVOT stands for **Edge-Optimized**. Without this integration, researchers had to manually extract profiling data and call `DeviceSimulator` in separate scripts — the benchmark pipeline produced no edge deployment insight by default. With this PR, a single config flag enables full fleet-level deployment analysis.

## Example output (`device_report.md`)

```markdown
# EOVOT Device Deployment Report

## MOSSE

| Rank | Device                      | FPS   | Latency (ms) | Mem (MB)      | Fits? | Thermal | mJ/frame |
|------|-----------------------------|------:|-------------:|--------------:|:-----:|---------|----------|
| 1    | NVIDIA Jetson Xavier NX     | 162.2 |          6.2 |   120 / 7800  |  ✓   | nominal |   64.750 |
| 2    | Raspberry Pi 5              |  54.1 |         18.5 |   120 / 7800  |  ✓   | nominal |   97.125 |
| 3    | Raspberry Pi 4B (4 GB)      |  27.0 |         37.0 |   120 / 3800  |  ✓   | nominal |  194.250 |
| 4    | NVIDIA Jetson Nano (4 GB)   |  22.5 |         44.4 |   120 / 3800  |  ✓   | nominal |  310.800 |
| 5    | Google Coral Dev Board      |  15.8 |         63.5 |   120 /  900  |  ✓   | nominal |  177.800 |
```

## Usage

```yaml
# configs/experiments/device_aware.yaml
experiment:
  name: "device-deployment-analysis"
  device_simulation:
    enabled: true
    devices: [rpi4, rpi5, jetson_nano, jetson_xnx, coral_board]
    sustained_seconds: 60.0
```

```bash
python scripts/run_experiment.py --config configs/experiments/device_aware.yaml
```

## No breaking changes

All additions are strictly additive. `device_simulation` config block defaults to `enabled: false`, so existing configs behave identically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaSrJcAMzD5YurToBsYuQh)_