### PR TITLE
feat(trackers+metrics): PSR-based confidence scoring for correlation filter trackers

### DIFF
--- a/eovot/benchmark/engine.py
+++ b/eovot/benchmark/engine.py
@@ -24,6 +24,7 @@ class SequenceResult:
     center_distances: Optional[np.ndarray] = None  # shape (N,)  — per-frame centre-distance (px)
     energy: Optional[EnergyResult] = None          # energy estimate; None when TDP not configured
     accuracy_metrics: Optional[AccuracyMetrics] = None  # success AUC, precision AUC
+    confidence_scores: Optional[np.ndarray] = None  # shape (N-1,) — per-frame PSR confidence
 
     @property
     def mean_iou(self) -> float:
@@ -240,6 +241,7 @@ class BenchmarkEngine:
         gt = seq.ground_truth
         preds: List = []
 
+        confidences: List[float] = []
         for i, frame in enumerate(frames):
             if i == 0:
                 tracker.initialize(frame, seq.init_bbox)
@@ -248,11 +250,12 @@ class BenchmarkEngine:
                 self._profiler.start_frame()
                 if self._energy_profiler is not None:
                     self._energy_profiler.start_frame()
-                bbox = tracker.update(frame)
+                bbox, conf = tracker.update_with_confidence(frame)
                 self._profiler.end_frame()
                 if self._energy_profiler is not None:
                     self._energy_profiler.end_frame()
                 preds.append(bbox)
+                confidences.append(conf)
 
         preds_arr = np.array(preds, dtype=np.float64)
         n_eval = min(len(preds_arr), len(gt))
@@ -274,6 +277,10 @@ class BenchmarkEngine:
             except ValueError:
                 pass  # sequence too short (0 update frames)
 
+        conf_arr: Optional[np.ndarray] = None
+        if confidences and confidences[0] >= 0.0:
+            conf_arr = np.array(confidences, dtype=np.float32)
+
         return SequenceResult(
             sequence_name=seq.name,
             ious=ious,
@@ -283,4 +290,5 @@ class BenchmarkEngine:
             center_distances=dists,
             energy=energy,
             accuracy_metrics=accuracy,
+            confidence_scores=conf_arr,
         )

--- a/eovot/metrics/robustness.py
+++ b/eovot/metrics/robustness.py
@@ -1,5 +1,12 @@
 """Robustness metrics for visual object tracking evaluation.
 
+.. note::
+    This module also provides :class:`ConfidenceAwareRobustnessAnalyzer`, which
+    supplements IoU-based failure detection with PSR confidence scores produced
+    by correlation-filter trackers (MOSSE, KCF).  Using confidence enables
+    *early* failure warnings before IoU collapses to zero, giving edge systems
+    time to trigger re-initialization or fallback strategies.
+
 Implements VOT-challenge-style robustness analysis on top of per-frame IoU
 arrays produced by :class:`~eovot.benchmark.engine.BenchmarkEngine`:
 
@@ -32,7 +39,7 @@ Typical usage::
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -285,3 +292,205 @@ class RobustnessAnalyzer:
                 "mean_recovery_lag_frames": round(mean_lag, 2),
             },
         }
+
+
+@dataclass
+class ConfidenceRobustnessResult:
+    """Extended robustness result that includes confidence-signal statistics."""
+
+    base: RobustnessResult
+    """Standard IoU-based robustness result."""
+
+    mean_confidence: float
+    """Mean PSR-derived confidence over the sequence (excluding init frame)."""
+
+    min_confidence: float
+    """Minimum confidence observed — indicates worst-case response quality."""
+
+    confidence_failure_rate: float
+    """Fraction of frames where confidence fell below ``confidence_threshold``."""
+
+    early_warnings: List[int]
+    """Frame indices where confidence dropped below threshold *before* a
+    corresponding IoU failure was detected — true early warnings."""
+
+    def __str__(self) -> str:
+        return (
+            f"ConfidenceRobustnessResult[{self.base.tracker_name} on "
+            f"{self.base.sequence_name}] "
+            f"failures={self.base.num_failures}  EAO={self.base.eao:.4f}  "
+            f"mean_conf={self.mean_confidence:.3f}  "
+            f"early_warnings={len(self.early_warnings)}"
+        )
+
+
+class ConfidenceAwareRobustnessAnalyzer:
+    """Extends :class:`RobustnessAnalyzer` with PSR-confidence-based analysis.
+
+    Combines per-frame IoU arrays (from ground truth) with per-frame confidence
+    scores (from the tracker's internal state, e.g. PSR) to produce richer
+    robustness diagnostics:
+
+    * **Early warning detection** — identifies frames where confidence falls
+      before IoU collapses, enabling proactive re-initialization.
+    * **Confidence-failure rate** — fraction of frames below
+      ``confidence_threshold``.
+    * **Confidence–IoU correlation** — Pearson r between confidence and IoU,
+      quantifying how predictive PSR is for this tracker/dataset combination.
+
+    Args:
+        confidence_threshold: Normalised confidence below which a frame is
+            flagged as uncertain.  Default: ``0.3``.
+        failure_threshold:    IoU threshold forwarded to the underlying
+            :class:`RobustnessAnalyzer`.  Default: ``0.1``.
+        burn_in_frames:       Frames to skip at sequence start.  Default: ``5``.
+        early_warning_lead:   How many frames *before* an IoU failure a
+            confidence drop must occur to count as a true early warning.
+            Default: ``3``.
+
+    Example::
+
+        from eovot.metrics.robustness import ConfidenceAwareRobustnessAnalyzer
+
+        analyzer = ConfidenceAwareRobustnessAnalyzer()
+        result = analyzer.analyze(ious, confidence_scores,
+                                  tracker_name="MOSSE", sequence_name="car1")
+        print(result.early_warnings)
+        print(result.base.eao)
+    """
+
+    def __init__(
+        self,
+        confidence_threshold: float = 0.3,
+        failure_threshold: float = 0.1,
+        burn_in_frames: int = 5,
+        early_warning_lead: int = 3,
+    ) -> None:
+        self.confidence_threshold = confidence_threshold
+        self.early_warning_lead = early_warning_lead
+        self._base_analyzer = RobustnessAnalyzer(
+            failure_threshold=failure_threshold,
+            recovery_threshold=failure_threshold,
+            burn_in_frames=burn_in_frames,
+        )
+
+    def analyze(
+        self,
+        ious: np.ndarray,
+        confidence_scores: np.ndarray,
+        tracker_name: str = "",
+        sequence_name: str = "",
+    ) -> ConfidenceRobustnessResult:
+        """Run combined IoU + confidence analysis on a single sequence.
+
+        Args:
+            ious:             Per-frame IoU array, shape ``(N,)``.  Includes
+                              the initialisation frame (index 0, IoU ≈ 1).
+            confidence_scores: Per-update confidence scores, shape ``(N-1,)``.
+                              Index ``i`` corresponds to frame ``i+1`` in *ious*.
+            tracker_name:     Stored in the result for reporting.
+            sequence_name:    Stored in the result for reporting.
+
+        Returns:
+            :class:`ConfidenceRobustnessResult` with both IoU-based and
+            confidence-based statistics.
+        """
+        ious = np.asarray(ious, dtype=np.float64)
+        confidence_scores = np.asarray(confidence_scores, dtype=np.float64)
+
+        base = self._base_analyzer.analyze_sequence(ious, tracker_name, sequence_name)
+
+        burn = self._base_analyzer.burn_in_frames
+        # confidence_scores are 0-indexed to update frames (frame 1 onward).
+        conf_analysis = confidence_scores[max(0, burn - 1):]
+
+        mean_conf = float(conf_analysis.mean()) if len(conf_analysis) else 0.0
+        min_conf = float(conf_analysis.min()) if len(conf_analysis) else 0.0
+        conf_failure_rate = float(
+            np.mean(conf_analysis < self.confidence_threshold)
+        ) if len(conf_analysis) else 0.0
+
+        early_warnings = self._find_early_warnings(
+            ious, confidence_scores, base.failure_frames
+        )
+
+        return ConfidenceRobustnessResult(
+            base=base,
+            mean_confidence=mean_conf,
+            min_confidence=min_conf,
+            confidence_failure_rate=conf_failure_rate,
+            early_warnings=early_warnings,
+        )
+
+    def confidence_iou_correlation(
+        self,
+        ious: np.ndarray,
+        confidence_scores: np.ndarray,
+    ) -> float:
+        """Compute Pearson correlation between confidence scores and IoU.
+
+        A high positive correlation (r > 0.5) means PSR is a reliable proxy
+        for tracking quality on this sequence/dataset, validating its use for
+        autonomous failure detection.
+
+        Args:
+            ious:             Per-frame IoU array, shape ``(N,)``.
+            confidence_scores: Per-update confidence scores, shape ``(N-1,)``.
+
+        Returns:
+            Pearson r in ``[-1, 1]``, or ``0.0`` if inputs are too short or
+            have zero variance.
+        """
+        ious = np.asarray(ious, dtype=np.float64)
+        confidence_scores = np.asarray(confidence_scores, dtype=np.float64)
+
+        n = min(len(confidence_scores), len(ious) - 1)
+        if n < 2:
+            return 0.0
+
+        iou_aligned = ious[1 : n + 1]
+        conf_aligned = confidence_scores[:n]
+
+        if iou_aligned.std() < 1e-10 or conf_aligned.std() < 1e-10:
+            return 0.0
+
+        return float(np.corrcoef(iou_aligned, conf_aligned)[0, 1])
+
+    def _find_early_warnings(
+        self,
+        ious: np.ndarray,
+        confidence_scores: np.ndarray,
+        failure_frames: List[int],
+    ) -> List[int]:
+        """Identify frames where confidence dropped before an IoU failure.
+
+        A frame ``f_conf`` is an early warning if:
+        - confidence_scores[f_conf - 1] < confidence_threshold
+        - There exists an IoU failure at frame ``f_iou`` with
+          0 < f_iou - f_conf ≤ early_warning_lead
+
+        Args:
+            ious:           Per-frame IoU array.
+            confidence_scores: Per-update confidence scores (len = len(ious)-1).
+            failure_frames: Output of :meth:`RobustnessAnalyzer.detect_failures`.
+
+        Returns:
+            Sorted list of frame indices that qualify as early warnings.
+        """
+        if not failure_frames or len(confidence_scores) == 0:
+            return []
+
+        failure_set = set(failure_frames)
+        warnings: List[int] = []
+
+        for conf_frame in range(1, len(confidence_scores) + 1):
+            if conf_frame not in failure_set:
+                conf_val = confidence_scores[conf_frame - 1]
+                if conf_val < self.confidence_threshold:
+                    # Check if a failure follows within the lead window.
+                    for lead in range(1, self.early_warning_lead + 1):
+                        if (conf_frame + lead) in failure_set:
+                            warnings.append(conf_frame)
+                            break
+
+        return sorted(set(warnings))

--- a/eovot/trackers/__init__.py
+++ b/eovot/trackers/__init__.py
@@ -3,6 +3,7 @@ from .mosse import MOSSETracker
 from .kcf import KCFTracker
 from .csrt import CSRTTracker
 from .median_flow import MedianFlowTracker
+from .confidence import compute_psr, psr_to_confidence
 
 __all__ = [
     "BaseTracker",
@@ -11,4 +12,6 @@ __all__ = [
     "KCFTracker",
     "CSRTTracker",
     "MedianFlowTracker",
+    "compute_psr",
+    "psr_to_confidence",
 ]

--- a/eovot/trackers/base.py
+++ b/eovot/trackers/base.py
@@ -19,6 +19,11 @@ class BaseTracker(ABC):
     Bounding boxes use the ``(x, y, w, h)`` convention throughout, where
     ``(x, y)`` is the top-left corner.
 
+    Trackers that produce a native confidence signal (e.g. correlation filters
+    computing PSR) should also override :meth:`update_with_confidence` to expose
+    it without redundant computation.  The default implementation calls
+    :meth:`update` and returns a sentinel confidence of ``-1.0``.
+
     Example::
 
         class MyTracker(BaseTracker):
@@ -57,6 +62,28 @@ class BaseTracker(ABC):
             Predicted bounding box ``(x, y, w, h)``.
         """
         ...
+
+    def update_with_confidence(self, frame: np.ndarray) -> Tuple[BBox, float]:
+        """Predict the target location and return a confidence score.
+
+        The confidence is a scalar in ``[0, 1]`` where 1 means very certain
+        and 0 means the tracker has likely lost the target.
+
+        Trackers that derive a native confidence signal from their internal
+        state (e.g. PSR from a correlation filter response) should override
+        this method to return it efficiently.
+
+        The default implementation delegates to :meth:`update` and returns
+        ``-1.0`` as a sentinel indicating that no confidence is available.
+
+        Args:
+            frame: BGR image as a ``(H, W, 3)`` uint8 numpy array.
+
+        Returns:
+            Tuple ``(bbox, confidence)`` where ``bbox`` is ``(x, y, w, h)``
+            and ``confidence`` is in ``[0, 1]`` or ``-1.0`` if unsupported.
+        """
+        return self.update(frame), -1.0
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r})"

--- a/eovot/trackers/confidence.py
+++ b/eovot/trackers/confidence.py
@@ -1,0 +1,95 @@
+"""Peak-to-Sidelobe Ratio (PSR) confidence estimation for correlation filters.
+
+PSR is a response-map quality metric from Bolme et al. (2010) that measures
+how sharply peaked the correlation response is relative to background noise.
+High PSR indicates the filter found a strong, localised match; low PSR
+signals that the response is flat or ambiguous — a reliable proxy for tracking
+failure without requiring ground-truth annotations.
+
+    PSR = (peak - μ_sidelobe) / σ_sidelobe
+
+where the sidelobe region excludes an (exclusion_size × exclusion_size) window
+centred on the peak.
+
+Empirical thresholds (Bolme et al. 2010):
+    PSR > 7   — confident track (strong peak)
+    3 < PSR ≤ 7 — uncertain / degraded conditions
+    PSR ≤ 3  — likely failure
+
+Reference
+---------
+Bolme, D. S. et al. "Visual object tracking using adaptive correlation filters."
+IEEE CVPR 2010, pp. 2544-2550.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def compute_psr(response: np.ndarray, exclusion_size: int = 11) -> float:
+    """Compute the Peak-to-Sidelobe Ratio of a correlation response map.
+
+    Args:
+        response:       2-D float array of shape ``(H, W)``.
+        exclusion_size: Side length (pixels) of the window centred on the peak
+                        that is excluded from the sidelobe statistics.
+                        Must be odd and positive.  Default: ``11``.
+
+    Returns:
+        PSR as a non-negative float.  Returns ``0.0`` if the sidelobe region
+        is empty (response map smaller than the exclusion window).
+
+    Raises:
+        ValueError: If *response* is not a 2-D array.
+    """
+    if response.ndim != 2:
+        raise ValueError(
+            f"response must be a 2-D array, got shape {response.shape}"
+        )
+
+    peak_val = float(response.max())
+    peak_y, peak_x = np.unravel_index(np.argmax(response), response.shape)
+
+    half = exclusion_size // 2
+    mask = np.ones(response.shape, dtype=bool)
+    y_lo = max(0, peak_y - half)
+    y_hi = min(response.shape[0], peak_y + half + 1)
+    x_lo = max(0, peak_x - half)
+    x_hi = min(response.shape[1], peak_x + half + 1)
+    mask[y_lo:y_hi, x_lo:x_hi] = False
+
+    sidelobe = response[mask]
+    if sidelobe.size == 0:
+        return 0.0
+
+    mu = float(sidelobe.mean())
+    sigma = float(sidelobe.std())
+
+    # When sigma ≈ 0 the sidelobe is perfectly flat.
+    # If the peak exceeds the flat background the PSR is effectively infinite;
+    # return a large finite value so callers can still threshold on it.
+    if sigma < 1e-10:
+        return 100.0 if peak_val > mu + 1e-10 else 0.0
+
+    return max(0.0, (peak_val - mu) / sigma)
+
+
+def psr_to_confidence(psr: float, low: float = 3.0, high: float = 7.0) -> float:
+    """Map a PSR value to a normalised confidence score in ``[0, 1]``.
+
+    Uses a linear ramp between *low* and *high*:
+
+        confidence = clip((psr - low) / (high - low), 0, 1)
+
+    Args:
+        psr:  Raw PSR value (non-negative float).
+        low:  PSR at which confidence is considered 0.  Default: ``3.0``.
+        high: PSR at which confidence saturates to 1.  Default: ``7.0``.
+
+    Returns:
+        Float in ``[0, 1]``.
+    """
+    if high <= low:
+        raise ValueError(f"high ({high}) must be greater than low ({low})")
+    return float(np.clip((psr - low) / (high - low), 0.0, 1.0))

--- a/eovot/trackers/kcf.py
+++ b/eovot/trackers/kcf.py
@@ -14,6 +14,7 @@ import cv2
 import numpy as np
 
 from .base import BaseTracker, BBox
+from .confidence import compute_psr, psr_to_confidence
 
 
 class KCFTracker(BaseTracker):
@@ -68,6 +69,7 @@ class KCFTracker(BaseTracker):
         self._xf: Optional[np.ndarray] = None
         self._window: Optional[np.ndarray] = None
         self._yf: Optional[np.ndarray] = None
+        self._last_psr: float = 0.0
 
     # ------------------------------------------------------------------
     # Public BaseTracker interface
@@ -123,6 +125,8 @@ class KCFTracker(BaseTracker):
         kzf = self._kernel_corr(self._xf, zf)
         response = np.real(np.fft.ifft2(self._alphaf * kzf))
 
+        self._last_psr = compute_psr(response)
+
         dy, dx = np.unravel_index(np.argmax(response), response.shape)
         sh, sw = response.shape
         if dy > sh // 2:
@@ -147,6 +151,15 @@ class KCFTracker(BaseTracker):
         tw, th = self._target_sz
         return (new_cx - tw / 2.0, new_cy - th / 2.0, float(tw), float(th))
 
+    def update_with_confidence(self, frame: np.ndarray) -> Tuple[BBox, float]:
+        """Track and return PSR-derived confidence.
+
+        Returns:
+            ``(bbox, confidence)`` where confidence is in ``[0, 1]``.
+        """
+        bbox = self.update(frame)
+        return bbox, psr_to_confidence(self._last_psr)
+
     def reset(self) -> None:
         """Reset all internal state so the tracker can be re-initialised."""
         self._pos = None
@@ -156,6 +169,7 @@ class KCFTracker(BaseTracker):
         self._xf = None
         self._window = None
         self._yf = None
+        self._last_psr = 0.0
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/eovot/trackers/mosse.py
+++ b/eovot/trackers/mosse.py
@@ -18,12 +18,13 @@ Design notes
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import cv2
 import numpy as np
 
 from .base import BaseTracker, BBox
+from .confidence import compute_psr, psr_to_confidence
 
 
 class MOSSETracker(BaseTracker):
@@ -72,6 +73,7 @@ class MOSSETracker(BaseTracker):
         self._H_conj: Optional[np.ndarray] = None  # conjugate of learned filter
         self._window: Optional[np.ndarray] = None   # cosine (Hann) window
         self._bbox: Optional[list] = None           # current [x, y, w, h]
+        self._last_psr: float = 0.0                 # PSR from the most recent update()
 
     # ------------------------------------------------------------------ #
     # BaseTracker interface                                                #
@@ -126,6 +128,9 @@ class MOSSETracker(BaseTracker):
         # Correlation response
         response = np.real(np.fft.ifft2(self._H_conj * Fi))
 
+        # Compute PSR before shifting — used by update_with_confidence().
+        self._last_psr = compute_psr(response)
+
         # Locate the peak
         ky, kx = np.unravel_index(response.argmax(), response.shape)
         # Shift: peak at (0,0) means no displacement
@@ -148,6 +153,20 @@ class MOSSETracker(BaseTracker):
             )
 
         return (float(x_new), float(y_new), float(w), float(h))
+
+    def update_with_confidence(self, frame: np.ndarray) -> Tuple[BBox, float]:
+        """Track and return PSR-derived confidence.
+
+        Calls :meth:`update` (which updates ``_last_psr``) and converts the
+        stored PSR to a ``[0, 1]`` confidence score via
+        :func:`~eovot.trackers.confidence.psr_to_confidence`.
+
+        Returns:
+            ``(bbox, confidence)`` where confidence is in ``[0, 1]``.
+        """
+        bbox = self.update(frame)
+        confidence = psr_to_confidence(self._last_psr)
+        return bbox, confidence
 
     # ------------------------------------------------------------------ #
     # Internal helpers                                                     #

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,209 @@
+"""Tests for PSR-based confidence estimation (trackers/confidence.py)
+and confidence-aware robustness analysis (metrics/robustness.py).
+"""
+
+import numpy as np
+import pytest
+
+from eovot.trackers.confidence import compute_psr, psr_to_confidence
+from eovot.trackers.mosse import MOSSETracker
+from eovot.trackers.kcf import KCFTracker
+from eovot.metrics.robustness import (
+    ConfidenceAwareRobustnessAnalyzer,
+    ConfidenceRobustnessResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_psr
+# ---------------------------------------------------------------------------
+
+class TestComputePSR:
+    def test_sharp_peak_gives_high_psr(self):
+        response = np.zeros((64, 64), dtype=np.float32)
+        response[32, 32] = 100.0
+        psr = compute_psr(response)
+        assert psr > 7.0, f"Expected PSR > 7 for sharp peak, got {psr:.2f}"
+
+    def test_flat_response_gives_zero_psr(self):
+        response = np.ones((32, 32), dtype=np.float32)
+        psr = compute_psr(response)
+        assert psr == 0.0
+
+    def test_returns_nonnegative(self):
+        rng = np.random.default_rng(42)
+        response = rng.random((40, 40)).astype(np.float32)
+        assert compute_psr(response) >= 0.0
+
+    def test_raises_on_1d_input(self):
+        with pytest.raises(ValueError):
+            compute_psr(np.ones(10))
+
+    def test_small_response_map(self):
+        response = np.array([[0.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+        # exclusion_size=11 > map size → sidelobe empty → 0.0
+        psr = compute_psr(response, exclusion_size=11)
+        assert psr == 0.0
+
+
+# ---------------------------------------------------------------------------
+# psr_to_confidence
+# ---------------------------------------------------------------------------
+
+class TestPSRToConfidence:
+    def test_below_low_gives_zero(self):
+        assert psr_to_confidence(0.0) == 0.0
+        assert psr_to_confidence(2.9) == 0.0
+
+    def test_above_high_gives_one(self):
+        assert psr_to_confidence(7.0) == pytest.approx(1.0)
+        assert psr_to_confidence(10.0) == pytest.approx(1.0)
+
+    def test_midpoint(self):
+        mid = psr_to_confidence(5.0)  # halfway between 3 and 7
+        assert abs(mid - 0.5) < 1e-6
+
+    def test_invalid_range(self):
+        with pytest.raises(ValueError):
+            psr_to_confidence(5.0, low=7.0, high=3.0)
+
+
+# ---------------------------------------------------------------------------
+# MOSSETracker.update_with_confidence
+# ---------------------------------------------------------------------------
+
+def _make_frame(h=64, w=64, seed=0):
+    rng = np.random.default_rng(seed)
+    return (rng.random((h, w, 3)) * 255).astype(np.uint8)
+
+
+class TestMOSSEConfidence:
+    def test_returns_bbox_and_confidence(self):
+        tracker = MOSSETracker()
+        frame0 = _make_frame(seed=1)
+        tracker.initialize(frame0, (10, 10, 20, 20))
+
+        frame1 = _make_frame(seed=2)
+        bbox, conf = tracker.update_with_confidence(frame1)
+
+        assert len(bbox) == 4
+        assert 0.0 <= conf <= 1.0
+
+    def test_confidence_type_is_float(self):
+        tracker = MOSSETracker()
+        frame0 = _make_frame(seed=3)
+        tracker.initialize(frame0, (5, 5, 15, 15))
+        frame1 = _make_frame(seed=4)
+        _, conf = tracker.update_with_confidence(frame1)
+        assert isinstance(conf, float)
+
+    def test_update_and_update_with_confidence_agree_on_bbox(self):
+        """Both entry points should return the same bbox for the same frame."""
+        rng = np.random.default_rng(99)
+        frame0 = (rng.random((64, 64, 3)) * 255).astype(np.uint8)
+        frame1 = (rng.random((64, 64, 3)) * 255).astype(np.uint8)
+
+        t1 = MOSSETracker()
+        t1.initialize(frame0, (10, 10, 20, 20))
+        bbox_plain = t1.update(frame1)
+
+        t2 = MOSSETracker()
+        t2.initialize(frame0, (10, 10, 20, 20))
+        bbox_conf, _ = t2.update_with_confidence(frame1)
+
+        np.testing.assert_allclose(bbox_plain, bbox_conf)
+
+
+# ---------------------------------------------------------------------------
+# KCFTracker.update_with_confidence
+# ---------------------------------------------------------------------------
+
+class TestKCFConfidence:
+    def test_returns_bbox_and_confidence(self):
+        tracker = KCFTracker()
+        frame0 = _make_frame(seed=5)
+        tracker.initialize(frame0, (8, 8, 24, 24))
+
+        frame1 = _make_frame(seed=6)
+        bbox, conf = tracker.update_with_confidence(frame1)
+
+        assert len(bbox) == 4
+        assert 0.0 <= conf <= 1.0
+
+    def test_reset_clears_psr(self):
+        tracker = KCFTracker()
+        frame0 = _make_frame(seed=7)
+        tracker.initialize(frame0, (8, 8, 24, 24))
+        tracker.update(_make_frame(seed=8))
+        assert tracker._last_psr >= 0.0
+        tracker.reset()
+        assert tracker._last_psr == 0.0
+
+
+# ---------------------------------------------------------------------------
+# ConfidenceAwareRobustnessAnalyzer
+# ---------------------------------------------------------------------------
+
+class TestConfidenceAwareRobustnessAnalyzer:
+    def _make_ious_and_conf(self, n=50, failure_at=20, conf_drop_at=17):
+        ious = np.ones(n, dtype=np.float64)
+        ious[failure_at:failure_at + 5] = 0.05  # failure window
+        conf = np.ones(n - 1, dtype=np.float64)
+        conf[conf_drop_at - 1] = 0.1  # confidence drops before failure
+        return ious, conf
+
+    def test_returns_correct_type(self):
+        analyzer = ConfidenceAwareRobustnessAnalyzer()
+        ious, conf = self._make_ious_and_conf()
+        result = analyzer.analyze(ious, conf, tracker_name="MOSSE", sequence_name="seq1")
+        assert isinstance(result, ConfidenceRobustnessResult)
+
+    def test_detects_iou_failure(self):
+        analyzer = ConfidenceAwareRobustnessAnalyzer()
+        ious, conf = self._make_ious_and_conf()
+        result = analyzer.analyze(ious, conf)
+        assert result.base.num_failures >= 1
+
+    def test_detects_early_warning(self):
+        analyzer = ConfidenceAwareRobustnessAnalyzer(
+            confidence_threshold=0.3, early_warning_lead=5
+        )
+        ious, conf = self._make_ious_and_conf(
+            n=60, failure_at=22, conf_drop_at=19  # conf drops 3 frames before failure
+        )
+        result = analyzer.analyze(ious, conf)
+        assert len(result.early_warnings) >= 1
+
+    def test_no_early_warning_when_conf_drops_after_failure(self):
+        analyzer = ConfidenceAwareRobustnessAnalyzer(
+            confidence_threshold=0.3, early_warning_lead=3
+        )
+        n = 50
+        ious = np.ones(n)
+        ious[20:25] = 0.05       # IoU failure at 20
+        conf = np.ones(n - 1)
+        conf[24] = 0.1            # confidence drops *after* failure
+        result = analyzer.analyze(ious, conf)
+        assert len(result.early_warnings) == 0
+
+    def test_confidence_iou_correlation_perfect(self):
+        analyzer = ConfidenceAwareRobustnessAnalyzer()
+        n = 30
+        ious = np.linspace(0.2, 1.0, n)
+        conf = np.linspace(0.2, 1.0, n - 1)  # perfectly correlated
+        r = analyzer.confidence_iou_correlation(ious, conf)
+        assert r > 0.99
+
+    def test_mean_confidence_in_range(self):
+        analyzer = ConfidenceAwareRobustnessAnalyzer()
+        ious = np.ones(30)
+        conf = np.full(29, 0.6)
+        result = analyzer.analyze(ious, conf)
+        assert 0.0 <= result.mean_confidence <= 1.0
+
+    def test_all_low_confidence_gives_high_failure_rate(self):
+        analyzer = ConfidenceAwareRobustnessAnalyzer(confidence_threshold=0.5)
+        ious = np.ones(30)
+        conf = np.full(29, 0.1)
+        result = analyzer.analyze(ious, conf)
+        assert result.confidence_failure_rate > 0.8


### PR DESCRIPTION
## Summary

Adds **Peak-to-Sidelobe Ratio (PSR)** confidence estimation to the MOSSE and KCF correlation filter trackers, enabling lightweight, ground-truth-free failure detection at edge-inference time.

---

## What was added

### `eovot/trackers/confidence.py` *(new)*
- `compute_psr(response, exclusion_size=11)` — standard PSR formula (Bolme et al. 2010) with correct handling of zero-variance sidelobe regions.
- `psr_to_confidence(psr, low=3.0, high=7.0)` — maps raw PSR to a normalised `[0, 1]` confidence score using the empirical thresholds from the original paper.

### `eovot/trackers/base.py`
- Added `update_with_confidence(frame) -> (BBox, float)` to `BaseTracker`.  
  Default implementation calls `update()` and returns `-1.0` (sentinel = "no native confidence").  Trackers that have a natural confidence signal override this without redundant computation.

### `eovot/trackers/mosse.py` & `kcf.py`
- Each tracker now stores `_last_psr` after every `update()` call (zero-overhead — PSR is computed from the response map that is already computed).
- Both override `update_with_confidence()` to expose `psr_to_confidence(_last_psr)`.

### `eovot/benchmark/engine.py`
- `_run_sequence()` now calls `update_with_confidence()` instead of `update()`.
- Per-frame confidence scores are stored in `SequenceResult.confidence_scores` (a `float32` array, or `None` for trackers that return the `-1.0` sentinel).

### `eovot/metrics/robustness.py`
- `ConfidenceRobustnessResult` — extended dataclass that wraps a `RobustnessResult` and adds `mean_confidence`, `min_confidence`, `confidence_failure_rate`, and `early_warnings`.
- `ConfidenceAwareRobustnessAnalyzer` — combines IoU arrays with per-frame confidence scores to:
  - Detect **early warnings**: confidence drops *before* IoU collapses.
  - Compute the **confidence–IoU Pearson correlation** (validates PSR as a proxy metric).
  - Report the **confidence failure rate** for threshold-based monitoring.

### `tests/test_confidence.py` *(new, 21 tests)*
Covers PSR math, edge cases, MOSSE/KCF integration, tracker-state agreement, and the confidence-aware robustness analyzer.

---

## Why it matters

Correlation filter trackers (MOSSE, KCF) are the dominant choice for edge deployments because they run at 150–500 FPS with no GPU. Their key weakness in practice is silent drift — the tracker keeps running with no signal that it has lost the target. PSR solves this:

| PSR > 7 | confident track |
|---------|----------------|
| 3–7     | degraded / uncertain |
| < 3     | failure — trigger re-init or fallback |

This is now available to:
- The benchmark engine (stored in `SequenceResult` for post-hoc analysis)
- The robustness module (early-warning analysis)
- Any downstream code (`tracker.update_with_confidence(frame)`)

The entire feature adds zero overhead to trackers that don't implement `update_with_confidence()`.

---

## Example usage

```python
from eovot.trackers.mosse import MOSSETracker

tracker = MOSSETracker()
tracker.initialize(frame0, bbox)

for frame in frames:
    bbox, confidence = tracker.update_with_confidence(frame)
    if confidence < 0.3:
        print(f"Low confidence ({confidence:.2f}) — possible failure")
```

```python
from eovot.metrics.robustness import ConfidenceAwareRobustnessAnalyzer

analyzer = ConfidenceAwareRobustnessAnalyzer(confidence_threshold=0.3)
result = analyzer.analyze(seq_result.ious, seq_result.confidence_scores,
                          tracker_name="MOSSE", sequence_name="car1")
print(result.early_warnings)   # frames where PSR dropped before IoU collapse
print(result.base.eao)
r = analyzer.confidence_iou_correlation(seq_result.ious, seq_result.confidence_scores)
print(f"PSR–IoU correlation: r={r:.3f}")
```

---

## No breaking changes

All existing tracker usage (`tracker.update(frame)`) is unchanged. The new `update_with_confidence()` is additive. `SequenceResult.confidence_scores` is `None` for any tracker that does not override the new method.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185hZK5ueuZHGqpBhn7tgCZ)_