### PR TITLE
[agent] Add EdgeDeploymentReport and simulate_edge CLI for hardware-fleet analysis

### DIFF
--- a/eovot/reporting/edge_report.py
+++ b/eovot/reporting/edge_report.py
@@ -1,0 +1,382 @@
+"""Edge deployment report generator for EOVOT.
+
+Combines benchmark results (accuracy + profiling) with :class:`DeviceSimulator`
+projections to answer the central edge-deployment question:
+
+    **"Which trackers can run on which edge devices, and at what cost?"**
+
+The main output is an :class:`EdgeDeploymentReport` containing a *deployment
+matrix* — a table of trackers × devices annotated with:
+
+* Estimated FPS on each device
+* Estimated energy per frame (mJ)
+* Memory feasibility (fits / OOM)
+* Deployability verdict against user-supplied FPS and memory constraints
+
+Typical usage::
+
+    from eovot.reporting.edge_report import EdgeDeploymentReport
+
+    report = EdgeDeploymentReport.from_result_dicts(
+        result_dicts,          # list of BenchmarkResult.to_dict() outputs
+        min_fps=15.0,          # deployability threshold
+        sustained_seconds=60.0,
+    )
+
+    print(report.to_markdown())
+    report.save(output_dir="results/edge_report")
+
+The :mod:`scripts.simulate_edge` CLI script wraps this class for command-line use.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from ..profiling.device_sim import DeviceSimulator, DeviceSimResult, KNOWN_DEVICES
+from ..profiling.profiler import ProfilingResult
+
+
+# ---------------------------------------------------------------------------
+# Cell: one (tracker, device) pair
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DeploymentCell:
+    """Performance estimate for one tracker on one edge device.
+
+    Attributes:
+        tracker_name: Human-readable tracker identifier.
+        device_name: Device key (e.g. ``"rpi4"``).
+        device_display: Human-readable device label.
+        host_fps: Measured FPS on the benchmark host.
+        estimated_fps: Projected FPS on the target device.
+        estimated_latency_ms: Projected mean per-frame latency (ms).
+        estimated_memory_mb: Memory footprint (same as host; algorithm-bound).
+        memory_limit_mb: Device RAM ceiling.
+        fits_in_memory: Whether the tracker fits within the device RAM.
+        estimated_energy_mj: Estimated energy per frame (milli-Joules).
+        thermal_state: ``"nominal"``, ``"transitioning"``, or ``"throttled"``.
+        deployable: Whether estimated FPS ≥ ``min_fps`` and ``fits_in_memory``.
+        mean_iou: Mean IoU from the benchmark result (accuracy proxy).
+    """
+
+    tracker_name: str
+    device_name: str
+    device_display: str
+    host_fps: float
+    estimated_fps: float
+    estimated_latency_ms: float
+    estimated_memory_mb: float
+    memory_limit_mb: float
+    fits_in_memory: bool
+    estimated_energy_mj: float
+    thermal_state: str
+    deployable: bool
+    mean_iou: float = 0.0
+
+    def to_dict(self) -> Dict:
+        return {
+            "tracker": self.tracker_name,
+            "device": self.device_name,
+            "device_display": self.device_display,
+            "host_fps": round(self.host_fps, 2),
+            "estimated_fps": round(self.estimated_fps, 2),
+            "estimated_latency_ms": round(self.estimated_latency_ms, 2),
+            "estimated_memory_mb": round(self.estimated_memory_mb, 1),
+            "memory_limit_mb": self.memory_limit_mb,
+            "fits_in_memory": self.fits_in_memory,
+            "estimated_energy_mj_per_frame": round(self.estimated_energy_mj, 4),
+            "thermal_state": self.thermal_state,
+            "deployable": self.deployable,
+            "mean_iou": round(self.mean_iou, 4),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EdgeDeploymentReport:
+    """Deployment analysis for a set of trackers across edge devices.
+
+    Attributes:
+        tracker_names: Ordered list of tracker names in the report.
+        device_names: Ordered list of device keys in the report.
+        cells: Flat list of :class:`DeploymentCell` objects (one per tracker×device pair).
+        min_fps: FPS threshold used for the deployability verdict.
+        sustained_seconds: Sustained-load duration used for thermal modelling.
+    """
+
+    tracker_names: List[str]
+    device_names: List[str]
+    cells: List[DeploymentCell] = field(default_factory=list)
+    min_fps: float = 10.0
+    sustained_seconds: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_result_dicts(
+        cls,
+        result_dicts: List[Dict],
+        min_fps: float = 10.0,
+        sustained_seconds: float = 0.0,
+        device_names: Optional[List[str]] = None,
+        host_calibration_factor: float = 1.0,
+    ) -> "EdgeDeploymentReport":
+        """Build a report from benchmark result dicts.
+
+        Args:
+            result_dicts: List of ``BenchmarkResult.to_dict()`` outputs.
+            min_fps: Minimum FPS required for a deployment to be marked
+                feasible.  Default ``10.0`` (practical real-time floor).
+            sustained_seconds: Seconds of sustained operation to model
+                thermal throttling.  ``0.0`` models a cold-start burst.
+            device_names: Subset of device keys to include.  If ``None``,
+                all built-in devices are included.
+            host_calibration_factor: Passed to :class:`DeviceSimulator`.
+                Adjust if the benchmark host is not an Intel Core i7 class CPU.
+
+        Returns:
+            :class:`EdgeDeploymentReport` populated with all cells.
+        """
+        sim = DeviceSimulator(host_calibration_factor=host_calibration_factor)
+        target_devices = device_names or sim.list_devices()
+
+        tracker_names: List[str] = []
+        cells: List[DeploymentCell] = []
+
+        for rd in result_dicts:
+            summary = rd.get("summary", rd)
+            tracker_name = summary.get("tracker_name") or summary.get("tracker", "unknown")
+            if tracker_name not in tracker_names:
+                tracker_names.append(tracker_name)
+
+            mean_iou = float(summary.get("mean_iou", 0.0))
+            host_fps = float(summary.get("mean_fps", 1.0))
+            peak_mem = float(summary.get("peak_memory_mb", 0.0))
+            latency_ms = (1000.0 / host_fps) if host_fps > 0 else float("inf")
+
+            prof = ProfilingResult(
+                tracker_name=tracker_name,
+                frame_count=1,
+                fps=host_fps,
+                latency_mean_ms=latency_ms,
+                latency_std_ms=0.0,
+                latency_p95_ms=latency_ms,
+                peak_memory_mb=peak_mem,
+            )
+
+            for device_key in target_devices:
+                sim_result: DeviceSimResult = sim.simulate(
+                    prof, device_key, sustained_seconds=sustained_seconds
+                )
+                deployable = (
+                    sim_result.estimated_fps >= min_fps
+                    and sim_result.fits_in_memory
+                )
+                cell = DeploymentCell(
+                    tracker_name=tracker_name,
+                    device_name=device_key,
+                    device_display=sim_result.display_name,
+                    host_fps=host_fps,
+                    estimated_fps=sim_result.estimated_fps,
+                    estimated_latency_ms=sim_result.estimated_latency_ms,
+                    estimated_memory_mb=sim_result.estimated_memory_mb,
+                    memory_limit_mb=sim_result.memory_limit_mb,
+                    fits_in_memory=sim_result.fits_in_memory,
+                    estimated_energy_mj=sim_result.estimated_energy_mj_per_frame,
+                    thermal_state=sim_result.thermal_state,
+                    deployable=deployable,
+                    mean_iou=mean_iou,
+                )
+                cells.append(cell)
+
+        return cls(
+            tracker_names=tracker_names,
+            device_names=target_devices,
+            cells=cells,
+            min_fps=min_fps,
+            sustained_seconds=sustained_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def get_cell(self, tracker_name: str, device_name: str) -> Optional[DeploymentCell]:
+        """Return the cell for a specific (tracker, device) pair."""
+        for cell in self.cells:
+            if cell.tracker_name == tracker_name and cell.device_name == device_name:
+                return cell
+        return None
+
+    def deployable_combinations(self) -> List[Tuple[str, str]]:
+        """Return list of ``(tracker_name, device_name)`` pairs marked deployable."""
+        return [
+            (c.tracker_name, c.device_name)
+            for c in self.cells
+            if c.deployable
+        ]
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def to_markdown(self) -> str:
+        """Render the deployment matrix as a Markdown string.
+
+        The table has one row per tracker and one column group per device.
+        Each cell shows ``FPS / mJ`` and a deployability icon (✓ or ✗).
+
+        Returns:
+            Multi-line Markdown string suitable for GitHub, reports, or paper appendix.
+        """
+        lines: List[str] = []
+
+        lines.append("# EOVOT Edge Deployment Matrix\n")
+        lines.append(f"**Min FPS threshold:** {self.min_fps:.0f} FPS  ")
+        lines.append(
+            f"**Sustained load:** "
+            f"{'cold-start' if self.sustained_seconds <= 0 else f'{self.sustained_seconds:.0f}s'}  "
+        )
+        lines.append(f"**Trackers evaluated:** {len(self.tracker_names)}  ")
+        lines.append(f"**Devices simulated:** {len(self.device_names)}  \n")
+
+        # --- Deployment matrix table ---
+        lines.append("## Deployment Matrix\n")
+        lines.append("> ✓ = deployable (FPS ≥ threshold, fits in RAM)  ✗ = not deployable\n")
+
+        # Get display names for header
+        device_displays: Dict[str, str] = {}
+        for cell in self.cells:
+            device_displays[cell.device_name] = cell.device_display
+
+        # Header
+        device_cols = [device_displays.get(d, d) for d in self.device_names]
+        header = "| Tracker | mIoU |" + "".join(
+            f" {_truncate(d, 22)} |" for d in device_cols
+        )
+        sep = "|---------|------|" + "".join("-" * (len(_truncate(d, 22)) + 2) + "|" for d in device_cols)
+
+        lines.append(header)
+        lines.append(sep)
+
+        for tracker in self.tracker_names:
+            # Find mIoU (same for all devices for this tracker)
+            miou = 0.0
+            for c in self.cells:
+                if c.tracker_name == tracker:
+                    miou = c.mean_iou
+                    break
+            row = f"| {tracker:<7} | {miou:.3f} |"
+            for device in self.device_names:
+                cell = self.get_cell(tracker, device)
+                if cell is None:
+                    row += " — |"
+                else:
+                    icon = "✓" if cell.deployable else "✗"
+                    mem_flag = "" if cell.fits_in_memory else " OOM"
+                    row += f" {icon} {cell.estimated_fps:.0f} FPS{mem_flag} |"
+            lines.append(row)
+
+        lines.append("")
+
+        # --- Per-device detail tables ---
+        lines.append("## Per-Device Detail\n")
+        for device in self.device_names:
+            display = device_displays.get(device, device)
+            device_cells = [c for c in self.cells if c.device_name == device]
+            if not device_cells:
+                continue
+            lines.append(f"### {display}\n")
+            lines.append(
+                "| Tracker | Host FPS | Est. FPS | Latency (ms) | Mem (MB) | Fits? | mJ/frame | Thermal | Deploy? |"
+            )
+            lines.append(
+                "|---------|----------|----------|--------------|----------|:-----:|----------|---------|---------|"
+            )
+            for cell in sorted(device_cells, key=lambda c: c.estimated_fps, reverse=True):
+                fits = "✓" if cell.fits_in_memory else "✗"
+                deploy = "✓" if cell.deployable else "✗"
+                lines.append(
+                    f"| {cell.tracker_name} "
+                    f"| {cell.host_fps:.1f} "
+                    f"| {cell.estimated_fps:.1f} "
+                    f"| {cell.estimated_latency_ms:.1f} "
+                    f"| {cell.estimated_memory_mb:.0f} / {cell.memory_limit_mb:.0f} "
+                    f"| {fits} "
+                    f"| {cell.estimated_energy_mj:.3f} "
+                    f"| {cell.thermal_state} "
+                    f"| {deploy} |"
+                )
+            lines.append("")
+
+        # --- Summary ---
+        n_deployable = len(self.deployable_combinations())
+        n_total = len(self.tracker_names) * len(self.device_names)
+        lines.append("## Summary\n")
+        lines.append(
+            f"**{n_deployable} / {n_total}** tracker-device combinations are deployable "
+            f"at ≥{self.min_fps:.0f} FPS.\n"
+        )
+        if self.deployable_combinations():
+            lines.append("**Deployable combinations:**\n")
+            for tracker, device in self.deployable_combinations():
+                cell = self.get_cell(tracker, device)
+                lines.append(
+                    f"- {tracker} → {device_displays.get(device, device)}: "
+                    f"{cell.estimated_fps:.0f} FPS, {cell.estimated_energy_mj:.3f} mJ/frame"
+                )
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> Dict:
+        """Serialize the full report to a dict (for JSON export)."""
+        return {
+            "min_fps_threshold": self.min_fps,
+            "sustained_seconds": self.sustained_seconds,
+            "trackers": self.tracker_names,
+            "devices": self.device_names,
+            "deployable_combinations": self.deployable_combinations(),
+            "cells": [c.to_dict() for c in self.cells],
+        }
+
+    def save(self, output_dir: str = "results/edge_report", prefix: str = "edge_report") -> Dict[str, Path]:
+        """Save Markdown and JSON reports to *output_dir*.
+
+        Args:
+            output_dir: Directory where files are written (created if absent).
+            prefix: Filename prefix for both output files.
+
+        Returns:
+            Dict mapping ``"markdown"`` and ``"json"`` to their saved paths.
+        """
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        md_path = out / f"{prefix}.md"
+        md_path.write_text(self.to_markdown(), encoding="utf-8")
+
+        json_path = out / f"{prefix}.json"
+        json_path.write_text(
+            json.dumps(self.to_dict(), indent=2), encoding="utf-8"
+        )
+
+        return {"markdown": md_path, "json": json_path}
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _truncate(s: str, max_len: int) -> str:
+    return s if len(s) <= max_len else s[: max_len - 1] + "…"

--- a/scripts/simulate_edge.py
+++ b/scripts/simulate_edge.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Edge deployment simulation CLI for EOVOT.
+
+Projects benchmark results (saved as JSON) onto edge hardware profiles and
+generates a deployment matrix answering: *which trackers can run on which
+devices?*
+
+This script is the command-line interface to
+:class:`~eovot.reporting.edge_report.EdgeDeploymentReport`.  It reads one or
+more JSON result files produced by the benchmark engine (or
+:class:`~eovot.experiment.runner.ExperimentRunner`) and outputs:
+
+1. A Markdown deployment matrix (trackers × devices) with FPS, energy, and
+   memory feasibility.
+2. A JSON export of all simulation data.
+
+Usage
+-----
+Simulate all trackers in a results directory on all built-in devices::
+
+    python scripts/simulate_edge.py results/my-experiment/
+
+Simulate specific result files, only on embedded Linux devices::
+
+    python scripts/simulate_edge.py \\
+        results/MOSSE-OTB100.json \\
+        results/KCF-OTB100.json \\
+        --devices rpi4 rpi5 coral_board \\
+        --min-fps 20
+
+Model a 2-minute sustained tracking workload (triggers thermal throttling)::
+
+    python scripts/simulate_edge.py results/experiment/ \\
+        --sustained-seconds 120 \\
+        --min-fps 10 \\
+        --output-dir results/edge_analysis
+
+List available device profiles::
+
+    python scripts/simulate_edge.py --list-devices
+
+Available built-in devices
+--------------------------
+    rpi4          Raspberry Pi 4B (Cortex-A72, 4 GB, 7.5 W)
+    rpi5          Raspberry Pi 5   (Cortex-A76, 8 GB, 12 W)
+    jetson_nano   NVIDIA Jetson Nano (Cortex-A57, 4 GB, 10 W)
+    jetson_xnx    NVIDIA Jetson Xavier NX (Carmel ARM, 8 GB, 15 W)
+    coral_board   Google Coral Dev Board (i.MX 8M, 1 GB, 4 W)
+    snapdragon888 Qualcomm Snapdragon 888 mobile (Kryo 680, 6 GB, 15 W)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from eovot.profiling.device_sim import KNOWN_DEVICES
+from eovot.reporting.edge_report import EdgeDeploymentReport
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+def _collect_json_files(inputs: List[str]) -> List[Path]:
+    """Expand directories to *.json; keep explicit file paths as-is."""
+    paths: List[Path] = []
+    for item in inputs:
+        p = Path(item)
+        if p.is_dir():
+            found = sorted(p.glob("*.json"))
+            if not found:
+                print(f"[WARN] No JSON files found in: {p}", file=sys.stderr)
+            paths.extend(found)
+        elif p.is_file() and p.suffix == ".json":
+            paths.append(p)
+        elif p.is_file():
+            print(f"[WARN] Skipping non-JSON file: {p}", file=sys.stderr)
+        else:
+            print(f"[WARN] Path not found: {p}", file=sys.stderr)
+    return paths
+
+
+def _load_result(path: Path) -> Optional[dict]:
+    """Load one JSON result file; return None if malformed."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"[WARN] Could not read {path.name}: {exc}", file=sys.stderr)
+        return None
+
+    # Support both top-level summary dicts and wrapped {summary, sequences} dicts.
+    if "summary" not in data:
+        # Wrap legacy / plain-summary JSONs
+        data = {"summary": data, "sequences": []}
+
+    summary = data["summary"]
+    if not summary.get("tracker_name") and not summary.get("tracker"):
+        summary["tracker_name"] = path.stem.split("-")[0]
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="simulate_edge",
+        description="Project EOVOT benchmark results onto edge device profiles.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="*",
+        metavar="PATH",
+        help=(
+            "JSON result files or directories containing them.  "
+            "Use --list-devices to skip simulation and only list device profiles."
+        ),
+    )
+    parser.add_argument(
+        "--devices",
+        nargs="+",
+        default=None,
+        metavar="DEVICE",
+        help=(
+            "Subset of device keys to simulate.  "
+            f"Choices: {sorted(KNOWN_DEVICES)}.  "
+            "Default: all built-in devices."
+        ),
+    )
+    parser.add_argument(
+        "--min-fps",
+        type=float,
+        default=10.0,
+        metavar="FPS",
+        help="Minimum FPS required for a deployment to be marked feasible. Default: 10.",
+    )
+    parser.add_argument(
+        "--sustained-seconds",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help=(
+            "Duration of sustained tracking on the device.  "
+            "Controls thermal throttling model.  "
+            "0 (default) = cold-start / burst scenario."
+        ),
+    )
+    parser.add_argument(
+        "--host-calibration",
+        type=float,
+        default=1.0,
+        metavar="FACTOR",
+        help=(
+            "Calibration multiplier for the benchmark host CPU relative to an "
+            "Intel Core i7 reference (default: 1.0).  "
+            "Set > 1.0 if your host is faster; < 1.0 if slower."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/edge_report",
+        metavar="DIR",
+        help="Directory where Markdown and JSON reports are saved. Default: results/edge_report",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="edge_report",
+        help="Filename prefix for saved reports. Default: edge_report",
+    )
+    parser.add_argument(
+        "--list-devices",
+        action="store_true",
+        help="Print all available device profiles and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    # --- List devices mode ---
+    if args.list_devices:
+        print("\nAvailable edge device profiles:")
+        print("-" * 60)
+        for key, profile in sorted(KNOWN_DEVICES.items()):
+            print(
+                f"  {key:<20} {profile.display_name}  "
+                f"[{profile.cpu_speed_factor:.0%} host speed, "
+                f"{profile.memory_limit_mb:.0f} MB RAM, "
+                f"{profile.tdp_watts:.1f} W TDP]"
+            )
+            if profile.notes:
+                print(f"    Note: {profile.notes}")
+        print()
+        return 0
+
+    if not args.inputs:
+        parser.print_help()
+        return 1
+
+    # --- Validate device choices ---
+    if args.devices:
+        unknown = [d for d in args.devices if d not in KNOWN_DEVICES]
+        if unknown:
+            print(
+                f"[ERROR] Unknown device(s): {unknown}. "
+                f"Run --list-devices to see available options.",
+                file=sys.stderr,
+            )
+            return 1
+
+    # --- Load result files ---
+    json_files = _collect_json_files(args.inputs)
+    if not json_files:
+        print("[ERROR] No JSON result files found.", file=sys.stderr)
+        return 1
+
+    result_dicts = []
+    for path in json_files:
+        data = _load_result(path)
+        if data is not None:
+            result_dicts.append(data)
+            tracker = (
+                data.get("summary", {}).get("tracker_name")
+                or data.get("summary", {}).get("tracker", path.stem)
+            )
+            print(f"  Loaded: {tracker!r}  ({path.name})")
+
+    if not result_dicts:
+        print("[ERROR] No valid result files could be loaded.", file=sys.stderr)
+        return 1
+
+    # --- Run simulation ---
+    print(
+        f"\nSimulating {len(result_dicts)} tracker(s) on "
+        f"{len(args.devices) if args.devices else len(KNOWN_DEVICES)} device(s) "
+        f"[min FPS={args.min_fps}, sustained={args.sustained_seconds:.0f}s] …"
+    )
+
+    report = EdgeDeploymentReport.from_result_dicts(
+        result_dicts,
+        min_fps=args.min_fps,
+        sustained_seconds=args.sustained_seconds,
+        device_names=args.devices,
+        host_calibration_factor=args.host_calibration,
+    )
+
+    # --- Print deployment matrix to stdout ---
+    print()
+    print(report.to_markdown())
+
+    # --- Save reports ---
+    saved = report.save(output_dir=args.output_dir, prefix=args.prefix)
+    print(f"[Markdown] saved → {saved['markdown']}")
+    print(f"[JSON]     saved → {saved['json']}")
+
+    n_ok = len(report.deployable_combinations())
+    n_total = len(report.tracker_names) * len(report.device_names)
+    print(
+        f"\n{n_ok}/{n_total} tracker-device combinations are deployable "
+        f"at ≥{args.min_fps:.0f} FPS.\n"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_edge_report.py
+++ b/tests/test_edge_report.py
@@ -1,0 +1,295 @@
+"""Tests for EdgeDeploymentReport and the simulate_edge CLI."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from eovot.reporting.edge_report import EdgeDeploymentReport, DeploymentCell
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_result_dict(
+    tracker: str = "MOSSE",
+    mean_iou: float = 0.65,
+    mean_fps: float = 500.0,
+    peak_memory_mb: float = 50.0,
+) -> dict:
+    return {
+        "summary": {
+            "tracker_name": tracker,
+            "tracker": tracker,
+            "dataset": "Synthetic",
+            "num_sequences": 5,
+            "mean_iou": mean_iou,
+            "mean_fps": mean_fps,
+            "peak_memory_mb": peak_memory_mb,
+        },
+        "sequences": [],
+    }
+
+
+TWO_TRACKERS = [
+    _make_result_dict("MOSSE", mean_iou=0.65, mean_fps=500.0, peak_memory_mb=50.0),
+    _make_result_dict("KCF",   mean_iou=0.72, mean_fps=150.0, peak_memory_mb=80.0),
+]
+
+
+# ---------------------------------------------------------------------------
+# DeploymentCell
+# ---------------------------------------------------------------------------
+
+class TestDeploymentCell:
+    def test_to_dict_keys(self):
+        cell = DeploymentCell(
+            tracker_name="MOSSE",
+            device_name="rpi4",
+            device_display="Raspberry Pi 4B (4 GB)",
+            host_fps=500.0,
+            estimated_fps=60.0,
+            estimated_latency_ms=16.7,
+            estimated_memory_mb=50.0,
+            memory_limit_mb=3800.0,
+            fits_in_memory=True,
+            estimated_energy_mj=0.5,
+            thermal_state="nominal",
+            deployable=True,
+            mean_iou=0.65,
+        )
+        d = cell.to_dict()
+        for key in ["tracker", "device", "estimated_fps", "deployable", "mean_iou"]:
+            assert key in d, f"Missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# EdgeDeploymentReport construction
+# ---------------------------------------------------------------------------
+
+class TestEdgeDeploymentReport:
+    def test_from_result_dicts_two_trackers(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, min_fps=10.0, device_names=["rpi4", "jetson_nano"]
+        )
+        assert len(report.tracker_names) == 2
+        assert "MOSSE" in report.tracker_names
+        assert "KCF" in report.tracker_names
+        assert len(report.device_names) == 2
+        # 2 trackers × 2 devices = 4 cells
+        assert len(report.cells) == 4
+
+    def test_cells_contain_valid_fps(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4"]
+        )
+        for cell in report.cells:
+            assert cell.estimated_fps > 0.0
+            assert cell.estimated_latency_ms > 0.0
+
+    def test_memory_fits_for_small_tracker(self):
+        # MOSSE uses only 50 MB — should fit on all devices
+        report = EdgeDeploymentReport.from_result_dicts(
+            [_make_result_dict("MOSSE", peak_memory_mb=50.0)],
+            device_names=["rpi4", "jetson_nano"],
+        )
+        for cell in report.cells:
+            assert cell.fits_in_memory, f"Expected MOSSE to fit on {cell.device_name}"
+
+    def test_oom_for_large_tracker(self):
+        # 2 GB tracker should not fit on Coral (1 GB RAM)
+        report = EdgeDeploymentReport.from_result_dicts(
+            [_make_result_dict("HeavyDL", peak_memory_mb=2000.0)],
+            device_names=["coral_board"],
+        )
+        cell = report.get_cell("HeavyDL", "coral_board")
+        assert cell is not None
+        assert not cell.fits_in_memory
+        assert not cell.deployable
+
+    def test_min_fps_threshold(self):
+        # Fast tracker on fast device — check deployability changes with min_fps
+        report_low = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, min_fps=1.0, device_names=["jetson_xnx"]
+        )
+        report_high = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, min_fps=999.0, device_names=["jetson_xnx"]
+        )
+        # With min_fps=1, more should be deployable than with min_fps=999
+        assert len(report_low.deployable_combinations()) >= len(report_high.deployable_combinations())
+
+    def test_get_cell(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4", "rpi5"]
+        )
+        cell = report.get_cell("MOSSE", "rpi4")
+        assert cell is not None
+        assert cell.tracker_name == "MOSSE"
+        assert cell.device_name == "rpi4"
+
+    def test_get_cell_missing_returns_none(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4"]
+        )
+        assert report.get_cell("MOSSE", "nonexistent_device") is None
+
+    def test_deployable_combinations_list(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, min_fps=0.1, device_names=["rpi4"]
+        )
+        combos = report.deployable_combinations()
+        # All should be deployable at 0.1 FPS (assuming memory fits)
+        for tracker, device in combos:
+            assert tracker in report.tracker_names
+            assert device in report.device_names
+
+    def test_all_built_in_devices_simulated(self):
+        report = EdgeDeploymentReport.from_result_dicts(TWO_TRACKERS, min_fps=1.0)
+        from eovot.profiling.device_sim import KNOWN_DEVICES
+        assert len(report.device_names) == len(KNOWN_DEVICES)
+
+
+# ---------------------------------------------------------------------------
+# Markdown output
+# ---------------------------------------------------------------------------
+
+class TestMarkdownOutput:
+    def test_markdown_contains_tracker_names(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4"]
+        )
+        md = report.to_markdown()
+        assert "MOSSE" in md
+        assert "KCF" in md
+
+    def test_markdown_contains_device_names(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4", "rpi5"]
+        )
+        md = report.to_markdown()
+        assert "rpi4" in md.lower() or "raspberry pi 4" in md.lower()
+
+    def test_markdown_has_summary_section(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4"]
+        )
+        md = report.to_markdown()
+        assert "Summary" in md
+
+    def test_to_dict_serializable(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4"]
+        )
+        d = report.to_dict()
+        # Must be JSON-serializable
+        serialized = json.dumps(d)
+        restored = json.loads(serialized)
+        assert "trackers" in restored
+        assert "devices" in restored
+        assert "cells" in restored
+
+
+# ---------------------------------------------------------------------------
+# Save / IO
+# ---------------------------------------------------------------------------
+
+class TestSave:
+    def test_save_creates_files(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4"]
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saved = report.save(output_dir=tmpdir, prefix="test_report")
+            assert saved["markdown"].exists()
+            assert saved["json"].exists()
+            assert saved["markdown"].stat().st_size > 0
+            assert saved["json"].stat().st_size > 0
+
+    def test_saved_json_is_valid(self):
+        report = EdgeDeploymentReport.from_result_dicts(
+            TWO_TRACKERS, device_names=["rpi4"]
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saved = report.save(output_dir=tmpdir)
+            content = saved["json"].read_text()
+            data = json.loads(content)
+            assert "cells" in data
+            assert len(data["cells"]) == 2  # 2 trackers × 1 device
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestSimulateEdgeCLI:
+    def _write_result(self, tmpdir: Path, tracker: str, fps: float) -> Path:
+        path = tmpdir / f"{tracker}-Synthetic.json"
+        path.write_text(
+            json.dumps(_make_result_dict(tracker, mean_fps=fps)),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_cli_runs_on_directory(self, tmp_path):
+        self._write_result(tmp_path, "MOSSE", 500.0)
+        self._write_result(tmp_path, "KCF", 150.0)
+
+        from scripts.simulate_edge import main
+
+        out_dir = str(tmp_path / "edge_out")
+        exit_code = main([
+            str(tmp_path),
+            "--devices", "rpi4",
+            "--min-fps", "5",
+            "--output-dir", out_dir,
+        ])
+        assert exit_code == 0
+        assert (Path(out_dir) / "edge_report.md").exists()
+        assert (Path(out_dir) / "edge_report.json").exists()
+
+    def test_cli_list_devices(self, capsys):
+        from scripts.simulate_edge import main
+        exit_code = main(["--list-devices"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "rpi4" in captured.out
+        assert "jetson_nano" in captured.out
+
+    def test_cli_no_inputs_returns_1(self):
+        from scripts.simulate_edge import main
+        exit_code = main([])
+        assert exit_code == 1
+
+    def test_cli_invalid_device_returns_1(self, tmp_path):
+        self._write_result(tmp_path, "MOSSE", 500.0)
+        from scripts.simulate_edge import main
+        exit_code = main([str(tmp_path), "--devices", "nonexistent_device_xyz"])
+        assert exit_code == 1
+
+    def test_cli_sustained_seconds(self, tmp_path):
+        self._write_result(tmp_path, "MOSSE", 500.0)
+        from scripts.simulate_edge import main
+        out_dir = str(tmp_path / "edge_out")
+        exit_code = main([
+            str(tmp_path),
+            "--devices", "rpi4",
+            "--sustained-seconds", "120",
+            "--output-dir", out_dir,
+        ])
+        assert exit_code == 0
+
+    def test_cli_explicit_json_files(self, tmp_path):
+        p1 = self._write_result(tmp_path, "MOSSE", 500.0)
+        p2 = self._write_result(tmp_path, "KCF", 150.0)
+        from scripts.simulate_edge import main
+        out_dir = str(tmp_path / "edge_out")
+        exit_code = main([
+            str(p1), str(p2),
+            "--devices", "rpi4", "rpi5",
+            "--output-dir", out_dir,
+        ])
+        assert exit_code == 0


### PR DESCRIPTION
## What was added

### `eovot/reporting/edge_report.py` — EdgeDeploymentReport
Answers the core edge-deployment question from saved benchmark JSON results:

> **"Which trackers can run on which edge devices, at what FPS, energy cost, and memory footprint?"**

```python
from eovot.reporting.edge_report import EdgeDeploymentReport

report = EdgeDeploymentReport.from_result_dicts(
    result_dicts,          # list of BenchmarkResult.to_dict() outputs
    min_fps=15.0,          # deployability threshold
    sustained_seconds=60.0,
)

# Deployment matrix (trackers × devices) as Markdown
print(report.to_markdown())

# Which combinations pass the FPS + memory constraints?
print(report.deployable_combinations())

# Save Markdown and JSON reports
report.save(output_dir="results/edge_analysis")
```

**Deployment matrix output example:**

```
| Tracker | mIoU | Raspberry Pi 4B | Jetson Nano | Jetson Xavier NX | Snapdragon 888 |
|---------|------|-----------------|-------------|------------------|----------------|
| MOSSE   | 0.650| ✓ 60 FPS       | ✗ 5 FPS    | ✓ 180 FPS       | ✓ 170 FPS     |
| KCF     | 0.720| ✗ 18 FPS       | ✗ 2 FPS    | ✓ 54 FPS        | ✓ 51 FPS      |
```

### `scripts/simulate_edge.py` — CLI entry point
Reads any EOVOT benchmark JSON files and runs the simulation pipeline:

```bash
# Simulate a results directory on all built-in devices
python scripts/simulate_edge.py results/my-experiment/

# Only specific devices, with FPS threshold
python scripts/simulate_edge.py results/my-experiment/ \
    --devices rpi4 rpi5 jetson_nano \
    --min-fps 20

# Model 2-minute sustained load (triggers thermal throttling)
python scripts/simulate_edge.py results/ \
    --sustained-seconds 120 \
    --output-dir results/edge_analysis

# List all available device profiles
python scripts/simulate_edge.py --list-devices
```

## Why it matters

`DeviceSimulator` (added in #118) is a powerful engine for projecting benchmark results onto edge hardware — but until now there was **no user-facing entry point** to use it from saved results. Researchers had to write custom Python to access it. This PR closes that gap with a single CLI call.

The deployment matrix format is directly usable in paper appendices and repository READMEs, enabling the complete EOVOT workflow:

```
Benchmark → Profiling → DeviceSimulator → EdgeDeploymentReport → paper table
```

## Example output

```
$ python scripts/simulate_edge.py results/ --devices rpi4 jetson_xnx --min-fps 15

Simulating 4 tracker(s) on 2 device(s) [min FPS=15, sustained=0s] …

## Deployment Matrix
| Tracker | mIoU | Raspberry Pi 4B (4 GB) | Jetson Xavier NX (8 GB) |
...

4/8 tracker-device combinations are deployable at ≥15 FPS.

[Markdown] saved → results/edge_report/edge_report.md
[JSON]     saved → results/edge_report/edge_report.json
```

## Files changed

| File | Change |
|------|--------|
| `eovot/reporting/edge_report.py` | New — DeploymentCell, EdgeDeploymentReport |
| `scripts/simulate_edge.py` | New — full-featured CLI with --devices, --min-fps, --sustained-seconds |
| `tests/test_edge_report.py` | New — 22 tests covering cell, report, Markdown, JSON, CLI |

## Test results

```
22 passed in 0.23s
```


---
_Generated by [Claude Code](https://claude.ai/code/session_0155xL92XkW54zsFtcuTqXqR)_